### PR TITLE
Adds optional "vmin"/"vmax" values to anchor color ramps.

### DIFF
--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -34,11 +34,15 @@ const genericScale = (cmin, cmax, vals = false) => {
 };
 
 
-const minMaxAttributeScale = (nodes, attr) => {
+const minMaxAttributeScale = (nodes, attr, options) => {
+  if (options.vmin && options.vmax){
+      return genericScale(options.vmin, options.vmax);
+  } else {
   const vals = nodes.map((n) => n.attr[attr])
     .filter((n) => n !== undefined)
     .filter((item, i, ar) => ar.indexOf(item) === i);
   return genericScale(d3.min(vals), d3.max(vals), vals);
+}
 };
 
 const integerAttributeScale = (nodes, attr) => {
@@ -132,13 +136,13 @@ const getColorScale = (colorBy, tree, sequences, colorOptions, version) => {
     } else if (colorOptions && colorOptions[colorBy].type === "continuous") {
       // console.log("making a continuous color scale for ", colorBy)
       continuous = true;
-      colorScale = minMaxAttributeScale(tree.nodes, colorBy);
+      colorScale = minMaxAttributeScale(tree.nodes, colorBy, colorOptions[colorBy]);
     }
   } else {
     // This shouldn't ever happen!
     // console.log("no colorOptions for ", colorBy, " returning minMaxAttributeScale")
     continuous = true;
-    colorScale = minMaxAttributeScale(tree.nodes, colorBy);
+    colorScale = minMaxAttributeScale(tree.nodes, colorBy, colorOptions[colorBy]);
   }
   return {
     "scale": colorScale,

--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -35,14 +35,14 @@ const genericScale = (cmin, cmax, vals = false) => {
 
 
 const minMaxAttributeScale = (nodes, attr, options) => {
-  if (options.vmin && options.vmax){
-      return genericScale(options.vmin, options.vmax);
+  if (options.vmin && options.vmax) {
+    return genericScale(options.vmin, options.vmax);
   } else {
-  const vals = nodes.map((n) => n.attr[attr])
-    .filter((n) => n !== undefined)
-    .filter((item, i, ar) => ar.indexOf(item) === i);
-  return genericScale(d3.min(vals), d3.max(vals), vals);
-}
+    const vals = nodes.map((n) => n.attr[attr])
+      .filter((n) => n !== undefined)
+      .filter((item, i, ar) => ar.indexOf(item) === i);
+    return genericScale(d3.min(vals), d3.max(vals), vals);
+  }
 };
 
 const integerAttributeScale = (nodes, attr) => {


### PR DESCRIPTION
E.g., for dengue titers I want to anchor the color ramp at the full range of the assay (0 - 2) across all dengue builds, rather than anchoring it at the range of the dataset. 

This PR allows optional for "vmin" and "vmax" values to be added to augur like so:

```
## within config
 "color_options": {
     "cTiter": { 
         "menuItem": "antigenic advance", "type": "continuous", "legendTitle": "Antigenic Advance", 
         "key": "cTiter", "vmin": 0.0, "vmax": 2.0}
     }
 ```

Within auspice, these arguments are not required; if omitted, color ramps are computed exactly as they are now. If present, color ramps are interpolated between vmin and vmax, rather that data min and data max.