### PR TITLE
Publication title in tip info

### DIFF
--- a/src/components/charts/entropyInfoPanel.js
+++ b/src/components/charts/entropyInfoPanel.js
@@ -2,7 +2,7 @@
 import React from "react";
 // import * as globals from "../../util/globals";
 import { infoPanelStyles} from "../../globalStyles";
-// import { prettyString } from "../tree/treeViewFunctions";
+// import { prettyString } from "../../util/stringHelpers";
 
 const InfoPanel = ({hovered, mutType}) => {
 

--- a/src/components/controls/recursive_filter.js
+++ b/src/components/controls/recursive_filter.js
@@ -5,7 +5,7 @@ import { controlsWidth } from "../../util/globals";
 import { connect } from "react-redux";
 import { applyFilterQuery } from "../../actions/treeProperties"
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
-import { prettyString } from "../tree/treeViewFunctions";
+import { prettyString } from "../../util/stringHelpers";
 
 /*
  * implements a selector that

--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -1,7 +1,7 @@
 /*eslint-env browser*/
 import React from "react";
 import { infoPanelStyles } from "../../globalStyles";
-import { prettyString } from "./treeViewFunctions";
+import { prettyString } from "../../util/stringHelpers";
 import { floatDateToMoment } from "../../util/dateHelpers";
 
 const infoLineJSX = (item, value) => (

--- a/src/components/tree/legend-item.js
+++ b/src/components/tree/legend-item.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { legendMouseEnterExit } from "../../actions/treeProperties";
 import { dataFont, darkGrey } from "../../globalStyles";
-import { prettyString } from "./treeViewFunctions";
+import { prettyString } from "../../util/stringHelpers";
 
 const LegendItem = ({
   dispatch, transform,
@@ -29,7 +29,7 @@ const LegendItem = ({
       y={legendRectSize - legendSpacing}
       style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}
     >
-      {prettyString(label, dFreq)}
+      {prettyString(label, {multiplier: dFreq})}
     </text>
   </g>
 );

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -2,7 +2,7 @@
 /*eslint max-len: 0*/
 import React from "react";
 import {infoPanelStyles} from "../../globalStyles";
-import {prettyString, authorString} from "./treeViewFunctions";
+import {prettyString, authorString} from "../../util/stringHelpers";
 import { floatDateToMoment } from "../../util/dateHelpers";
 
 const styles = {

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -30,8 +30,8 @@ const stopProp = (e) => {
 /* min width to get "collection date" on 1 line: 120 */
 const item = (key, value) => (
   <tr key={key}>
-    <th style={{minWidth: 120}}>{key}</th>
-    <td>{value}</td>
+    <th style={infoPanelStyles.item}>{key}</th>
+    <td style={infoPanelStyles.item}>{value}</td>
   </tr>
 );
 
@@ -84,7 +84,7 @@ const TipSelectedPanel = ({tip, goAwayCallback}) => {
             {item(uncertainty ? "Inferred collection date" : "Collection date", prettyString(tip.n.attr.date))}
             {uncertainty ? dateConfidence(tip.n.attr.num_date_confidence) : null}
             {/* Paper Title, Author(s), Accession + URL (if provided) */}
-            {validAttr(tip.n.attr, "title") ? item("Publication", prettyString(tip.n.attr.title, {trim: 70, camelCase: false})) : null}
+            {validAttr(tip.n.attr, "title") ? item("Publication", prettyString(tip.n.attr.title, {trim: 80, camelCase: false})) : null}
             {validAttr(tip.n.attr, "authors") ? item("Authors", authorString(tip.n.attr.authors)) : null}
             {/* try to join URL with accession, else display the one that's available */}
             {url && validAttr(tip.n.attr, "accession") ?

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -84,7 +84,7 @@ const TipSelectedPanel = ({tip, goAwayCallback}) => {
             {item(uncertainty ? "Inferred collection date" : "Collection date", prettyString(tip.n.attr.date))}
             {uncertainty ? dateConfidence(tip.n.attr.num_date_confidence) : null}
             {/* Paper Title, Author(s), Accession + URL (if provided) */}
-            {validAttr(tip.n.attr, "title") ? item("Publication", prettyString(tip.n.attr.title, {trim: 70})) : null}
+            {validAttr(tip.n.attr, "title") ? item("Publication", prettyString(tip.n.attr.title, {trim: 70, camelCase: false})) : null}
             {validAttr(tip.n.attr, "authors") ? item("Authors", authorString(tip.n.attr.authors)) : null}
             {/* try to join URL with accession, else display the one that's available */}
             {url && validAttr(tip.n.attr, "accession") ?

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -27,9 +27,10 @@ const stopProp = (e) => {
   if (e.stopPropagation) {e.stopPropagation();}
 };
 
+/* min width to get "collection date" on 1 line: 120 */
 const item = (key, value) => (
   <tr key={key}>
-    <th>{key}</th>
+    <th style={{minWidth: 120}}>{key}</th>
     <td>{value}</td>
   </tr>
 );

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -62,9 +62,11 @@ const justURL = (url) => (
   </tr>
 );
 
+const validAttr = (attrs, key) => key in attrs && attrs[key] !== "?" && attrs[key] !== "" && attrs[key] !== undefined;
+
 const TipSelectedPanel = ({tip, goAwayCallback}) => {
   if (!tip) {return null;}
-  const url = formatURL(tip.n.attr.url);
+  const url = validAttr(tip.n.attr, "url") ? formatURL(tip.n.attr.url) : false;
   const uncertainty = "num_date_confidence" in tip.n.attr && tip.n.attr.num_date_confidence[0] !== tip.n.attr.num_date_confidence[1];
   return (
     <div style={styles.container} onClick={() => goAwayCallback(tip)}>
@@ -76,18 +78,19 @@ const TipSelectedPanel = ({tip, goAwayCallback}) => {
           <tbody>
             {/* the "basic" attributes (which may not exist in certain datasets) */}
             {["country", "region", "division"].map((x) => {
-              return (x in tip.n.attr) ? item(prettyString(x), prettyString(tip.n.attr[x])) : null;
+              return validAttr(tip.n.attr, x) ? item(prettyString(x), prettyString(tip.n.attr[x])) : null;
             })}
             {/* Dates */}
             {item(uncertainty ? "Inferred collection date" : "Collection date", prettyString(tip.n.attr.date))}
             {uncertainty ? dateConfidence(tip.n.attr.num_date_confidence) : null}
-            {/* authors (if provided) */}
-            {("authors" in tip.n.attr) ? item("Publication", authorString(tip.n.attr.authors)) : null}
+            {/* Paper Title, Author(s), Accession + URL (if provided) */}
+            {validAttr(tip.n.attr, "title") ? item("Publication", prettyString(tip.n.attr.title, {trim: 70})) : null}
+            {validAttr(tip.n.attr, "authors") ? item("Authors", authorString(tip.n.attr.authors)) : null}
             {/* try to join URL with accession, else display the one that's available */}
-            {url !== undefined && ("accession" in tip.n.attr) ?
+            {url && validAttr(tip.n.attr, "accession") ?
               accessionAndURL(url, tip.n.attr.accession) :
-              url !== undefined ? justURL(url) :
-              ("accession" in tip.n.attr) ? item("Accession", tip.n.attr.accession) :
+              url ? justURL(url) :
+              validAttr(tip.n.attr, "accession") ? item("Accession", tip.n.attr.accession) :
               null
             }
           </tbody>

--- a/src/components/tree/treeViewFunctions.js
+++ b/src/components/tree/treeViewFunctions.js
@@ -12,32 +12,6 @@ import { mediumTransitionDuration } from "../../util/globals";
 import React from "react";
 import d3 from "d3";
 
-export const prettyString = (x, multiplier = false) => {
-  if (!x) {
-    return "";
-  }
-  if (typeof x === "string") {
-    if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
-      return x.toUpperCase();
-    }
-    return x.replace(/_/g, " ")
-            .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
-  } else if (typeof x === "number") {
-    const val = parseFloat(x);
-    const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));
-    return multiplier ? val.toFixed(5 - magnitude) + "\u00D7" : val.toFixed(5 - magnitude);
-  }
-  return x;
-};
-
-export const authorString = (x) => {
-  const y = prettyString(x);
-  if (y.indexOf("Et Al") !== -1) {
-    return (<span>{y.replace(" Et Al", "")}<em> et al</em></span>);
-  }
-  return y;
-};
-
 export const visibleArea = function (Viewer) {
   const V = Viewer.getValue();
   return {

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -138,7 +138,8 @@ export const infoPanelStyles = {
     fontFamily: dataFont,
     fontSize: 18,
     lineHeight: 1,
-    fontWeight: 300
+    fontWeight: 300,
+    maxWidth: 500
   },
   modalHeading: {
     fontSize: 24,
@@ -159,4 +160,9 @@ export const infoPanelStyles = {
     paddingLeft: 15,
     listStyleType: "disc"
   },
+  item: {
+    paddingTop: 4,
+    paddingBottom: 4,
+    minWidth: 120
+  }
 };

--- a/src/util/stringHelpers.js
+++ b/src/util/stringHelpers.js
@@ -7,7 +7,7 @@ import React from "react";
  * @param {int} trim (default: 0) should strings get trimmed? Applies only to strings. 0: no trimming.
  * @returns {string|float} to display
  */
-export const prettyString = (x, {multiplier = false, trim = 0} = {}) => {
+export const prettyString = (x, {multiplier = false, trim = 0, camelCase = true} = {}) => {
   if (!x) {
     return "";
   }
@@ -18,8 +18,11 @@ export const prettyString = (x, {multiplier = false, trim = 0} = {}) => {
     if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
       return x.toUpperCase();
     }
-    return x.replace(/_/g, " ")
-            .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
+    x = x.replace(/_/g, " ");
+    if (camelCase) {
+      return x.replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
+    }
+    return x;
   } else if (typeof x === "number") {
     const val = parseFloat(x);
     const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));

--- a/src/util/stringHelpers.js
+++ b/src/util/stringHelpers.js
@@ -1,0 +1,37 @@
+import React from "react";
+
+/**
+ * Convert string or number, often with underscores etc, into a form for display
+ * @param {string|int} x one of .tip or .branch
+ * @param {bool} multiplier (default: false) add multiplier symbol to end
+ * @param {int} trim (default: 0) should strings get trimmed? Applies only to strings. 0: no trimming.
+ * @returns {string|float} to display
+ */
+export const prettyString = (x, {multiplier = false, trim = 0} = {}) => {
+  if (!x) {
+    return "";
+  }
+  if (typeof x === "string") {
+    if (trim > 0 && x.length > trim) {
+      x = x.slice(0, trim) + "...";
+    }
+    if (["usvi", "usa", "uk"].indexOf(x.toLowerCase()) !== -1) {
+      return x.toUpperCase();
+    }
+    return x.replace(/_/g, " ")
+            .replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
+  } else if (typeof x === "number") {
+    const val = parseFloat(x);
+    const magnitude = Math.ceil(Math.log10(Math.abs(val) + 1e-10));
+    return multiplier ? val.toFixed(5 - magnitude) + "\u00D7" : val.toFixed(5 - magnitude);
+  }
+  return x;
+};
+
+export const authorString = (x) => {
+  const y = prettyString(x);
+  if (y.indexOf("Et Al") !== -1) {
+    return (<span>{y.replace(" Et Al", "")}<em> et al</em></span>);
+  }
+  return y;
+};


### PR DESCRIPTION
This PR adds the publication title to the tip header box (if present in the node `attr`, not displayed otherwise). No datasets currently have this, but they will soon!
![image](https://user-images.githubusercontent.com/8350992/27886588-99af4f40-6191-11e7-9c34-dc31ff179daa.png)


Titles currently cut off at 70 characters - https://github.com/nextstrain/auspice/blob/publication-title/src/components/tree/tipSelectedPanel.js#L87

Additionally, the string display functions have been grouped together in `util/stringHelpers.js` 