### PR TITLE
Date window v2

### DIFF
--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -6,6 +6,7 @@ import Slider from "./slider";
 import { connect } from "react-redux";
 import { controlsWidth } from "../../util/globals";
 import { modifyURLquery } from "../../util/urlHelpers";
+import { numericToCalendar, calendarToNumeric } from "../../util/dateHelpers";
 import { changeDateFilter } from "../../actions/treeProperties";
 import d3 from "d3";
 import {
@@ -53,14 +54,6 @@ class DateRangeInputs extends React.Component {
     };
   }
 
-  numericToCalendar(numDate) {
-    return(this.props.dateFormat(this.props.dateScale.invert(numDate)));
-  }
-
-  calendarToNumeric(calDate) {
-    return(this.props.dateScale(this.props.dateFormat.parse(calDate)));
-  }
-
   maybeClearMapAnimationInterval() {
     if (window.NEXTSTRAIN && window.NEXTSTRAIN.mapAnimationLoop) {
       clearInterval(window.NEXTSTRAIN.mapAnimationLoop);
@@ -105,8 +98,8 @@ class DateRangeInputs extends React.Component {
 
     // {numDateValues} is an array of numDates received from Slider
     // [numDateStart, numDateEnd]
-    const newRange = {min: this.numericToCalendar(numDateValues[0]),
-      max: this.numericToCalendar(numDateValues[1])};
+    const newRange = {min: numericToCalendar(this.props.dateFormat, this.props.dateScale, numDateValues[0]),
+      max: numericToCalendar(this.props.dateFormat, this.props.dateScale, numDateValues[1])};
     if (this.props.dateMin !== newRange.min && this.props.dateMax === newRange.max) { // update min
       this.props.dispatch(changeDateFilter({newMin: newRange.min}));
       modifyURLquery(this.context.router, {dmin: newRange.min}, true);
@@ -165,10 +158,10 @@ class DateRangeInputs extends React.Component {
     const selectedMin = this.props.dateMin;
     const selectedMax = this.props.dateMax;
 
-    const absoluteMinNumDate = this.calendarToNumeric(absoluteMin);
-    const absoluteMaxNumDate = this.calendarToNumeric(absoluteMax);
-    const selectedMinNumDate = this.calendarToNumeric(selectedMin);
-    const selectedMaxNumDate = this.calendarToNumeric(selectedMax);
+    const absoluteMinNumDate = calendarToNumeric(this.props.dateFormat, this.props.dateScale, absoluteMin);
+    const absoluteMaxNumDate = calendarToNumeric(this.props.dateFormat, this.props.dateScale, absoluteMax);
+    const selectedMinNumDate = calendarToNumeric(this.props.dateFormat, this.props.dateScale, selectedMin);
+    const selectedMaxNumDate = calendarToNumeric(this.props.dateFormat, this.props.dateScale, selectedMax);
 
     const minDistance = (absoluteMaxNumDate - absoluteMinNumDate) / 10.0;
 

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -10,7 +10,7 @@ import { numericToCalendar, calendarToNumeric } from "../../util/dateHelpers";
 import setupLeaflet from "../../util/leaflet";
 import setupLeafletPlugins from "../../util/leaflet-plugins";
 import {drawDemesAndTransmissions, updateOnMoveEnd, updateVisibility} from "../../util/mapHelpers";
-import * as globals from "../../util/globals";
+import { animationWindowWidth, animationTick, twoColumnBreakpoint } from "../../util/globals";
 import computeResponsive from "../../util/computeResponsive";
 import {getLatLongs} from "../../util/mapHelpersLatLong";
 import {
@@ -138,7 +138,7 @@ class Map extends React.Component {
   }
   doComputeResponsive(nextProps) {
     return computeResponsive({
-      horizontal: nextProps.browserDimensions.width > globals.twoColumnBreakpoint && (this.props.controls && this.props.controls.splitTreeAndMap) ? .5 : 1,
+      horizontal: nextProps.browserDimensions.width > twoColumnBreakpoint && (this.props.controls && this.props.controls.splitTreeAndMap) ? .5 : 1,
       vertical: 1.0, /* if we are in single column, full height */
       browserDimensions: nextProps.browserDimensions,
       sidebar: nextProps.sidebar,
@@ -455,9 +455,8 @@ class Map extends React.Component {
     let end = calendarToNumeric(this.props.dateFormat, this.props.dateScale, this.props.absoluteDateMax);
     let totalRange = end - leftWindow; // years in the animation
 
-    const tick = 100; // Length of each tick in milliseconds
-    let animationIncrement = Math.ceil((tick*totalRange)/this.props.mapAnimationDurationInMilliseconds); // [(ms * days) / ms] = days
-    const windowRange = Math.ceil((totalRange / 100)); // this is 1/10 the date range in date slider
+    let animationIncrement = (animationTick * totalRange) / this.props.mapAnimationDurationInMilliseconds; // [(ms * years) / ms] = years eg 100 ms * 5 years / 30,000 ms =  0.01666666667 years
+    const windowRange = animationWindowWidth * totalRange;
     let rightWindow = leftWindow + windowRange;
 
     if (!window.NEXTSTRAIN) {
@@ -488,7 +487,7 @@ class Map extends React.Component {
           data: "Play"
         });
       }
-    }, tick);
+    }, animationTick);
 
     // controls: state.controls,
     // this.props.dateMin //"2013-06-28"

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -451,9 +451,10 @@ class Map extends React.Component {
     // leftWindow --- rightWindow ------------------------------- end
     // 2011.4 ------- 2011.6 ------------------------------------ 2015.4
 
+    let start = calendarToNumeric(this.props.dateFormat, this.props.dateScale, this.props.absoluteDateMin);
     let leftWindow = calendarToNumeric(this.props.dateFormat, this.props.dateScale, this.props.dateMin);
     let end = calendarToNumeric(this.props.dateFormat, this.props.dateScale, this.props.absoluteDateMax);
-    let totalRange = end - leftWindow; // years in the animation
+    let totalRange = end - start; // years in the animation
 
     let animationIncrement = (animationTick * totalRange) / this.props.mapAnimationDurationInMilliseconds; // [(ms * years) / ms] = years eg 100 ms * 5 years / 30,000 ms =  0.01666666667 years
     const windowRange = animationWindowWidth * totalRange;

--- a/src/util/dateHelpers.js
+++ b/src/util/dateHelpers.js
@@ -6,3 +6,11 @@ export const floatDateToMoment = function (num_date) {
   if (days === "0") {days = 1;}
   return moment("".concat(years, "-", days), "Y-DDD");
 };
+
+export const numericToCalendar = function (dateFormat, dateScale, numDate) {
+  return(dateFormat(dateScale.invert(numDate)));
+};
+
+export const calendarToNumeric = function (dateFormat, dateScale, calDate) {
+  return(dateScale(dateFormat.parse(calDate)));
+};

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -53,6 +53,8 @@ export const defaultDistanceMeasures = ["num_date", "div"];
 export const fastTransitionDuration = 350; // in milliseconds
 export const mediumTransitionDuration = 700; // in milliseconds
 export const slowTransitionDuration = 1400; // in milliseconds
+export const animationWindowWidth = 0.075; // width of animation window relative to date slider
+export const animationTick = 100; // animation tick in milliseconds
 export const HIColorDomain = genericDomain.map((d) => {
   return Math.round(100 * (d * 3.6)) / 100;
 });


### PR DESCRIPTION
This replaces moment date conversion with d3 date conversion in map animation. It also (actually) resolves #363.

I made a new branch and cherry picked in commits from `363-date-window` because there ended up being merge conflicts with commits that came in from `simplify`. Easier to do it this way.

Supersedes PR #368. 