### PR TITLE
Make legend collapsible 

### DIFF
--- a/src/components/controls/legend.js
+++ b/src/components/controls/legend.js
@@ -1,9 +1,9 @@
 import React from "react";
 import d3 from "d3";
 import { connect } from "react-redux";
-import { legendRectSize, legendSpacing, defaultColorBy } from "../../util/globals";
 import LegendItem from "./legend-item";
-import {headerFont, medGrey, darkGrey} from "../../globalStyles";
+import { headerFont, darkGrey } from "../../globalStyles";
+import { legendRectSize, legendSpacing, fastTransitionDuration } from "../../util/globals";
 import titleCase from "title-case";
 
 @connect((state) => {
@@ -12,13 +12,20 @@ import titleCase from "title-case";
   };
 })
 class Legend extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      legendVisible: true
+    };
+  }
   getSVGHeight() {
     let nItems = 10;
+    const titlePadding = 20;
     if (this.props.colorScale.scale) {
       nItems = this.props.colorScale.scale.domain().length;
     }
     return Math.ceil(nItems / 2) *
-      (legendRectSize + legendSpacing) + legendSpacing + 20 || 100;
+      (legendRectSize + legendSpacing) + legendSpacing + titlePadding || 100;
   }
   getTransformationForLegendItem(i) {
     const count = this.props.colorScale.scale.domain().length;
@@ -29,7 +36,12 @@ class Legend extends React.Component {
     const vert = fromTop * (legendRectSize + legendSpacing);
     return "translate(" + horz + "," + vert + ")";
   }
-  createLegendTitle() {
+
+  /*
+   * draws legend title
+   * coordinate system from top,left of parent SVG
+   */
+  legendTitle() {
     let title = "";
     if (this.props.colorBy) {
       title = this.props.colorBy;
@@ -43,22 +55,65 @@ class Legend extends React.Component {
       title = titleCase(title);
     }
     return (
-      <text
-        x={0}
-        y={10}
-        style={{
-          fontSize: 12,
-          fill: darkGrey,
-          fontFamily: headerFont
-        }}>
-        {title}
-      </text>
+      <g>
+        <rect width="100" height="12" fill="rgba(255,255,255,.85)"/>
+        <text
+          x={0}
+          y={10}
+          style={{
+            fontSize: 12,
+            fill: darkGrey,
+            fontFamily: headerFont,
+            backgroundColor: "#fff"
+          }}>
+          {title}
+        </text>
+      </g>
     );
   }
-  createLegendItems() {
-    let legendItems = [];
+
+  /*
+   * draws show/hide chevron
+   * coordinate system from top,left of parent SVG
+   */
+  legendChevron() {
+    const degrees = this.state.legendVisible ? -180 : 0;
+    const offset = 50;  // TODO fix this to be dynamically determined by title width
+    return (
+      <g transform={`translate(${offset},0)`}>
+        <svg width="12" height="12" viewBox="0 0 1792 1792"
+          style={{
+            cursor: "pointer"
+          }}
+          onClick={() => {
+            const newState = this.state.legendVisible ? false : true;
+            this.setState({"legendVisible": newState});
+          }}
+          >
+          <rect width="1792" height="1792" fill="rgba(255,255,255,.85)"/>
+          <path
+            fill={darkGrey}
+            style={{
+              transform: `rotate(${degrees}deg)`,
+              transformOrigin: "50% 50%",
+              transition: `${fastTransitionDuration}ms ease-in-out`
+            }}
+            d="M1683 808l-742 741q-19 19-45 19t-45-19l-742-741q-19-19-19-45.5t19-45.5l166-165q19-19 45-19t45 19l531 531 531-531q19-19 45-19t45 19l166 165q19 19 19 45.5t-19 45.5z"/>
+        </svg>
+      </g>
+    );
+  }
+
+  /*
+   * draws rects and titles for each legend item
+   * coordinate system from top,left of parent SVG
+   */
+  legendItems() {
+    const opacity = this.state.legendVisible ? 1 : 0;
+    const offset = this.state.legendVisible ? 0 : -0.25 * this.getSVGHeight();
+    let items = [];
     if (this.props.colorScale.scale) {
-      legendItems = this.props.colorScale.scale.domain().map((d, i) => {
+      items = this.props.colorScale.scale.domain().map((d, i) => {
         return (
           <LegendItem
             legendRectSize={legendRectSize}
@@ -74,35 +129,38 @@ class Legend extends React.Component {
         );
       });
     }
-    return legendItems;
+    return (
+      <g style={{
+        opacity: opacity,
+        transform: `translate(0, ${offset}px)`,
+        transition: `${fastTransitionDuration}ms ease-in-out`
+        }}>
+        <rect width="280" height={this.getSVGHeight()} fill="rgba(255,255,255,.85)"/>
+        <g transform="translate(0,20)">
+          {items}
+        </g>
+      </g>
+    );
   }
+
   getStyles() {
     return {
       svg: {
-        width: 280,
-        height: this.getSVGHeight(),
-      },
-      container: {
-        marginBottom: 20
+        position: "absolute",
+        left: 12,
+        top: 38,
+        borderRadius: 2,
+        zIndex: 1000
       }
     };
   }
   render() {
     const styles = this.getStyles();
     return (
-      <svg
-        width = {styles.svg.width}
-        height = {styles.svg.height}
-        style={{
-          position: "absolute",
-          left: 12,
-          top: 38,
-          borderRadius: 2,
-          zIndex: 1000,
-          backgroundColor: "rgba(255,255,255,.85)"
-        }}>
-        <g>{this.createLegendTitle()}</g>
-        <g transform="translate(0,20)">{this.createLegendItems()}</g>
+      <svg width = "280" height = {this.getSVGHeight()} style={styles.svg}>
+        {this.legendItems()}
+        {this.legendTitle()}
+        {this.legendChevron()}
       </svg>
     );
   }

--- a/src/components/controls/legend.js
+++ b/src/components/controls/legend.js
@@ -36,12 +36,7 @@ class Legend extends React.Component {
     const vert = fromTop * (legendRectSize + legendSpacing);
     return "translate(" + horz + "," + vert + ")";
   }
-
-  /*
-   * draws legend title
-   * coordinate system from top,left of parent SVG
-   */
-  legendTitle() {
+  getTitleString() {
     let title = "";
     if (this.props.colorBy) {
       title = this.props.colorBy;
@@ -54,6 +49,13 @@ class Legend extends React.Component {
     } else {
       title = titleCase(title);
     }
+    return title;
+  }
+  /*
+   * draws legend title
+   * coordinate system from top,left of parent SVG
+   */
+  legendTitle() {
     return (
       <g>
         <rect width="100" height="12" fill="rgba(255,255,255,.85)"/>
@@ -66,7 +68,7 @@ class Legend extends React.Component {
             fontFamily: headerFont,
             backgroundColor: "#fff"
           }}>
-          {title}
+          {this.getTitleString()}
         </text>
       </g>
     );
@@ -78,7 +80,10 @@ class Legend extends React.Component {
    */
   legendChevron() {
     const degrees = this.state.legendVisible ? -180 : 0;
-    const offset = 50;  // TODO fix this to be dynamically determined by title width
+    // This is a hack because we can't use getBBox in React.
+    // Lots of work to get measured width of DOM element.
+    // Works fine, but will need adjusting if title font is changed.
+    const offset = 10 + 5.3 * this.getTitleString().length;
     return (
       <g transform={`translate(${offset},0)`}>
         <svg width="12" height="12" viewBox="0 0 1792 1792"

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -336,7 +336,9 @@ class TreeView extends React.Component {
 
     return (
       <Card center title="Phylogeny">
-        <Legend colorScale={this.props.colorScale}/>
+        <Legend
+          colorScale={this.props.colorScale}
+          sidebar={this.props.sidebar}/>
         <InfoPanel
           dismiss={this.infoPanelDismiss.bind(this)}
           zoom={this.state.tree ? this.state.tree.zoomIntoClade.bind(this.state.tree) : null}


### PR DESCRIPTION
This adds a ⬆️ / ⬇️  chevron widget next to legend title that collapses and expands the legend.

* This is animated with a rotation of the chevron and a slide of the legend.
* This is responsive to browser width and sidebar presence. On load or window resize legend collapses/expands automatically.

With this in place, mobile is looking quite decent.

EDIT:
* Fixes #97 
* Fixes #126