### PR TITLE
Update date range from metadata on load

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -2,8 +2,40 @@ import { updateColorScale, updateNodeColors } from "./colors";
 import { dataURLStem } from "../util/globals";
 import * as types from "./types";
 
-/* request metadata */
+const updateDateRange = function () {
+  return function (dispatch, getState) {
+    const { controls, metadata } = getState();
+    /* bail if all required params aren't (yet) available! */
+    if (!(metadata.loadStatus === 2)) {
+      return null;
+    }
+    if (metadata.metadata.date_range) {
+      if (metadata.metadata.date_range.date_min) {
+        dispatch({
+          type: types.CHANGE_ABSOLUTE_DATE_MIN,
+          data: metadata.metadata.date_range.date_min
+        });
+        dispatch({
+          type: types.CHANGE_DATE_MIN,
+          data: metadata.metadata.date_range.date_min
+        });
+      }
+      if (metadata.metadata.date_range.date_max) {
+        dispatch({
+          type: types.CHANGE_ABSOLUTE_DATE_MAX,
+          data: metadata.metadata.date_range.date_max
+        });
+        dispatch({
+          type: types.CHANGE_DATE_MAX,
+          data: metadata.metadata.date_range.date_max
+        });
+      }
+    }
 
+  };
+};
+
+/* request metadata */
 const requestMetadata = () => {
   return {
     type: types.REQUEST_METADATA
@@ -42,6 +74,7 @@ const populateMetadataStore = (queryParams) => {
         dispatch(receiveMetadata(json));
         dispatch(updateColorScale());
         dispatch(updateNodeColors());
+        dispatch(updateDateRange());
       },
       (err) => dispatch(metadataFetchError(err))
     );

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -1,39 +1,8 @@
+/*eslint dot-notation: 0*/
 import { updateColorScale, updateNodeColors } from "./colors";
 import { dataURLStem } from "../util/globals";
 import * as types from "./types";
 
-const updateDateRange = function () {
-  return function (dispatch, getState) {
-    const { controls, metadata } = getState();
-    /* bail if all required params aren't (yet) available! */
-    if (!(metadata.loadStatus === 2)) {
-      return null;
-    }
-    if (metadata.metadata.date_range) {
-      if (metadata.metadata.date_range.date_min) {
-        dispatch({
-          type: types.CHANGE_ABSOLUTE_DATE_MIN,
-          data: metadata.metadata.date_range.date_min
-        });
-        dispatch({
-          type: types.CHANGE_DATE_MIN,
-          data: metadata.metadata.date_range.date_min
-        });
-      }
-      if (metadata.metadata.date_range.date_max) {
-        dispatch({
-          type: types.CHANGE_ABSOLUTE_DATE_MAX,
-          data: metadata.metadata.date_range.date_max
-        });
-        dispatch({
-          type: types.CHANGE_DATE_MAX,
-          data: metadata.metadata.date_range.date_max
-        });
-      }
-    }
-
-  };
-};
 
 /* request metadata */
 const requestMetadata = () => {
@@ -43,10 +12,22 @@ const requestMetadata = () => {
 };
 
 const receiveMetadata = (data) => {
-  return {
+  const ret = {
     type: types.RECEIVE_METADATA,
     data: data
   };
+  /* if there's data data include this for the controls reducer */
+  if (data.date_range) {
+    if (data.date_range.date_min) {
+      ret["dateMin"] = data.date_range.date_min;
+      ret["absoluteDateMin"] = data.date_range.date_min;
+    }
+    if (data.date_range.date_min) {
+      ret["dateMax"] = data.date_range.date_max;
+      ret["absoluteDateMax"] = data.date_range.date_max;
+    }
+  }
+  return ret;
 };
 
 const metadataFetchError = (err) => {
@@ -74,7 +55,6 @@ const populateMetadataStore = (queryParams) => {
         dispatch(receiveMetadata(json));
         dispatch(updateColorScale());
         dispatch(updateNodeColors());
-        dispatch(updateDateRange());
       },
       (err) => dispatch(metadataFetchError(err))
     );

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -15,26 +15,21 @@ moment.updateLocale("en", {
   }
 });
 
-export const calendarToNumericDeprecated = (calDate) => {
-  const unixDate = moment(calDate).unix();  // number of seconds since 1970
-  return 1970 + (unixDate / 365.2425 / 24 / 3600);
-};
-
 @connect((state) => {
   return {
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     absoluteDateMin: state.controls.absoluteDateMin,
-    absoluteDateMax: state.controls.absoluteDateMax
+    absoluteDateMax: state.controls.absoluteDateMax,
+    dateScale: state.controls.dateScale,
+    dateFormat: state.controls.dateFormat
   };
 })
 class DateRangeInputs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      lastSliderUpdateTime: Date.now(),
-      dateScale: d3.time.scale().domain([new Date(2000, 0, 0), new Date(2100, 0, 0)]).range([2000, 2100]),
-      dateFormater: d3.time.format("%Y-%m-%d")
+      lastSliderUpdateTime: Date.now()
     }
   }
   static contextTypes = {
@@ -56,11 +51,11 @@ class DateRangeInputs extends React.Component {
   }
 
   numericToCalendar(numDate) {
-    return(this.state.dateFormater(this.state.dateScale.invert(numDate)));
+    return(this.props.dateFormat(this.props.dateScale.invert(numDate)));
   }
 
   calendarToNumeric(calDate) {
-    return(this.state.dateScale(this.state.dateFormater.parse(calDate)));
+    return(this.props.dateScale(this.props.dateFormat.parse(calDate)));
   };
 
   updateFromPicker(ref, momentDate) {

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -7,6 +7,7 @@ import { connect } from "react-redux";
 import { controlsWidth } from "../../util/globals";
 import { modifyURLquery } from "../../util/urlHelpers";
 import { changeDateFilter } from "../../actions/treeProperties";
+import d3 from "d3";
 
 moment.updateLocale("en", {
   longDateFormat: {
@@ -14,7 +15,7 @@ moment.updateLocale("en", {
   }
 });
 
-export const calendarToNumeric = (calDate) => {
+export const calendarToNumericDeprecated = (calDate) => {
   const unixDate = moment(calDate).unix();  // number of seconds since 1970
   return 1970 + (unixDate / 365.2425 / 24 / 3600);
 };
@@ -31,7 +32,9 @@ class DateRangeInputs extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      lastSliderUpdateTime: Date.now()
+      lastSliderUpdateTime: Date.now(),
+      dateScale: d3.time.scale().domain([new Date(2000, 0, 0), new Date(2100, 0, 0)]).range([2000, 2100]),
+      dateFormater: d3.time.format("%Y-%m-%d")
     }
   }
   static contextTypes = {
@@ -53,9 +56,12 @@ class DateRangeInputs extends React.Component {
   }
 
   numericToCalendar(numDate) {
-    const unixDate = (numDate - 1970) * 365.2425 * 24 * 3600; // number of seconds since 1970
-    return moment.unix(unixDate).format("YYYY-MM-DD");
+    return(this.state.dateFormater(this.state.dateScale.invert(numDate)));
   }
+
+  calendarToNumeric(calDate) {
+    return(this.state.dateScale(this.state.dateFormater.parse(calDate)));
+  };
 
   updateFromPicker(ref, momentDate) {
     // a momentDate is received from DatePicker
@@ -145,10 +151,10 @@ class DateRangeInputs extends React.Component {
     const selectedMin = this.props.dateMin;
     const selectedMax = this.props.dateMax;
 
-    const absoluteMinNumDate = calendarToNumeric(absoluteMin);
-    const absoluteMaxNumDate = calendarToNumeric(absoluteMax);
-    const selectedMinNumDate = calendarToNumeric(selectedMin);
-    const selectedMaxNumDate = calendarToNumeric(selectedMax);
+    const absoluteMinNumDate = this.calendarToNumeric(absoluteMin);
+    const absoluteMaxNumDate = this.calendarToNumeric(absoluteMax);
+    const selectedMinNumDate = this.calendarToNumeric(selectedMin);
+    const selectedMaxNumDate = this.calendarToNumeric(selectedMax);
 
     const minDistance = (absoluteMaxNumDate - absoluteMinNumDate) / 10.0;
 

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -150,6 +150,8 @@ class DateRangeInputs extends React.Component {
     const selectedMinNumDate = calendarToNumeric(selectedMin);
     const selectedMaxNumDate = calendarToNumeric(selectedMax);
 
+    const minDistance = (absoluteMaxNumDate - absoluteMinNumDate) / 10.0;
+
     return (
       <div>
         <div style={{width: controlsWidth}}>
@@ -161,7 +163,7 @@ class DateRangeInputs extends React.Component {
           /* debounce the onChange event, but ensure the final one goes through */
           onChange={this.updateFromSlider.bind(this, true)}
           onAfterChange={this.updateFromSlider.bind(this, false)}
-          minDistance={0.5}                           // minDistance is in years
+          minDistance={minDistance}
           pearling
           withBars/>
         </div>

--- a/src/components/controls/slider.js
+++ b/src/components/controls/slider.js
@@ -171,7 +171,7 @@ var Slider = React.createClass({
     return {
       min: 0,
       max: 100,
-      step: 1.0/365.2425,
+      step: 0.00001,
       minDistance: 0,
       defaultValue: 0,
       orientation: 'horizontal',

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -3,6 +3,7 @@ import * as types from "../actions/types";
 import * as globals from "../util/globals";
 import getColorScale from "../util/getColorScale";
 import moment from 'moment';
+import d3 from "d3";
 
 /*
   we don't actually need to have legendBoundsMap default if regions will always be the
@@ -33,7 +34,9 @@ const getDefaultState = function () {
     colorScale: getColorScale(globals.defaultColorBy, {}, {}, {}, 1),
     geoResolution: globals.defaultGeoResolution,
     datasetPathName: null,
-    filters: {}
+    filters: {},
+    dateScale: d3.time.scale().domain([new Date(2000, 0, 0), new Date(2100, 0, 0)]).range([2000, 2100]),
+    dateFormat: d3.time.format("%Y-%m-%d")
   };
 };
 

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -1,3 +1,4 @@
+/*eslint dot-notation: 0*/
 import * as types from "../actions/types";
 import * as globals from "../util/globals";
 import getColorScale from "../util/getColorScale";
@@ -108,6 +109,24 @@ const Controls = (state = getDefaultState(), action) => {
     return Object.assign({}, state, {
       geoResolution: action.data
     });
+  /* metadata in may affect the date ranges... */
+  case types.RECEIVE_METADATA:
+    const dates = {};
+    /* do each of the 4 conditions manually as they're different... */
+    if ("absoluteDateMin" in action) {
+      dates["absoluteDateMin"] = action["absoluteDateMin"];
+    }
+    if ("absoluteDateMax" in action) {
+      dates["absoluteDateMax"] = action["absoluteDateMax"];
+    }
+    /* only change the dateMax / dateMin *if* they're outside bounds */
+    if ("dateMax" in action && action["dateMax"] < state["dateMax"]) {
+      dates["dateMax"] = action["dateMax"];
+    }
+    if ("dateMin" in action && action["dateMin"] > state["dateMin"]) {
+      dates["dateMin"] = action["dateMin"];
+    }
+    return Object.assign({}, state, dates);
   case types.APPLY_FILTER_QUERY:
     // values arrive as array
     const filters = Object.assign({}, state.filters, {});

--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -23,7 +23,7 @@ const genericScale = (cmin, cmax) => {
   const range = cmax - cmin;
   const tmpColorScale = d3.scale.linear()
     .domain(genericDomain.map((d) => offset + d * range))
-    .range(colors[10]);
+    .range(colors[9]);
   return tmpColorScale;
 };
 

--- a/src/util/treeHelpers.js
+++ b/src/util/treeHelpers.js
@@ -1,6 +1,5 @@
 import { tipRadius, freqScale } from "./globals";
 import { getGenotype } from "./getGenotype";
-import { calendarToNumericDeprecated } from "../components/controls/date-range-inputs";
 
 export const gatherTips = (node, tips) => {
 
@@ -239,8 +238,8 @@ export const calcVisibility = function (tree, controls) {
     let visibility;
 
     // TIME FILTERING (internal + terminal nodes)
-    const lowerLimit = calendarToNumericDeprecated(controls.dateMin);
-    const upperLimit = calendarToNumericDeprecated(controls.dateMax);
+    const lowerLimit = controls.dateScale(controls.dateFormat.parse(controls.dateMin)); // convert caldate to numdate
+    const upperLimit = controls.dateScale(controls.dateFormat.parse(controls.dateMax)); // convert caldate to numdate
     visibility = tree.nodes.map((d) => (
       d.attr.num_date >= lowerLimit && d.attr.num_date <= upperLimit
     ));

--- a/src/util/treeHelpers.js
+++ b/src/util/treeHelpers.js
@@ -1,6 +1,6 @@
 import { tipRadius, freqScale } from "./globals";
 import { getGenotype } from "./getGenotype";
-import { calendarToNumeric } from "../components/controls/date-range-inputs";
+import { calendarToNumericDeprecated } from "../components/controls/date-range-inputs";
 
 export const gatherTips = (node, tips) => {
 
@@ -239,8 +239,8 @@ export const calcVisibility = function (tree, controls) {
     let visibility;
 
     // TIME FILTERING (internal + terminal nodes)
-    const lowerLimit = calendarToNumeric(controls.dateMin);
-    const upperLimit = calendarToNumeric(controls.dateMax);
+    const lowerLimit = calendarToNumericDeprecated(controls.dateMin);
+    const upperLimit = calendarToNumericDeprecated(controls.dateMax);
     visibility = tree.nodes.map((d) => (
       d.attr.num_date >= lowerLimit && d.attr.num_date <= upperLimit
     ));

--- a/src/util/urlHelpers.js
+++ b/src/util/urlHelpers.js
@@ -59,6 +59,18 @@ const makeDataPathFromParsedParams = function (parsedParams) {
   return tmp_levels.map((d) => d[1]).join("_");
 };
 
+const selectivelyUpdateSearch = function (defaultSearch, userSearch) {
+  if (!defaultSearch) {return userSearch;}
+  const final = queryString.parse(userSearch);
+  const defaults = queryString.parse(defaultSearch);
+  for (const key of Object.keys(defaults)) {
+    if (!(key in final)) {
+      final[key] = defaults[key];
+    }
+  }
+  return queryString.stringify(final);
+};
+
 /* if we have decided that the URL (data, not query) has changed
 this fn will work out the correct datapath, set it if necessary,
 and return the data path used to load the data
@@ -72,7 +84,7 @@ export const turnURLtoDataPath = function (router) {
     // console.log("parsed params incomplete => modifying URL")
     router.replace({
       pathname: parsedParams.fullsplat,
-      search: parsedParams.search ? parsedParams.search : router.location.search
+      search: selectivelyUpdateSearch(parsedParams.search, router.location.search)
     });
   }
   // if valid, return the data_path, else undefined
@@ -80,4 +92,4 @@ export const turnURLtoDataPath = function (router) {
     return makeDataPathFromParsedParams(parsedParams);
   }
   return undefined;
-}
+};


### PR DESCRIPTION
This finds `date_range` in `meta.json` with `date_min` and `date_max`:

```
 "date_range": {
  "date_min": "2013-06-29", 
  "date_max": "2016-11-21"
 }, 
```

And after `meta.json` is loaded it fires an action to update `controls` in redux store. This seems to be working just fine. If `date_range` is not in `meta.json` then the defaults in `globals.js` are kept, just as before. @jameshadfield: could you look to see if this done as cleanly as possible in terms of redux? You're more familiar with this than I am now. I've pushed new JSONs to `data.nextstrain.org`, so this should work with remote data.

Fixes #258 