### PR TITLE
Properly avoid unnecessary rerendering of footer

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -19,6 +19,14 @@ class Footer extends React.Component {
   static contextTypes = {
     router: React.PropTypes.object.isRequired
   }
+  shouldComponentUpdate(nextProps, nextState) {
+    if (this.props.tree.version !== nextProps.tree.version) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
   getStyles() {
     return {
       footer: {


### PR DESCRIPTION
Per #367 

The page footer (with citations) was rerendering every time redux `tree` was updated. This included visibility changes etc... This fixes it so that footer is only rerendered if `tree.version` is updated. Testing seems to be okay.

This shaves ~5ms from Zika animation frames.