### PR TITLE
Compress bundle and serve compressed bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Nextstrain auspice",
   "scripts": {
     "clean": "rimraf dist",
-    "build:webpack": "NODE_ENV=production webpack --config webpack.config.js",
+    "build:webpack": "NODE_ENV=production webpack --config webpack.config.prod.js",
     "build": "npm run clean && npm run build:webpack",
     "start": "node dev-server.js",
     "server": "node server.js",
@@ -18,6 +18,7 @@
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
+    "compression-webpack-plugin": "^0.3.2",
     "css-loader": "^0.26.1",
     "es6-promise": "~1.0.0",
     "eslint": "3.5.0",
@@ -39,6 +40,7 @@
   "dependencies": {
     "color": "^0.7.3",
     "d3": "^3.5.17",
+    "express-static-gzip": "^0.2.2",
     "lodash": "4.16.4",
     "moment": "^2.14.1",
     "moment-range": "^2.2.0",

--- a/server.js
+++ b/server.js
@@ -1,9 +1,10 @@
 var path = require("path");
 var express = require("express");
+var expressStaticGzip = require("express-static-gzip");
 
 var app = express();
 app.set('port', process.env.PORT || 8080);
-app.use('/data', express.static('data'))
+app.use("/dist", expressStaticGzip("dist"));
 app.use('/dist', express.static('dist'))
 
 app.get("*", function(req, res) {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var webpack = require("webpack");
+var CompressionPlugin = require('compression-webpack-plugin');
 
 // let commitHash = require('child_process')
 //   .execSync('git rev-parse --short HEAD')
@@ -22,16 +23,21 @@ module.exports = {
         "NODE_ENV": JSON.stringify("production")
       }
     }),
-    // new webpack.DefinePlugin({
-    //   __COMMIT_HASH__: JSON.stringify(commitHash)
-    // }),
-    new webpack.optimize.UglifyJsPlugin({
+    new webpack.optimize.UglifyJsPlugin({ // minify everything
       compressor: {
         warnings: false
       }
     }),
-    // Ignore all locale files of moment.js
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)    
+    new webpack.optimize.DedupePlugin(), // dedupe similar code
+    new webpack.optimize.AggressiveMergingPlugin(), // merge chunks
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/), // ignore all locale files of moment.js
+    new CompressionPlugin({ // gzip everything
+       asset: "[path].gz[query]",
+       algorithm: "gzip",
+       test: /\.js$|\.css$|\.html$/,
+       threshold: 10240,
+       minRatio: 0.8
+    })
   ],
   module: {
 


### PR DESCRIPTION
* Webpack now produces `dist/bundle.js.gz`
* Express now serves this

This takes the 1.5MB bundle down to 400KB.