### PR TITLE
 apply fitToViewer before zooming into clade to make sure that zoomed…

### DIFF
--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -299,6 +299,7 @@ class TreeView extends React.Component {
     });
   }
   onBranchClick(d) {
+    this.Viewer.fitToViewer();
     this.state.tree.zoomIntoClade(d, mediumTransitionDuration);
     /* to stop multiple phyloTree updates potentially clashing,
     we change tipVis after geometry update + transition */


### PR DESCRIPTION
After panning the tree, clicking on branch executes function zoomIntoClade but the zoomed area can extend beyond viewer. 
Adding fitToViewer before zoomIntoClade will ensure that the zoomed region always fits the viewer.
