### PR TITLE
Tree transition

### DIFF
--- a/src/components/tree/grid.js
+++ b/src/components/tree/grid.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Radium from "radium";
-import {VictoryAnimation} from "victory";
 import GridLine from "./gridLine";
 
 /*

--- a/src/components/tree/gridLine.js
+++ b/src/components/tree/gridLine.js
@@ -69,4 +69,3 @@ class GridLine extends React.Component {
 }
 
 export default GridLine;
-

--- a/src/components/tree/tip.js
+++ b/src/components/tree/tip.js
@@ -50,7 +50,7 @@ class Tip extends React.Component {
           fill = {this.props.nodeColor}
           visibility = {this.props.tipVisibility}
           style = {{
-            transition: "1s ease-in-out",
+            transition: "transform 1s ease-in-out",
             WebkitTransform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`,
             transform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`
           }}

--- a/src/components/tree/tip.js
+++ b/src/components/tree/tip.js
@@ -50,7 +50,7 @@ class Tip extends React.Component {
           fill = {this.props.nodeColor}
           visibility = {this.props.tipVisibility}
           style = {{
-            transition: "transform 1s ease-in-out",
+            transition: "transform 1200ms ease-in-out",
             WebkitTransform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`,
             transform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`
           }}

--- a/src/components/tree/tip.js
+++ b/src/components/tree/tip.js
@@ -51,8 +51,8 @@ class Tip extends React.Component {
           visibility = {this.props.tipVisibility}
           style = {{
             transition: "1s ease-in-out",
-            WebkitTransform: `translate(${this.props.x}px, ${this.props.y}px)`,
-            transform: `translate(${this.props.x}px, ${this.props.y}px)`
+            WebkitTransform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`,
+            transform: `translate3d(${this.props.x}px, ${this.props.y}px, 0)`
           }}
         />
       );

--- a/src/components/tree/tip.js
+++ b/src/components/tree/tip.js
@@ -44,11 +44,16 @@ class Tip extends React.Component {
     if (!this.props.node.hasChildren) {
       return (
         <circle
-          visibility = {this.props.tipVisibility}
-          fill = {this.props.nodeColor}
+          cx="0"
+          cy="0"
           r={this.props.tipRadius}
-          cx={this.props.x}
-          cy={this.props.y}
+          fill = {this.props.nodeColor}
+          visibility = {this.props.tipVisibility}
+          style = {{
+            transition: "1s ease-in-out",
+            WebkitTransform: `translate(${this.props.x}px, ${this.props.y}px)`,
+            transform: `translate(${this.props.x}px, ${this.props.y}px)`
+          }}
         />
       );
     } else {

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -7,7 +7,6 @@ import "moment-range";
 //import { connect } from "react-redux";
 // import { FOO } from "../actions";
 import TreeNode from "./treeNode";
-import {VictoryAnimation} from "victory";
 
 
 /*
@@ -76,38 +75,30 @@ class Tree extends React.Component {
   drawBranches(nodes) {
     const branchComponents = nodes.map((node, index) => {
       return (
-        <VictoryAnimation duration={1000} key={index} data={{
-          x: this.xVal(node, this.props.distanceMeasure, this.props.layout),
-          y: this.yVal(node, this.props.distanceMeasure, this.props.layout),
-          midpoint_x: this.xMidpoint(node, this.props.distanceMeasure, this.props.layout),
-          midpoint_y: this.yMidpoint(node, this.props.distanceMeasure, this.props.layout),
-          source_x:   this.xVal(node.parent, this.props.distanceMeasure, this.props.layout),
-          source_y:   this.yVal(node.parent, this.props.distanceMeasure, this.props.layout),
-          r_x: this.r_x(node, this.props.distanceMeasure, this.props.layout),
-          r_y: this.r_y(node, this.props.distanceMeasure, this.props.layout),
-          smallBigArc: this.smallBigArc(node, this.props.distanceMeasure, this.props.layout),
-          leftRight: this.leftRight(node, this.props.distanceMeasure, this.props.layout),
-          nodeColor: this.props.nodeColor[index],
-          tipRadius: this.props.tipRadii[index]
-        }}>
-        {(props) => {
-          return (
-            <TreeNode
-              {...props} animate={null}
-              key={index}
-              node={node}
-              nodeColorAttr={this.props.nodeColorAttr[index]}
-              tipVisibility={this.props.tipVisibility[index]}
-              showBranchLabels={this.props.showBranchLabels}
-              strain={node.attr.strain}
-              hasChildren={node.children ? true : false}
-              layout={this.props.layout}
-              distanceMeasure={this.props.distanceMeasure}
-            />
-          );
-        }}
-      </VictoryAnimation>
-     );
+        <TreeNode
+          key={index}
+          node={node}
+          x={this.xVal(node, this.props.distanceMeasure, this.props.layout)}
+          y={this.yVal(node, this.props.distanceMeasure, this.props.layout)}
+          midpoint_x={this.xMidpoint(node, this.props.distanceMeasure, this.props.layout)}
+          midpoint_y={this.yMidpoint(node, this.props.distanceMeasure, this.props.layout)}
+          source_x={this.xVal(node.parent, this.props.distanceMeasure, this.props.layout)}
+          source_y={this.yVal(node.parent, this.props.distanceMeasure, this.props.layout)}
+          r_x={this.r_x(node, this.props.distanceMeasure, this.props.layout)}
+          r_y={this.r_y(node, this.props.distanceMeasure, this.props.layout)}
+          smallBigArc={this.smallBigArc(node, this.props.distanceMeasure, this.props.layout)}
+          leftRight={this.leftRight(node, this.props.distanceMeasure, this.props.layout)}
+          nodeColor={this.props.nodeColor[index]}
+          tipRadius={this.props.tipRadii[index]}
+          nodeColorAttr={this.props.nodeColorAttr[index]}
+          tipVisibility={this.props.tipVisibility[index]}
+          showBranchLabels={this.props.showBranchLabels}
+          strain={node.attr.strain}
+          hasChildren={node.children ? true : false}
+          layout={this.props.layout}
+          distanceMeasure={this.props.distanceMeasure}
+        />
+      );
     });
     return branchComponents;
   }

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -43,6 +43,9 @@ class Tree extends React.Component {
   yMidpoint(node, distanceMeasure, layout) {
     return this.props.yScale(node.geometry[distanceMeasure][layout].yValMidpoint);
   }
+  thetaMidpoint(node, distanceMeasure, layout) {
+    return -1*node.geometry[distanceMeasure][layout].thetaMidpoint;
+  }
   r_x(node, distanceMeasure, layout) {
     if (layout === "radial") {
       return this.props.xScale(node.geometry[distanceMeasure][layout].radiusInner) - this.props.xScale(0);
@@ -84,6 +87,7 @@ class Tree extends React.Component {
           midpoint_y={this.yMidpoint(node, this.props.distanceMeasure, this.props.layout)}
           source_x={this.xVal(node.parent, this.props.distanceMeasure, this.props.layout)}
           source_y={this.yVal(node.parent, this.props.distanceMeasure, this.props.layout)}
+          theta_midpoint={this.thetaMidpoint(node, this.props.distanceMeasure, this.props.layout)}
           r_x={this.r_x(node, this.props.distanceMeasure, this.props.layout)}
           r_y={this.r_y(node, this.props.distanceMeasure, this.props.layout)}
           smallBigArc={this.smallBigArc(node, this.props.distanceMeasure, this.props.layout)}

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -74,72 +74,77 @@ class TreeNode extends React.Component {
     return this.props.nodeColor;
   }
 
-  branchPoints() {
-    const mod = 0;
-
-    if (this.props.layout==="rectangular"){
-      return 'M'+(this.props.source_x - mod).toString() +
-        " " +
-        this.props.source_y.toString() +
-        " L " +
-        (this.props.midpoint_x - mod).toString() +
-        " " +
-        this.props.midpoint_y.toString() +
-        " L " +
-        (this.props.x).toString() +
-        " " +
-        this.props.y.toString();
-    }else if (this.props.layout==="radial"){
-      var tmp_d = 'M '+(this.props.source_x).toString() +
-        "  " +
-        this.props.source_y.toString() +
-        " A " +
-        this.props.r_x.toString() +
-        " " +
-        this.props.r_y.toString() +
-        " 0 " + (this.props.smallBigArc?"1 ":"0 ") +  (this.props.leftRight?"0 ":"1 ") +
-        this.props.midpoint_x.toString() +
-        " " +
-        this.props.midpoint_y.toString() +
-        " L " +
-        this.props.x.toString() +
-        " " +
-        this.props.y.toString();
-      return tmp_d;
-    }
-  }
-
   render() {
+    const delta_sm_x = this.props.source_x - this.props.midpoint_x;
+    const delta_sm_y = this.props.source_y - this.props.midpoint_y;
+    const length_sm =  Math.sqrt(delta_sm_x * delta_sm_x + delta_sm_y * delta_sm_y);
+    const theta_sm = Math.atan2(delta_sm_y, delta_sm_x) - Math.PI;
+    const delta_mt_x = this.props.midpoint_x - this.props.x;
+    const delta_mt_y = this.props.midpoint_y - this.props.y;
+    const length_mt =  Math.sqrt(delta_mt_x * delta_mt_x + delta_mt_y * delta_mt_y);
+    const theta_mt = Math.atan2(delta_mt_y, delta_mt_x) - Math.PI;
     return (
-      <g>
-        <path
-          d={this.branchPoints()}
-          onMouseEnter={() => {
-            this.props.dispatch({
-              type: BRANCH_MOUSEENTER,
-              /*
-                send the source and target nodes in the action,
-                use x and y values in them to place tooltip
-              */
-              data: this.props.datum
-            });
-          }}
-          onMouseLeave={() => {
-            this.props.dispatch({ type: BRANCH_MOUSELEAVE });
-          }}
+      <g onMouseEnter={() => {
+        this.props.dispatch({
+          type: BRANCH_MOUSEENTER,
+          /*
+            send the source and target nodes in the action,
+            use x and y values in them to place tooltip
+          */
+          data: this.props.datum
+        });
+        }}
+        onMouseLeave={() => {
+          this.props.dispatch({ type: BRANCH_MOUSELEAVE });
+        }}>
+        <line
+          x1="0.0"
+          y1="0.0"
+          x2="1.0"
+          y2="0.0"
           style={{
             stroke: this.branchStrokeColor(),
             strokeWidth: this.branchStrokeWidth(),
             strokeLinejoin: "round",
             fill: "none",
-            cursor: "pointer"
-          }}>
-        </path>
+            transition: "1s ease-in-out",
+            transform: `translate(${this.props.source_x}px, ${this.props.source_y}px)
+              rotate(${theta_sm}rad)
+              scale(${length_sm}, 1)`
+          }}/>
+          <line
+            x1="0.0"
+            y1="0.0"
+            x2="1.0"
+            y2="0.0"
+            style={{
+              stroke: this.branchStrokeColor(),
+              strokeWidth: this.branchStrokeWidth(),
+              strokeLinejoin: "round",
+              fill: "none",
+              transition: "1s ease-in-out",
+              transform: `translate(${this.props.midpoint_x}px, ${this.props.midpoint_y}px)
+                rotate(${theta_mt}rad)
+                scale(${length_mt}, 1)`
+            }}/>
         <Tip {...this.props}/>
       </g>
     );
   }
 }
+
+
+//   <line
+//     x1={this.props.midpoint_x}
+//     y1={this.props.midpoint_y}
+//     x2={this.props.x}
+//     y2={this.props.y}
+//     style={{
+//       stroke: this.branchStrokeColor(),
+//       strokeWidth: this.branchStrokeWidth(),
+//       strokeLinejoin: "round",
+//       fill: "none"
+//     }}/>
 
 export default TreeNode;
 

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -104,7 +104,7 @@ class TreeNode extends React.Component {
               strokeWidth: this.branchStrokeWidth(),
               strokeLinejoin: "round",
               fill: "none",
-              transition: "transform 1s ease-in-out",
+              transition: "transform 1200ms ease-in-out",
               perspective: "1000",
               willChange: "transform",
               transform: `translate3d(${this.props.source_x}px, ${this.props.source_y}px, 0)
@@ -119,7 +119,7 @@ class TreeNode extends React.Component {
               strokeWidth: this.branchStrokeWidth(),
               strokeLinejoin: "round",
               fill: "none",
-              transition: "1s ease-in-out",
+              transition: "transform 1200ms ease-in-out",
               perspective: "1000",
               willChange: "transform",
               transform: `translate3d(${this.props.midpoint_x}px, ${this.props.midpoint_y}px, 0)

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -108,8 +108,8 @@ class TreeNode extends React.Component {
               perspective: "1000",
               willChange: "transform",
               transform: `translate3d(${this.props.source_x}px, ${this.props.source_y}px, 0)
-                rotate3d(0, 0, 1, ${theta_sm}rad)
-                scale3d(${length_sm}, 1, 0)`
+                rotate(${theta_sm}rad)
+                scale(${length_sm}, 1)`
             }}
           />
           <line
@@ -123,8 +123,8 @@ class TreeNode extends React.Component {
               perspective: "1000",
               willChange: "transform",
               transform: `translate3d(${this.props.midpoint_x}px, ${this.props.midpoint_y}px, 0)
-                rotate3d(0, 0, 1, ${this.props.theta_midpoint}rad)
-                scale3d(${length_mt}, 1, 0)`
+                rotate(${this.props.theta_midpoint}rad)
+                scale(${length_mt}, 1)`
             }}
           />
         </g>

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -77,7 +77,7 @@ class TreeNode extends React.Component {
   render() {
     const delta_sm_x = this.props.source_x - this.props.midpoint_x;
     const delta_sm_y = this.props.source_y - this.props.midpoint_y;
-    const length_sm =  Math.sqrt(delta_sm_x * delta_sm_x + delta_sm_y * delta_sm_y);
+    const length_sm =  Math.sqrt(delta_sm_x * delta_sm_x + delta_sm_y * delta_sm_y) + 0.5*this.branchStrokeWidth();
     const theta_sm = Math.atan2(delta_sm_y, delta_sm_x) - Math.PI;
     const delta_mt_x = this.props.midpoint_x - this.props.x;
     const delta_mt_y = this.props.midpoint_y - this.props.y;

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -104,7 +104,7 @@ class TreeNode extends React.Component {
               strokeWidth: this.branchStrokeWidth(),
               strokeLinejoin: "round",
               fill: "none",
-              transition: "1s ease-in-out",
+              transition: "transform 1s ease-in-out",
               perspective: "1000",
               willChange: "transform",
               transform: `translate3d(${this.props.source_x}px, ${this.props.source_y}px, 0)

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -105,9 +105,11 @@ class TreeNode extends React.Component {
               strokeLinejoin: "round",
               fill: "none",
               transition: "1s ease-in-out",
-              transform: `translate(${this.props.source_x}px, ${this.props.source_y}px)
-                rotate(${theta_sm}rad)
-                scale(${length_sm}, 1)`
+              perspective: "1000",
+              willChange: "transform",
+              transform: `translate3d(${this.props.source_x}px, ${this.props.source_y}px, 0)
+                rotate3d(0, 0, 1, ${theta_sm}rad)
+                scale3d(${length_sm}, 1, 0)`
             }}
           />
           <line
@@ -118,9 +120,11 @@ class TreeNode extends React.Component {
               strokeLinejoin: "round",
               fill: "none",
               transition: "1s ease-in-out",
-              transform: `translate(${this.props.midpoint_x}px, ${this.props.midpoint_y}px)
-                rotate(${this.props.theta_midpoint}rad)
-                scale(${length_mt}, 1)`
+              perspective: "1000",
+              willChange: "transform",
+              transform: `translate3d(${this.props.midpoint_x}px, ${this.props.midpoint_y}px, 0)
+                rotate3d(0, 0, 1, ${this.props.theta_midpoint}rad)
+                scale3d(${length_mt}, 1, 0)`
             }}
           />
         </g>

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -82,41 +82,36 @@ class TreeNode extends React.Component {
     const delta_mt_x = this.props.midpoint_x - this.props.x;
     const delta_mt_y = this.props.midpoint_y - this.props.y;
     const length_mt =  Math.sqrt(delta_mt_x * delta_mt_x + delta_mt_y * delta_mt_y);
-    const theta_mt = Math.atan2(delta_mt_y, delta_mt_x) - Math.PI;
     return (
-      <g onMouseEnter={() => {
-        this.props.dispatch({
-          type: BRANCH_MOUSEENTER,
-          /*
-            send the source and target nodes in the action,
-            use x and y values in them to place tooltip
-          */
-          data: this.props.datum
-        });
-        }}
-        onMouseLeave={() => {
-          this.props.dispatch({ type: BRANCH_MOUSELEAVE });
-        }}>
-        <line
-          x1="0.0"
-          y1="0.0"
-          x2="1.0"
-          y2="0.0"
-          style={{
-            stroke: this.branchStrokeColor(),
-            strokeWidth: this.branchStrokeWidth(),
-            strokeLinejoin: "round",
-            fill: "none",
-            transition: "1s ease-in-out",
-            transform: `translate(${this.props.source_x}px, ${this.props.source_y}px)
-              rotate(${theta_sm}rad)
-              scale(${length_sm}, 1)`
-          }}/>
+      <g>
+        <g onMouseEnter={() => {
+          this.props.dispatch({
+            type: BRANCH_MOUSEENTER,
+            /*
+              send the source and target nodes in the action,
+              use x and y values in them to place tooltip
+            */
+            data: this.props.datum
+          });
+          }}
+          onMouseLeave={() => {
+            this.props.dispatch({ type: BRANCH_MOUSELEAVE });
+          }}>
           <line
-            x1="0.0"
-            y1="0.0"
-            x2="1.0"
-            y2="0.0"
+            x1="0.0" y1="0.0" x2="1.0" y2="0.0"
+            style={{
+              stroke: this.branchStrokeColor(),
+              strokeWidth: this.branchStrokeWidth(),
+              strokeLinejoin: "round",
+              fill: "none",
+              transition: "1s ease-in-out",
+              transform: `translate(${this.props.source_x}px, ${this.props.source_y}px)
+                rotate(${theta_sm}rad)
+                scale(${length_sm}, 1)`
+            }}
+          />
+          <line
+            x1="0.0" y1="0.0" x2="1.0" y2="0.0"
             style={{
               stroke: this.branchStrokeColor(),
               strokeWidth: this.branchStrokeWidth(),
@@ -124,27 +119,16 @@ class TreeNode extends React.Component {
               fill: "none",
               transition: "1s ease-in-out",
               transform: `translate(${this.props.midpoint_x}px, ${this.props.midpoint_y}px)
-                rotate(${theta_mt}rad)
+                rotate(${this.props.theta_midpoint}rad)
                 scale(${length_mt}, 1)`
-            }}/>
+            }}
+          />
+        </g>
         <Tip {...this.props}/>
       </g>
     );
   }
 }
-
-
-//   <line
-//     x1={this.props.midpoint_x}
-//     y1={this.props.midpoint_y}
-//     x2={this.props.x}
-//     y2={this.props.y}
-//     style={{
-//       stroke: this.branchStrokeColor(),
-//       strokeWidth: this.branchStrokeWidth(),
-//       strokeLinejoin: "round",
-//       fill: "none"
-//     }}/>
 
 export default TreeNode;
 

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -127,6 +127,9 @@ class TreeView extends React.Component {
           width={this.state.width}
           height={this.treePlotHeight(this.state.width)}
           id="treeplot"
+          style={{
+            transform: "translate3d(0, 0, 0)" // force GPU compositing
+          }}
         >
          <Grid
            layout={this.props.layout}

--- a/src/util/processNodes.js
+++ b/src/util/processNodes.js
@@ -21,7 +21,8 @@ const rectangularLayout = (node, distanceMeasure) => {
     return {'xVal':(distanceMeasure=='div')?node.xvalue:node.attr[distanceMeasure],
             'yVal':node.yvalue,
             'xValMidpoint':(distanceMeasure=='div')?node.parent.xvalue:node.parent.attr[distanceMeasure],
-            'yValMidpoint':node.yvalue
+            'yValMidpoint':node.yvalue,
+            'thetaMidpoint':0
             };
 };
 
@@ -44,7 +45,8 @@ const radialLayout = (node, distanceMeasure, nTips, rootVal) => {
             'xValMidpoint':parentRadius*Math.sin(angle),
             'yValMidpoint':parentRadius*Math.cos(angle),
             'radius':radius,'radiusInner':parentRadius,
-            'angle':angle, 'smallBigArc':smallBigArc, 'leftRight':leftRight};
+            'angle':angle, 'thetaMidpoint':angle - 0.5*Math.PI,
+            'smallBigArc':smallBigArc, 'leftRight':leftRight};
 };
 
 /* Calculate layout geometry for radial and rectangular layouts
@@ -86,4 +88,3 @@ export const mapToCoordinates = (nodes, xScale, yScale, layout, distanceMeasure)
         node.geometry[distanceMeasure][layout]['y'] = yScales(node.geometry[distanceMeasure][layout]['yVal']);
     });
 }
-


### PR DESCRIPTION
Switch from VictoryAnimation to CSS transitions for animating branches in the tree. This significantly improves animation performance. However, we're forced to use SVG lines for branches rather than SVG paths. Because of this, the radial layout is slightly less pretty.  However, other layouts (Path-O-Gen style and unrooted) should be fine as lines.

@rneher --- see what you think and merge if happy