### PR TITLE
branch & tip hover functionality

### DIFF
--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -229,9 +229,9 @@ class TreeView extends React.Component {
           onTipClick: this.onTipClick.bind(this),
           onBranchHover: this.onBranchHover.bind(this),
           onBranchClick: this.onBranchClick.bind(this),
-	  onBranchLeave: this.onBranchLeave.bind(this),
-	  onTipLeave: this.onTipLeave.bind(this),
-	  // onBranchOrTipLeave: this.onBranchOrTipLeave.bind(this),
+          onBranchLeave: this.onBranchLeave.bind(this),
+          onTipLeave: this.onTipLeave.bind(this),
+          // onBranchOrTipLeave: this.onBranchOrTipLeave.bind(this),
           branchLabel: this.branchLabel.bind(this),
           branchLabelSize: this.branchLabelSize.bind(this)
         },
@@ -262,7 +262,7 @@ class TreeView extends React.Component {
   onBranchHover(d) {
     for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
       this.state.tree.svg.select(id)
-	.style("stroke", (d) => d["stroke"])
+        .style("stroke", (d) => d["stroke"])
     }
     if (!this.state.clicked) {
       this.setState({hovered: {d, type: ".branch"}});
@@ -275,7 +275,7 @@ class TreeView extends React.Component {
   onBranchLeave(d) {
     for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
       this.state.tree.svg.select(id)
-	.style("stroke", (d) => d3.rgb(d3.interpolateRgb(d["stroke"], "#BBB")(0.6)).toString());
+        .style("stroke", (d) => d3.rgb(d3.interpolateRgb(d["stroke"], "#BBB")(0.6)).toString());
     }
     if (this.state.hovered) {
       this.setState({hovered: null})


### PR DESCRIPTION
## regressions
none as far as I know

## code changes
* branch/tip hover tree manipulations are now within callbacks in treeView
* branch/tip click events change nothing on the tree - this has been done in a seperate branch (not yet public)
* phyloTree id names for branches changed to `branch_S_###` and `branch_T_###`

## style changes
* hovering on branches highlights the branch
* hovering on tips changes the radius