### PR TITLE
Add flag to globals to enable/disable animation display

### DIFF
--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -12,7 +12,7 @@ import ChooseMetric from "./choose-metric";
 import GeoResolution from "./geo-resolution";
 import MapAnimationControls from "./map-animation";
 import AllFilters from "./all-filter";
-import * as globals from "../../util/globals";
+import { controlsWidth, enableAnimationDisplay } from "../../util/globals";
 import { titleStyles } from "../../globalStyles";
 import { connect } from "react-redux";
 
@@ -54,7 +54,7 @@ class Controls extends React.Component {
         justifyContent="flex-start"
         alignItems="flex-start"
         style={{
-          width: globals.controlsWidth,
+          width: controlsWidth,
           padding: "0px 20px 20px 20px"
         }}
       >
@@ -81,7 +81,7 @@ class Controls extends React.Component {
         {header("Map Options")}
         <SelectLabel text="Geographic resolution"/>
         <GeoResolution/>
-        <MapAnimationControls/>
+        {enableAnimationDisplay ? <MapAnimationControls/> : null}
         {header("Filters")}
         <AllFilters/>
 

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -10,7 +10,7 @@ import { numericToCalendar, calendarToNumeric } from "../../util/dateHelpers";
 import setupLeaflet from "../../util/leaflet";
 import setupLeafletPlugins from "../../util/leaflet-plugins";
 import {drawDemesAndTransmissions, updateOnMoveEnd, updateVisibility} from "../../util/mapHelpers";
-import { animationWindowWidth, animationTick, twoColumnBreakpoint } from "../../util/globals";
+import { enableAnimationDisplay, animationWindowWidth, animationTick, twoColumnBreakpoint } from "../../util/globals";
 import computeResponsive from "../../util/computeResponsive";
 import {getLatLongs} from "../../util/mapHelpersLatLong";
 import {
@@ -358,6 +358,51 @@ class Map extends React.Component {
 
     this.setState({map});
   }
+
+  animationButtons() {
+    if (!enableAnimationDisplay) {
+        return null;
+    } else {
+      return (
+        <div>
+        <button style={{
+            position: "absolute",
+            left: 25,
+            top: 25,
+            zIndex: 9999,
+            border: "none",
+            width: 56,
+            padding: 15,
+            borderRadius: 4,
+            backgroundColor: "rgb(124, 184, 121)",
+            fontWeight: 700,
+            color: "white",
+          }}
+          onClick={this.handleAnimationPlayPauseClicked.bind(this) }
+          >
+          {this.props.mapAnimationPlayPauseButton}
+        </button>
+        <button style={{
+            position: "absolute",
+            left: 90,
+            top: 25,
+            zIndex: 9999,
+            border: "none",
+            padding: 15,
+            borderRadius: 4,
+            backgroundColor: "rgb(230, 230, 230)",
+            fontWeight: 700,
+            color: "white"
+          }}
+          onClick={this.handleAnimationResetClicked.bind(this) }
+          >
+          Reset
+        </button>
+        </div>
+      )
+    }
+  }
+
   maybeCreateMapDiv() {
     let container = null;
     if (
@@ -366,39 +411,7 @@ class Map extends React.Component {
     ) {
       container = (
         <div style={{position: "relative"}}>
-          <button style={{
-              position: "absolute",
-              left: 25,
-              top: 25,
-              zIndex: 9999,
-              border: "none",
-              width: 56,
-              padding: 15,
-              borderRadius: 4,
-              backgroundColor: "rgb(124, 184, 121)",
-              fontWeight: 700,
-              color: "white",
-            }}
-          onClick={this.handleAnimationPlayPauseClicked.bind(this) }
-            >
-            {this.props.mapAnimationPlayPauseButton}
-          </button>
-          <button style={{
-              position: "absolute",
-              left: 90,
-              top: 25,
-              zIndex: 9999,
-              border: "none",
-              padding: 15,
-              borderRadius: 4,
-              backgroundColor: "rgb(230, 230, 230)",
-              fontWeight: 700,
-              color: "white"
-            }}
-          onClick={this.handleAnimationResetClicked.bind(this) }
-            >
-            Reset
-          </button>
+          {this.animationButtons()}
           <div style={{
               height: this.state.responsive.height,
               width: this.state.responsive.width

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -53,6 +53,7 @@ export const defaultDistanceMeasures = ["num_date", "div"];
 export const fastTransitionDuration = 350; // in milliseconds
 export const mediumTransitionDuration = 700; // in milliseconds
 export const slowTransitionDuration = 1400; // in milliseconds
+export const enableAnimationDisplay = false;
 export const animationWindowWidth = 0.075; // width of animation window relative to date slider
 export const animationTick = 100; // animation tick in milliseconds
 export const HIColorDomain = genericDomain.map((d) => {


### PR DESCRIPTION
I've added a simple flag to globals called `enableAnimationDisplay` which is currently set to `false`. This hides the play/pause/reset buttons on the map and also hides the animation controls in the sidebar. With this in place we can deploy without having to have the animation itself completely up to speed.