### PR TITLE
branch highlighting on stem only

### DIFF
--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -260,10 +260,10 @@ class TreeView extends React.Component {
     this.setState({clicked: {d,type: ".tip"}, hovered: null});
   }
   onBranchHover(d) {
-    for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
-      this.state.tree.svg.select(id)
-        .style("stroke", (d) => d["stroke"])
-    }
+    // for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
+    const id = "#branch_S_" + d.n.clade;
+    this.state.tree.svg.select(id)
+      .style("stroke", (d) => d["stroke"])
     if (!this.state.clicked) {
       this.setState({hovered: {d, type: ".branch"}});
     }
@@ -273,10 +273,10 @@ class TreeView extends React.Component {
   }
 
   onBranchLeave(d) {
-    for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
-      this.state.tree.svg.select(id)
-        .style("stroke", (d) => d3.rgb(d3.interpolateRgb(d["stroke"], "#BBB")(0.6)).toString());
-    }
+    // for (let id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
+    const id = "#branch_S_" + d.n.clade;
+    this.state.tree.svg.select(id)
+      .style("stroke", (d) => d3.rgb(d3.interpolateRgb(d["stroke"], "#BBB")(0.6)).toString());
     if (this.state.hovered) {
       this.setState({hovered: null})
     }

--- a/src/util/phyloTree.js
+++ b/src/util/phyloTree.js
@@ -782,14 +782,14 @@ PhyloTree.prototype.drawBranches = function() {
       return d['stroke-width'] || params.branchStrokeWidth;
     })
     .style("fill", "none")
-    .style("cursor", "pointer")
+    // .style("cursor", "pointer")
     .style("pointer-events", "auto")
-    .on("mouseover", (d) => {
-      this.callbacks.onBranchHover(d)
-    })
-    .on("mouseout", (d) => {
-      this.callbacks.onBranchLeave(d)
-    })
+    // .on("mouseover", (d) => {
+    //   this.callbacks.onBranchHover(d)
+    // })
+    // .on("mouseout", (d) => {
+    //   this.callbacks.onBranchLeave(d)
+    // })
     .on("click", (d) => {
       this.callbacks.onBranchClick(d)
     });


### PR DESCRIPTION
Do people prefer this behaviour over what's currently in master?

You can now only hover / click on the stem of a branch (so only affects rectancular & radial views), and highlighting is only applied to the stem.