### PR TITLE
Fix legend zoom

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -80,7 +80,8 @@ class App extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const tmpQuery = queryString.parse(window.location.search);
-    const cScale = getColorScale(tmpQuery.colorBy, nextProps.tree, nextProps.sequences);
+    const cScale = getColorScale(tmpQuery.colorBy, nextProps.tree, nextProps.sequences,
+                                 this.props.metadata.metadata ? this.props.metadata.metadata.color_options : null);
     this.setState({
       colorScale: cScale
     });
@@ -196,7 +197,8 @@ class App extends React.Component {
   }
 
   updateColorScale(colorBy) {
-    const cScale = getColorScale(colorBy, this.props.tree, this.props.sequences);
+    const cScale = getColorScale(colorBy, this.props.tree, this.props.sequences,
+                                 this.props.metadata.metadata ? this.props.metadata.metadata.color_options : null);
     let gts = null;
     if (colorBy.slice(0,3) === "gt-" && this.props.sequences.geneLength) {
       gts = parseGenotype(colorBy, this.props.sequences.geneLength);

--- a/src/components/controls/legend-item.js
+++ b/src/components/controls/legend-item.js
@@ -4,6 +4,10 @@ import titleCase from "title-case";
 import { connect } from "react-redux";
 import { LEGEND_ITEM_MOUSEENTER, LEGEND_ITEM_MOUSELEAVE } from "../../actions/controls";
 
+function isNumeric(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
 @connect()
 @Radium
 class LegendItem extends React.Component {
@@ -21,6 +25,11 @@ class LegendItem extends React.Component {
     // d was undefined in some cases, Honduras thing, may not need conditional after fixed
     if (d) {
       label = titleCase(d.toString());
+    }
+    if (isNumeric(d)){
+      const val = parseFloat(d);
+      const magnitude = Math.ceil(Math.log10(Math.abs(val)+1e-10));
+      label = val.toFixed(5-magnitude);
     }
 
     if (this.props.dFreq) {

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -63,7 +63,8 @@ class TreeView extends React.Component {
       previously in componentDidMount, but we don't mount immediately anymore -
       need to wait for browserDimensions
     */
-    if (this.Viewer) {
+    const good_tree = (this.state.tree && (nextProps.datasetGuid === this.props.datasetGuid));
+    if (this.Viewer && !good_tree) {
       this.Viewer.fitToViewer();
       const tree = (this.state.tree)
         ? this.state.tree
@@ -72,7 +73,7 @@ class TreeView extends React.Component {
     }
 
     /* Do we have a tree to draw? if yes, check whether it needs to be redrawn */
-    const tree = ((nextProps.datasetGuid === this.props.datasetGuid) && this.state.tree)
+    const tree = good_tree
       ? this.state.tree
       : this.makeTree(nextProps.nodes, this.props.layout, this.props.distance);
 

--- a/src/util/colorScales.js
+++ b/src/util/colorScales.js
@@ -37,9 +37,9 @@ export const regionColorScale = d3.scale.ordinal()
   .domain(globals.regions.map((d) => { return d[0]; }))
   .range(globals.regions.map((d) => { return d[1]; }));
 
-  export const countryColorScale = d3.scale.ordinal()
-    .domain(globals.countries.map((d) => { return d[0]; }))
-    .range(globals.countries.map((d) => { return d[1]; }));
+export const countryColorScale = d3.scale.ordinal()
+  .domain(globals.countries.map((d) => { return d[0]; }))
+  .range(globals.countries.map((d) => { return d[1]; }));
 
 export const dateColorScale = d3.scale.linear().clamp([true])
   .domain(globals.dateColorDomain)

--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -43,7 +43,7 @@ const discreteAttributeScale = (nodes, attr) => {
   return d3.scale.ordinal().domain(domain);
 };
 
-const getColorScale = (colorBy, tree, sequences) => {
+const getColorScale = (colorBy, tree, sequences, colorOptions) => {
   const cScaleTypes = {ep: "integer", ne: "integer", rb: "integer",
                        lbi: "continuous", fitness: "continuous", num_date: "continuous",
                        region: "discrete", country: "discrete"};
@@ -71,24 +71,28 @@ const getColorScale = (colorBy, tree, sequences) => {
         colorScale = d3.scale.ordinal().domain(domain).range(genotypeColors);
       }
     }
-  } else if (colorBy === "region") {
-    continuous = false;
-    colorScale = scales.regionColorScale;
-  } else if (colorBy === "country") {
-      continuous = false;
-      colorScale = scales.countryColorScale;
-  } else if (cScaleTypes[colorBy] === "continuous") {
-    continuous = true;
-    colorScale = minMaxAttributeScale(tree.nodes, colorBy);
-  } else if (cScaleTypes[colorBy] === "integer") {
-    continuous = true;
-    colorScale = integerAttributeScale(tree.nodes, colorBy);
-  } else if (cScaleTypes[colorBy] === "discrete") {
-    continuous = false;
-    colorScale = discreteAttributeScale(tree.nodes, colorBy);
+  } else if (colorOptions && colorOptions[colorBy]){
+    if (colorOptions[colorBy].color_map){
+        continuous=false;
+        colorScale = d3.scale.ordinal()
+          .domain(colorOptions[colorBy].color_map.map((d) => { return d[0]; }))
+          .range(colorOptions[colorBy].color_map.map((d) => { return d[1]; }));
+    }
+    else if (colorOptions && colorOptions[colorBy].type === "discrete") {
+     continuous = false;
+     colorScale = discreteAttributeScale(tree.nodes, colorBy);
+    }
+    else if (colorOptions && colorOptions[colorBy].type === "integer") {
+     continuous = false;
+     colorScale = integerAttributeScale(tree.nodes, colorBy);
+    }
+    else if (colorOptions && colorOptions[colorBy].type === "continuous") {
+     continuous = true;
+     colorScale = minMaxAttributeScale(tree.nodes, colorBy);
+    }
   } else {
     continuous = true;
-    colorScale = genericScale(0, 1);
+    colorScale = minMaxAttributeScale(tree.nodes, colorBy);
   }
   return {"scale": colorScale, "continuous": continuous, "colorBy": colorBy,
           "legendBoundsMap": createLegendMatchBound(colorScale)};

--- a/src/util/mapHelpers.js
+++ b/src/util/mapHelpers.js
@@ -17,7 +17,7 @@ export const addAllTipsToMap = (nodes, metadata, colorScale, map) => {
       metadata.geo.country[key].longitude
     ], {
       stroke:	false,
-      radius: value * 2,
+      radius: 2 + Math.sqrt(value) * 4,
 
       // color: ""
       // weight:	5	Stroke width in pixels.

--- a/src/util/phyloTree.js
+++ b/src/util/phyloTree.js
@@ -276,7 +276,7 @@ PhyloTree.prototype.mapToScreen = function(){
     this.nodes.forEach(function(d){d.yTip = tmp_yScale(d.y)});
     this.nodes.forEach(function(d){d.xBase = tmp_xScale(d.px)});
     this.nodes.forEach(function(d){d.yBase = tmp_yScale(d.py)});
-    if (this.nodes[0].conf && this.layout==="rectangular"){
+    if (this.params.confidence && this.layout==="rectangular"){
       this.nodes.forEach(function(d){d.xConf = [tmp_xScale(d.conf[0]), tmp_xScale(d.conf[1])];});
     }
 
@@ -290,7 +290,7 @@ PhyloTree.prototype.mapToScreen = function(){
                                                  " L "+d.xTip.toString()+","+d.yTip.toString()+
                                                  " M "+d.xTip.toString()+","+d.cBarStart.toString()+
                                                  " L "+d.xTip.toString()+","+d.cBarEnd.toString();});
-        if (this.nodes[0].conf){
+        if (this.params.confidence){
           this.nodes.forEach(function(d){d.confLine =" M "+d.xConf[0].toString()+","+d.yBase.toString()+
                                                    " L "+d.xConf[1].toString()+","+d.yTip.toString();});
         }
@@ -862,7 +862,9 @@ PhyloTree.prototype.render = function(svg, layout, distance, options, callbacks)
   if (this.params.showGrid){
       this.addGrid();
   }
-  this.makeConfidence();
+  if (this.params.confidence){
+    this.makeConfidence();
+  }
   this.makeBranches();
   this.makeTips();
   this.updateGeometry(10);

--- a/src/util/phyloTree.js
+++ b/src/util/phyloTree.js
@@ -54,6 +54,7 @@ var PhyloTree = function(treeJson) {
   // remember the range of children subtending a node (i.e. the range of yvalues)
   // and create children structure
   this.nodes.forEach(function(d) {
+    d.parent = d.n.parent.shell;
     if (d.terminal) {
       d.yRange = [d.n.yvalue, d.n.yvalue];
       d.children=null;
@@ -227,6 +228,12 @@ PhyloTree.prototype.zoomIntoClade = function(clade, dt) {
       }
     }
   };
+  // zooming into terminal node doesn't make sense, presumably the parent is meant
+  if (clade.terminal){
+    kidsVisible(clade.parent);
+  }else{
+    kidsVisible(clade);
+  }
   kidsVisible(clade);
   this.mapToScreen();
   this.updateGeometry(dt);

--- a/src/util/phyloTree.js
+++ b/src/util/phyloTree.js
@@ -182,7 +182,7 @@ PhyloTree.prototype.radialLayout = function() {
     d.xCBarStart = (d.depth - offset) * Math.sin(angleCBar1);
     d.yCBarEnd = (d.depth - offset) * Math.cos(angleCBar2);
     d.xCBarEnd = (d.depth - offset) * Math.sin(angleCBar2);
-    d.smallBigArc = Math.abs(angleCBar2 - angleCBar1) > Math.Pi * 0.5;
+    d.smallBigArc = Math.abs(angleCBar2 - angleCBar1) > Math.PI * 1.0;
   });
 };
 


### PR DESCRIPTION
this implements a number of fixes:
 - no longer zooms into terminal node
 - colormaps are now specified in augur and exported along with the color options
 - formats legend numbers (could use some tweaking)
 - uses srqt counts for map circle radii
 - fixes the tree redrawing issue that caused the iffy behavior on legend mouse-over (closes #104)
 - adds confidence intervals to the tree