### PR TITLE
Tree info panels

### DIFF
--- a/src/components/charts/entropyInfoPanel.js
+++ b/src/components/charts/entropyInfoPanel.js
@@ -1,8 +1,8 @@
 /*eslint-env browser*/
 import React from "react";
-import * as globals from "../../util/globals";
-import {dataFont, infoPanelStyles} from "../../globalStyles";
-import { prettyString } from "../tree/tipSelectedPanel";
+// import * as globals from "../../util/globals";
+import { infoPanelStyles} from "../../globalStyles";
+// import { prettyString } from "../tree/treeViewFunctions";
 
 const InfoPanel = ({hovered, mutType}) => {
 

--- a/src/components/controls/all-filter.js
+++ b/src/components/controls/all-filter.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Radium from "radium";
-import { filterAbbrFwd } from "../../util/globals";
 import ChooseFilter from "./choose-filter";
 import { connect } from "react-redux";
 

--- a/src/components/controls/recursive_filter.js
+++ b/src/components/controls/recursive_filter.js
@@ -1,11 +1,11 @@
 import React from "react";
 import Radium from "radium";
 import Select from "react-select";
-import { filterAbbrRev, filterAbbrFwd, controlsWidth } from "../../util/globals";
-import { modifyURLquery } from "../../util/urlHelpers";
+import { controlsWidth } from "../../util/globals";
 import { connect } from "react-redux";
 import { applyFilterQuery } from "../../actions/treeProperties"
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
+import { prettyString } from "../tree/tipSelectedPanel";
 
 /*
  * implements a selector that
@@ -52,7 +52,7 @@ class RecursiveFilter extends React.Component {
     for (let i = 0; i < this.props.options.length; i++) {
       options.push({
         value: this.props.options[i],
-        label: this.props.options[i] + (this.props.counts[i] ? " (" + this.props.counts[i] + ")" : "")
+        label: prettyString(this.props.options[i]).replace("Et Al", "et al") + (this.props.counts[i] ? " (" + this.props.counts[i] + ")" : "")
       });
     }
     /* note that e (onChange) is an array of objects each with label and value */

--- a/src/components/controls/recursive_filter.js
+++ b/src/components/controls/recursive_filter.js
@@ -5,7 +5,7 @@ import { controlsWidth } from "../../util/globals";
 import { connect } from "react-redux";
 import { applyFilterQuery } from "../../actions/treeProperties"
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
-import { prettyString } from "../tree/tipSelectedPanel";
+import { prettyString } from "../tree/treeViewFunctions";
 
 /*
  * implements a selector that

--- a/src/components/tree/branchSelectedPanel.js
+++ b/src/components/tree/branchSelectedPanel.js
@@ -2,52 +2,35 @@ import React from "react";
 import {infoPanelStyles, dataFont} from "../../globalStyles";
 
 const BranchSelectedPanel = ({branch, viewEntireTreeCallback, responsive}) => {
+  if (!branch) {return null;}
 
   const styles = {
     container: {
-      // width: responsive.width - 280 /*legend*/ - 35 /*padding*/,
       position: "absolute",
-      // left: 280 /* legend width */ + 20, // RESPOND TO LEGEND COLLAPSE!
-      right: 5,
-      width: responsive.width - 30 /* paddingRight */ - 10 /*left + right space*/,
-      height: 18,
-      top: 3,
-      paddingTop: 7,
-      paddingBottom: 9,
-      paddingLeft: 10,
-      paddingRight: 30,
+      verticalAlign: "top",
+      right: 5, height: 18, top: 3,
+      width: responsive.width - 30 /* paddingRight */ - 10, /*left + right space*/
+      paddingTop: 7, paddingBottom: 9, paddingLeft: 10, paddingRight: 30,
       borderRadius: 5,
       pointerEvents: "all",
       backgroundColor: "rgba(151, 155, 155, 0.85)",
-    //  backgroundColor: "rgba(174, 182, 191, .85)", // "rgba(255,255,255,.85)"
       zIndex: 1000,
       color: "#fff",
-      fontFamily: dataFont,
-      fontSize: 14,
-      fontWeight: 400,
-      verticalAlign: "top"
+      fontFamily: dataFont, fontSize: 14, fontWeight: 400
     }
   };
 
-  const makePanel = () => {
-    if (!branch) {return null;}
-    let text = [`Branch selected with ${branch.n.fullTipCount} sequences`,
-      "Return to entire tree"];
-    if (responsive.width < 500) {
-      text = ["Branch selected", "Reset"];
-    }
-    return (
-      <div style={styles.container}>
-        <span style={infoPanelStyles.branchInfoHeading}>{text[0]}</span>
-        <button style={infoPanelStyles.buttonLink} onClick={() => viewEntireTreeCallback()}>
-          {text[1]}
-        </button>
-      </div>
-    );
-  };
-
+  let text = [`Branch selected with ${branch.n.fullTipCount} sequences`, "Return to entire tree"];
+  if (responsive.width < 500) {
+    text = ["Branch selected", "Reset"];
+  }
   return (
-    makePanel()
+    <div style={styles.container}>
+      <span style={infoPanelStyles.branchInfoHeading}>{text[0]}</span>
+      <button style={infoPanelStyles.buttonLink} onClick={viewEntireTreeCallback}>
+        {text[1]}
+      </button>
+    </div>
   );
 };
 

--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -33,11 +33,13 @@ const getBranchDivJSX = (d) =>
   <p>{infoLineJSX("Divergence:", prettyString(d.attr.div.toExponential(3)))}</p>;
 
 const getBranchTimeJSX = (d, temporalConfidence) => {
-  console.log("TC:", temporalConfidence)
   const dates = [floatDateToMoment(d.attr.num_date).format("YYYY-MM-DD")];
   if (temporalConfidence) {
     dates[1] = floatDateToMoment(d.attr.num_date_confidence[0]).format("YYYY-MM-DD");
     dates[2] = floatDateToMoment(d.attr.num_date_confidence[1]).format("YYYY-MM-DD");
+    if (dates[1] === dates[2]) {
+      return <p>{infoLineJSX("Date:", dates[0])}</p>;
+    }
     return (
       <p>
         {infoLineJSX("Inferred Date:", dates[0])}
@@ -46,7 +48,7 @@ const getBranchTimeJSX = (d, temporalConfidence) => {
       </p>
     );
   }
-  return <p>{infoLineJSX("Inferred Date:", dates[0])}</p>;
+  return <p>{infoLineJSX("Date:", dates[0])}</p>;
 };
 
 /**
@@ -209,7 +211,12 @@ const InfoPanel = ({tree, mutType, temporalConfidence, distanceMeasure,
   const styles = getPanelStyling(d, viewer);
   let inner;
   if (tip) {
-    inner = infoLineJSX(prettyString(colorBy) + ":", prettyString(d.n.attr[colorBy]));
+    inner = (
+      <p>
+        {infoLineJSX(prettyString(colorBy) + ":", prettyString(d.n.attr[colorBy]))}
+        {distanceMeasure === "div" ? getBranchDivJSX(d.n) : getBranchTimeJSX(d.n, temporalConfidence)}
+      </p>
+    );
   } else {
     inner = (
       <g>

--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -1,7 +1,7 @@
 /*eslint-env browser*/
 import React from "react";
 import { infoPanelStyles } from "../../globalStyles";
-import { prettyString } from "./tipSelectedPanel";
+import { prettyString } from "./treeViewFunctions";
 import { floatDateToMoment } from "../../util/dateHelpers";
 import moment from "moment";
 

--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -6,10 +6,10 @@ import { floatDateToMoment } from "../../util/dateHelpers";
 
 const infoLineJSX = (item, value) => (
   <g>
-    <span style={{fontWeight: "400"}}>
+    <span style={{fontWeight: "500"}}>
       {item + " "}
     </span>
-    <span style={{fontWeight: "200"}}>
+    <span style={{fontWeight: "300"}}>
       {value}
     </span>
   </g>
@@ -17,11 +17,11 @@ const infoLineJSX = (item, value) => (
 
 const infoBlockJSX = (item, values) => (
   <div>
-    <p style={{marginBottom: "-0.7em", fontWeight: "400"}}>
+    <p style={{marginBottom: "-0.7em", fontWeight: "500"}}>
       {item}
     </p>
     {values.map((k, i) => (
-      <p key={i} style={{fontWeight: "200", marginBottom: "-0.9em", marginLeft: "0em"}}>
+      <p key={i} style={{fontWeight: "300", marginBottom: "-0.9em", marginLeft: "0em"}}>
         {k}
       </p>
     ))}

--- a/src/components/tree/legend-item.js
+++ b/src/components/tree/legend-item.js
@@ -1,62 +1,37 @@
 import React from "react";
-import titleCase from "title-case";
-import { connect } from "react-redux";
 import { legendMouseEnterExit } from "../../actions/treeProperties";
 import { dataFont, darkGrey } from "../../globalStyles";
+import { prettyString } from "./tipSelectedPanel";
 
-function isNumeric(n) {
-  return !isNaN(parseFloat(n)) && isFinite(n);
-}
-
-@connect()
-class LegendItem extends React.Component {
-  static propTypes = {
-    dispatch: React.PropTypes.func.isRequired
-  }
-
-  createLabelText(d) {
-    // We assume that label text arrives either Properly Formatted or as snake_case or as CamelCase
-    let label = "";
-    // d was undefined in some cases, Honduras thing, may not need conditional after fixed
-    if (d) {
-      label = titleCase(d.toString());
-    }
-    if (isNumeric(d)){
-      const val = parseFloat(d);
-      const magnitude = Math.ceil(Math.log10(Math.abs(val)+1e-10));
-      label = val.toFixed(5 - magnitude);
-    }
-    if (this.props.dFreq) {
-      label += "\u00D7";
-    }
-    return label;
-  }
-
-  render() {
-    const label = this.createLabelText(this.props.label);
-    return (
-      <g
-        transform={this.props.transform}
-        onMouseEnter={() => {
-          this.props.dispatch(legendMouseEnterExit(this.props.label));
-        }}
-        onMouseLeave={() => {
-          this.props.dispatch(legendMouseEnterExit());
-        }}
-      >
-        <rect
-          style={{strokeWidth: 2}}
-          width={this.props.legendRectSize}
-          height={this.props.legendRectSize}
-          fill={this.props.rectFill}
-          stroke={this.props.rectStroke}/>
-        <text
-          x={this.props.legendRectSize + this.props.legendSpacing + 5}
-          y={this.props.legendRectSize - this.props.legendSpacing}
-          style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}>{label}</text>
-      </g>
-    );
-  }
-}
+const LegendItem = ({
+  dispatch, transform,
+  legendRectSize, legendSpacing,
+  rectStroke, rectFill,
+  label, dFreq}) => (
+  <g
+    transform={transform}
+    onMouseEnter={() => {
+      dispatch(legendMouseEnterExit(label));
+    }}
+    onMouseLeave={() => {
+      dispatch(legendMouseEnterExit());
+    }}
+  >
+    <rect
+      style={{strokeWidth: 2}}
+      width={legendRectSize}
+      height={legendRectSize}
+      fill={rectFill}
+      stroke={rectStroke}
+    />
+    <text
+      x={legendRectSize + legendSpacing + 5}
+      y={legendRectSize - legendSpacing}
+      style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}
+    >
+      {prettyString(label, dFreq)}
+    </text>
+  </g>
+);
 
 export default LegendItem;

--- a/src/components/tree/legend-item.js
+++ b/src/components/tree/legend-item.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { legendMouseEnterExit } from "../../actions/treeProperties";
 import { dataFont, darkGrey } from "../../globalStyles";
-import { prettyString } from "./tipSelectedPanel";
+import { prettyString } from "./treeViewFunctions";
 
 const LegendItem = ({
   dispatch, transform,

--- a/src/components/tree/legend.js
+++ b/src/components/tree/legend.js
@@ -165,6 +165,7 @@ class Legend extends React.Component {
       items = this.props.colorScale.scale.domain().map((d, i) => {
         return (
           <LegendItem
+            dispatch={this.props.dispatch}
             legendRectSize={legendRectSize}
             legendSpacing={legendSpacing}
             rectFill={d3.rgb(this.props.colorScale.scale(d)).brighter([0.35]).toString()}

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -7,12 +7,20 @@ export const prettyString = (x) => {
     return "unknown";
   }
   if (typeof x === "string") {
-    return x.replace("_", " ")
+    return x.replace(/_/g, " ")
             .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
   } else if (typeof x === "number") {
     return x.toFixed(2);
   }
   return x;
+};
+
+const authorString = (x) => {
+  const y = prettyString(x);
+  if (y.indexOf("Et Al") !== -1) {
+    return (<span>{y.replace(" Et Al", "")}<em> et al</em></span>);
+  }
+  return y;
 };
 
 const TipSelectedPanel = ({tip, goAwayCallback}) => {
@@ -75,7 +83,7 @@ const TipSelectedPanel = ({tip, goAwayCallback}) => {
               </tr>
               <tr>
                 <th>Authors</th>
-                <td>{tip.n.attr.authors}</td>
+                <td>{authorString(tip.n.attr.authors)}</td>
               </tr>
               <tr>
                 <th>Accession</th>

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -2,15 +2,20 @@
 import React from "react";
 import {infoPanelStyles} from "../../globalStyles";
 
-export const prettyString = (x) => {
+export const prettyString = (x, multiplier = false) => {
   if (!x) {
-    return "unknown";
+    return "";
   }
   if (typeof x === "string") {
+    if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
+      return x.toUpperCase();
+    }
     return x.replace(/_/g, " ")
             .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
   } else if (typeof x === "number") {
-    return x.toFixed(2);
+    const val = parseFloat(x);
+    const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));
+    return multiplier ? val.toFixed(5 - magnitude) + "\u00D7" : val.toFixed(5 - magnitude);
   }
   return x;
 };

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -1,87 +1,101 @@
 /*eslint-env browser*/
+/*eslint max-len: 0*/
 import React from "react";
 import {infoPanelStyles} from "../../globalStyles";
 import {prettyString, authorString} from "./treeViewFunctions";
+import { floatDateToMoment } from "../../util/dateHelpers";
+
+const styles = {
+  container: {
+    position: "absolute",
+    width: "100%", height: "100%",
+    pointerEvents: "all",
+    top: 0, left: 0,
+    zIndex: 2000,
+    backgroundColor: "rgba(80, 80, 80, .20)",
+    /* FLEXBOX */
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    wordWrap: "break-word", wordBreak: "break-word"
+  }
+};
+
+const stopProp = (e) => {
+  if (!e) {e = window.event;}
+  e.cancelBubble = true;
+  if (e.stopPropagation) {e.stopPropagation();}
+};
+
+const item = (key, value) => (
+  <tr key={key}>
+    <th>{key}</th>
+    <td>{value}</td>
+  </tr>
+);
+
+const formatURL = (url) => {
+  if (url !== undefined && url.startsWith("https_")) {
+    url = url.replace("https_", "https:");
+  } else if (url !== undefined && url.startsWith("http_")) {
+    url = url.replace("http_", "http:");
+  }
+  return url;
+};
+
+const dateConfidence = (x) => (
+  item("Collection date confidence", `(${floatDateToMoment(x[0]).format("YYYY-MM-DD")}, ${floatDateToMoment(x[1]).format("YYYY-MM-DD")})`)
+);
+
+const accessionAndURL = (url, accession) => (
+  <tr>
+    <th>Accession</th>
+    <td><a href={url} target="_blank">{accession}</a></td>
+  </tr>
+);
+
+const justURL = (url) => (
+  <tr>
+    <th>URL</th>
+    <td><a href={url} target="_blank"><em>click here</em></a></td>
+  </tr>
+);
 
 const TipSelectedPanel = ({tip, goAwayCallback}) => {
-  const styles = {
-    container: {
-      backgroundColor: "rgba(80, 80, 80, .20)",
-      position: "absolute",
-      width: "100%",
-      height: "100%",
-      pointerEvents: "all",
-      top: 0,
-      left: 0,
-      zIndex: 2000,
-      /* FLEXBOX */
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-      wordWrap: "break-word",
-      wordBreak: "break-word"
-    }
-  };
-
-  const stopProp = (e) => {
-    if (!e) {e = window.event;}
-    e.cancelBubble = true;
-    if (e.stopPropagation) {e.stopPropagation();}
-  };
-
-  const makePanel = () => {
-    if (!tip) {return null;}
-    let url = tip.n.attr.url;
-    if (url !== undefined && url.startsWith("https_")) {
-      url = url.replace("https_", "https:");
-    } else if (url !== undefined && url.startsWith("http_")) {
-      url = url.replace("http_", "http:");
-    }
-    return (
-      <div style={styles.container} onClick={() => goAwayCallback(tip)}>
-        <div className={"panel"} style={infoPanelStyles.panel} onClick={(e) => stopProp(e)}>
-          <p style={infoPanelStyles.modalHeading}>
-            {`${tip.n.strain}`}
-          </p>
-          <table>
-            <tbody>
-              <tr>
-                <th width={130}>Region</th>
-                <td>{prettyString(tip.n.attr.region)}</td>
-              </tr>
-              <tr>
-                <th>Country</th>
-                <td>{prettyString(tip.n.attr.country)}</td>
-              </tr>
-              <tr>
-                <th>Division</th>
-                <td>{prettyString(tip.n.attr.division)}</td>
-              </tr>
-              <tr>
-                <th>Collection date</th>
-                <td>{prettyString(tip.n.attr.date)}</td>
-              </tr>
-              <tr>
-                <th>Authors</th>
-                <td>{authorString(tip.n.attr.authors)}</td>
-              </tr>
-              {/* todo: check if both URL && accession exist */}
-              <tr>
-                <th>Accession</th>
-                <td><a href={url} target="_blank">{tip.n.attr.accession}</a></td>
-              </tr>
-            </tbody>
-          </table>
-          <p style={infoPanelStyles.comment}>
-            Click outside this box to go back to the tree
-          </p>
-        </div>
-      </div>
-    );
-  };
-
+  if (!tip) {return null;}
+  const url = formatURL(tip.n.attr.url);
+  const uncertainty = "num_date_confidence" in tip.n.attr && tip.n.attr.num_date_confidence[0] !== tip.n.attr.num_date_confidence[1];
   return (
-    makePanel()
+    <div style={styles.container} onClick={() => goAwayCallback(tip)}>
+      <div className={"panel"} style={infoPanelStyles.panel} onClick={(e) => stopProp(e)}>
+        <p style={infoPanelStyles.modalHeading}>
+          {`${tip.n.strain}`}
+        </p>
+        <table>
+          <tbody>
+            {/* the "basic" attributes (which may not exist in certain datasets) */}
+            {["country", "region", "division"].map((x) => {
+              return (x in tip.n.attr) ? item(prettyString(x), prettyString(tip.n.attr[x])) : null;
+            })}
+            {/* Dates */}
+            {item(uncertainty ? "Inferred collection date" : "Collection date", prettyString(tip.n.attr.date))}
+            {uncertainty ? dateConfidence(tip.n.attr.num_date_confidence) : null}
+            {/* authors (if provided) */}
+            {("authors" in tip.n.attr) ? item("Publication", authorString(tip.n.attr.authors)) : null}
+            {/* try to join URL with accession, else display the one that's available */}
+            {url !== undefined && ("accession" in tip.n.attr) ?
+              accessionAndURL(url, tip.n.attr.accession) :
+              url !== undefined ? justURL(url) :
+              ("accession" in tip.n.attr) ? item("Accession", tip.n.attr.accession) :
+              null
+            }
+          </tbody>
+        </table>
+        <p style={infoPanelStyles.comment}>
+          Click outside this box to go back to the tree
+        </p>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -1,32 +1,7 @@
 /*eslint-env browser*/
 import React from "react";
 import {infoPanelStyles} from "../../globalStyles";
-
-export const prettyString = (x, multiplier = false) => {
-  if (!x) {
-    return "";
-  }
-  if (typeof x === "string") {
-    if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
-      return x.toUpperCase();
-    }
-    return x.replace(/_/g, " ")
-            .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
-  } else if (typeof x === "number") {
-    const val = parseFloat(x);
-    const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));
-    return multiplier ? val.toFixed(5 - magnitude) + "\u00D7" : val.toFixed(5 - magnitude);
-  }
-  return x;
-};
-
-const authorString = (x) => {
-  const y = prettyString(x);
-  if (y.indexOf("Et Al") !== -1) {
-    return (<span>{y.replace(" Et Al", "")}<em> et al</em></span>);
-  }
-  return y;
-};
+import {prettyString, authorString} from "./treeViewFunctions";
 
 const TipSelectedPanel = ({tip, goAwayCallback}) => {
   const styles = {
@@ -90,13 +65,10 @@ const TipSelectedPanel = ({tip, goAwayCallback}) => {
                 <th>Authors</th>
                 <td>{authorString(tip.n.attr.authors)}</td>
               </tr>
+              {/* todo: check if both URL && accession exist */}
               <tr>
                 <th>Accession</th>
-                <td>{tip.n.attr.accession}</td>
-              </tr>
-              <tr>
-                <th>URL</th>
-                <td><a href={url} target="_blank">{url}</a></td>
+                <td><a href={url} target="_blank">{tip.n.attr.accession}</a></td>
               </tr>
             </tbody>
           </table>

--- a/src/components/tree/treeViewFunctions.js
+++ b/src/components/tree/treeViewFunctions.js
@@ -9,8 +9,34 @@ import { branchOpacityConstant,
          branchOpacityFunction,
          branchInterpolateColour } from "../../util/treeHelpers";
 import { mediumTransitionDuration } from "../../util/globals";
+import React from "react";
 import d3 from "d3";
 
+export const prettyString = (x, multiplier = false) => {
+  if (!x) {
+    return "";
+  }
+  if (typeof x === "string") {
+    if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
+      return x.toUpperCase();
+    }
+    return x.replace(/_/g, " ")
+            .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
+  } else if (typeof x === "number") {
+    const val = parseFloat(x);
+    const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));
+    return multiplier ? val.toFixed(5 - magnitude) + "\u00D7" : val.toFixed(5 - magnitude);
+  }
+  return x;
+};
+
+export const authorString = (x) => {
+  const y = prettyString(x);
+  if (y.indexOf("Et Al") !== -1) {
+    return (<span>{y.replace(" Et Al", "")}<em> et al</em></span>);
+  }
+  return y;
+};
 
 export const visibleArea = function (Viewer) {
   const V = Viewer.getValue();


### PR DESCRIPTION
This PR cleans up the tree info panels for hovering over a branch & tip as well as clicking on a tip.
Closes #332 #335 #338

BRANCH HOVER:
* Nucleotide mutations shown when selected in entropy panel (no screenshots)
![image](https://user-images.githubusercontent.com/8350992/27654670-a39ba2f0-5bf7-11e7-9fab-e1bf42ee1737.png)
![image](https://user-images.githubusercontent.com/8350992/27654694-b10eedac-5bf7-11e7-89f4-31baebf31528.png)

TIP HOVER:
* shows less information
![image](https://user-images.githubusercontent.com/8350992/27654841-215fe2be-5bf8-11e7-8ef7-1116476d7db6.png)

TIP SELECT:
* information hidden if not available.
* if both URL + accession, the accession is now a link
* only applicable attrs are shown (no division for flu etc)
![image](https://user-images.githubusercontent.com/8350992/27654881-47209e08-5bf8-11e7-95a9-92b6e60fc1eb.png)
![image](https://user-images.githubusercontent.com/8350992/27654892-52b8b912-5bf8-11e7-976b-8f8b1f2c1c37.png)

@trvrb if this looks good please merge