### PR TITLE
Improve app performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-router-dom": "^4.0.0-beta.5",
     "react-select": "^1.0.0-rc.2",
     "react-sidebar": "^2.2.1",
+    "react-sidebar": "git://github.com/nextstrain/react-sidebar.git#remove-savewidth",
     "react-svg-pan-zoom": "2.0.0",
     "react-tap-event-plugin": "^0.2.1",
     "react-throttle": "^0.3.0",

--- a/src/components/COMPONENT_TEMPLATE.js
+++ b/src/components/COMPONENT_TEMPLATE.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Radium from "radium";
 // import _ from "lodash";
 // import Flex from "./framework/flex";
 // import { connect } from "react-redux";
@@ -9,7 +8,6 @@ import Radium from "radium";
 // @connect(state => {
 //   return state.FOO;
 // })
-@Radium
 class ComponentName extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -5,7 +5,6 @@ import { loadJSONs } from "../actions/loadData";
 import { RESET_CONTROLS, NEW_DATASET } from "../actions/types";
 import { restoreStateFromURL, turnURLtoDataPath } from "../util/urlHelpers"
 import "whatwg-fetch"; // setup polyfill
-import Radium from "radium";
 import Title from "./framework/title";
 import Background from "./framework/background";
 import ToggleSidebarTab from "./framework/toggle-sidebar-tab";
@@ -32,7 +31,6 @@ import { analyticsNewPage } from "../util/googleAnalytics";
   see https://reacttraining.com/react-router
 */
 @connect()
-@Radium
 class App extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/charts/entropy.js
+++ b/src/components/charts/entropy.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Radium from "radium";
 import _ from "lodash";
 import { connect } from "react-redux";
 import {VictoryAxis} from "victory-chart";
@@ -18,7 +17,6 @@ import { dataFont, darkGrey } from "../../globalStyles";
     browserDimensions: state.browserDimensions.browserDimensions
   };
 })
-@Radium
 class Entropy extends React.Component {
   static contextTypes = {
     router: React.PropTypes.object.isRequired

--- a/src/components/charts/frequencies.js
+++ b/src/components/charts/frequencies.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Radium from "radium";
 import { connect } from "react-redux";
 import {VictoryAxis} from "victory-chart";
 import * as globals from "../../util/globals";
@@ -12,7 +11,6 @@ import Card from "../framework/card";
     colorBy: state.controls.colorBy
   };
 })
-@Radium
 class Frequencies extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -75,9 +75,9 @@ class DateRangeInputs extends React.Component {
 
   updateFromSlider(debounce, numDateValues) {
     if (debounce) {
-      // simple debounce @ 250ms
+      // simple debounce @ 100ms
       const currentTime = Date.now();
-      if (currentTime < this.state.lastSliderUpdateTime + 250) {
+      if (currentTime < this.state.lastSliderUpdateTime + 100) {
         return null
       }
       // console.log("UPDATING", currentTime, this.state.lastSliderUpdateTime)

--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -3,11 +3,7 @@ import { connect } from "react-redux";
 import { dataFont, medGrey } from "../../globalStyles";
 import computeResponsive from "../../util/computeResponsive";
 import Flex from "./flex";
-import Radium from "radium";
 import d3 from "d3";
-
-
-
 
 @connect((state) => {
   return {
@@ -16,7 +12,6 @@ import d3 from "d3";
     browserDimensions: state.browserDimensions.browserDimensions
   };
 })
-@Radium
 class Footer extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/tree/legend-item.js
+++ b/src/components/tree/legend-item.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Radium from "radium";
 import titleCase from "title-case";
 import { connect } from "react-redux";
 import { legendMouseEnterExit } from "../../actions/treeProperties";
@@ -10,7 +9,6 @@ function isNumeric(n) {
 }
 
 @connect()
-@Radium
 class LegendItem extends React.Component {
   static propTypes = {
     dispatch: React.PropTypes.func.isRequired

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -158,11 +158,11 @@ class TreeView extends React.Component {
       /* implement style changes */
       if (Object.keys(branchAttrToUpdate).length || Object.keys(branchStyleToUpdate).length) {
         // console.log("applying branch attr", Object.keys(branchAttrToUpdate), "branch style changes", Object.keys(branchStyleToUpdate))
-        tree.updateMultipleArray(".branch", branchAttrToUpdate, branchStyleToUpdate, fastTransitionDuration);
+        tree.updateMultipleArray(".branch", branchAttrToUpdate, branchStyleToUpdate);
       }
       if (Object.keys(tipAttrToUpdate).length || Object.keys(tipStyleToUpdate).length) {
         // console.log("applying tip attr", Object.keys(tipAttrToUpdate), "tip style changes", Object.keys(tipStyleToUpdate))
-        tree.updateMultipleArray(".tip", tipAttrToUpdate, tipStyleToUpdate, fastTransitionDuration);
+        tree.updateMultipleArray(".tip", tipAttrToUpdate, tipStyleToUpdate);
       }
 
       /* swap layouts */

--- a/src/util/treeHelpers.js
+++ b/src/util/treeHelpers.js
@@ -1,4 +1,4 @@
-import { tipRadius, freqScale } from "./globals";
+import { tipRadius, freqScale, tipRadiusOnLegendMatch } from "./globals";
 import { getGenotype } from "./getGenotype";
 import { calendarToNumeric } from "../components/controls/date-range-inputs";
 
@@ -183,7 +183,7 @@ export const calcTipRadii = function (selectedLegendItem,
                          ) {
   if (selectedLegendItem && tree && tree.nodes){
     const legendMap = colorScale.continuous ? colorScale.legendBoundsMap : false;
-    return tree.nodes.map((d) => determineLegendMatch(selectedLegendItem, d, legendMap, colorScale, sequences) ? 6 : 3);
+    return tree.nodes.map((d) => determineLegendMatch(selectedLegendItem, d, legendMap, colorScale, sequences) ? tipRadiusOnLegendMatch : tipRadius);
   } else if (tree && tree.nodes) {
     return tree.nodes.map((d) => tipRadius);
   }


### PR DESCRIPTION
This PR does three main things:

* Snap to rather than transition on attr / style tree updates. I think this works _much_ better for things like date slider and legend hover. Makes the app feel much more responsive.

* Profiling revealed that react-sidebar was thrashing the app when it would attempt to save it's width after component update. Because sidebar contains tree, map, etc... it would be constantly updating. This would causing a ~50ms hit after almost every action. I've forked react-sidebar to [nextstrain/react-sidebar](https://github.com/nextstrain/react-sidebar) and removed the code in question on branch `remove-savewidth`. This PR swaps us to using the forked repo here: https://github.com/nextstrain/auspice/compare/snappy?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R63. You'll need to `npm install` to see the improvement.

* Remove radium from non-framework components. Profiling was revealing decent overhead to having radium on DOM heavy components like tree. I've stripped it out of a few places.

Overall, I think this is a definite performance improvement.