### PR TITLE
Strip @Radium from most components

### DIFF
--- a/src/components/charts/entropy.js
+++ b/src/components/charts/entropy.js
@@ -13,7 +13,6 @@ import { parseGenotype } from "../../util/getGenotype";
 @connect(state => {
   return state.entropy;
 })
-@Radium
 class Entropy extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/charts/frequencies.js
+++ b/src/components/charts/frequencies.js
@@ -11,7 +11,6 @@ import Card from "../framework/card";
 @connect(state => {
   return state.frequencies;
 })
-@Radium
 class Frequencies extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/all-filter.js
+++ b/src/components/controls/all-filter.js
@@ -13,7 +13,6 @@ import parseParams from "../../util/parseParams";
  * the dataset hierarchy is specified in a datasets.json, currently
  * in ../../util/globals
 */
-@Radium
 class AllFilters extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/choose-filter.js
+++ b/src/components/controls/choose-filter.js
@@ -13,7 +13,6 @@ import parseParams from "../../util/parseParams";
  * the dataset hierarchy is specified in a datasets.json, currently
  * in ../../util/globals
 */
-@Radium
 class ChooseFilter extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -11,7 +11,6 @@ import queryString from "query-string";
 // @connect(state => {
 //   return state.FOO;
 // })
-@Radium
 class ChooseLayout extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -9,7 +9,6 @@ import MutationTree from "../framework/svg-mutation-tree";
  * implements a pair of buttons the toggle between timetree and divergence tree
  * copied from chose-layout
  */
-@Radium
 class ChooseMetric extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/choose-virus-select.js
+++ b/src/components/controls/choose-virus-select.js
@@ -15,7 +15,6 @@ import queryString from "query-string";
  * (i) knows about the upstream choices and
  * (ii) resets the route upon change
  */
-@Radium
 class ChooseVirusSelect extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/choose-virus.js
+++ b/src/components/controls/choose-virus.js
@@ -17,7 +17,6 @@ import parseParams from "../../util/parseParams";
  * the dataset hierarchy is specified in a datasets.json, currently
  * in ../../util/globals
 */
-@Radium
 class ChooseVirus extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -17,7 +17,6 @@ const returnStateNeeded = (fullStateTree) => {
 };
 
 @connect(returnStateNeeded)
-@Radium
 class ColorBy extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -23,7 +23,6 @@ const returnStateNeeded = (fullStateTree) => {
 };
 
 @connect(returnStateNeeded)
-@Radium
 class Controls extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -13,7 +13,6 @@ import _ from 'lodash';
 import Slider from './slider';
 
 @connect()
-@Radium
 class DateRangeInputs extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/genotypeInput.js
+++ b/src/components/controls/genotypeInput.js
@@ -9,7 +9,6 @@ import { connect } from "react-redux";
 // import { FOO } from "../actions";
 
 //@connect()
-//@Radium
 class genotypeInput extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/legend-item.js
+++ b/src/components/controls/legend-item.js
@@ -8,7 +8,6 @@ import { connect } from "react-redux";
 import { LEGEND_ITEM_MOUSEENTER, LEGEND_ITEM_MOUSELEAVE } from "../../actions/controls";
 
 @connect()
-@Radium
 class LegendItem extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/legend.js
+++ b/src/components/controls/legend.js
@@ -12,7 +12,6 @@ import LegendItem from "./legend-item";
 // @connect(state => {
 //
 // })
-@Radium
 class Legend extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/recursive_filter.js
+++ b/src/components/controls/recursive_filter.js
@@ -9,7 +9,6 @@ import { filterAbbrRev,filterAbbrFwd } from "../../util/globals";
  * (i) knows about the upstream choices and
  * (ii) resets the route upon change
  */
-@Radium
 class RecursiveFilter extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/search.js
+++ b/src/components/controls/search.js
@@ -9,7 +9,6 @@ import Autosuggest from 'react-autosuggest';
 @connect(state => {
   return state.tree
 })
-@Radium
 class SearchStrains extends React.Component {
   constructor(props) {
     super();

--- a/src/components/controls/toggle-branch-labels.js
+++ b/src/components/controls/toggle-branch-labels.js
@@ -7,7 +7,6 @@ import { TOGGLE_BRANCH_LABELS } from "../../actions/controls";
 
 
 @connect()
-@Radium
 class ToggleBranchLabels extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/frequency-line-graph.js
+++ b/src/components/frequency-line-graph.js
@@ -9,7 +9,6 @@ import Radium from "radium";
 // @connect(state => {
 //   return state.FOO;
 // })
-@Radium
 class FrequenciesGraph extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/grid.js
+++ b/src/components/tree/grid.js
@@ -7,7 +7,6 @@ import GridLine from "./gridLine";
  * Tree creates all TreeNodes of the tree, which consist of branches and tips.
  * Tree assignes the desired locations to all TreeNodes
 */
-@Radium
 class Grid extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/tip.js
+++ b/src/components/tree/tip.js
@@ -12,7 +12,6 @@ import { connect } from "react-redux";
  *
 */
 @connect()
-@Radium
 class Tip extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/tooltip.js
+++ b/src/components/tree/tooltip.js
@@ -2,7 +2,6 @@ import React from "react";
 import Radium from "radium";
 import * as globals from "../../util/globals";
 
-@Radium
 class Tooltip extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -14,7 +14,6 @@ import {VictoryAnimation} from "victory";
  * Tree creates all TreeNodes of the tree, which consist of branches and tips.
  * Tree assignes the desired locations to all TreeNodes
 */
-@Radium
 class Tree extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/treeNode.js
+++ b/src/components/tree/treeNode.js
@@ -12,7 +12,6 @@ import Tooltip from "./tooltip";
  * behavior of the path.
 */
 @connect()
-@Radium
 class TreeNode extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -24,7 +24,6 @@ import {Viewer, ViewerHelper} from 'react-svg-pan-zoom';
  * such that branches and tips are correctly placed.
  * will handle zooming
 */
-@Radium
 class TreeView extends React.Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
I think we're good here. Visual inspections says things are still working. A few components like those in `framework` and `map` suffered when removing, so I left the `@Radium` in these cases.

@colinmegill: please merge if this works for you.
