### PR TITLE
Fix dtype of distanceMeasure props

### DIFF
--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -109,7 +109,7 @@ const Controls = (state = getDefaultState(), action) => {
         base["colorBy"] = action.meta.defaults.colorBy;
       }
       if (action.meta.defaults.distanceMeasure) {
-        base["distanceMeasure"] = action.meta.defaults.distanceMeasure;
+        base["distanceMeasure"] = action.meta.defaults.distanceMeasure[0];
       }
       if (action.meta.defaults.layout) {
         base["layout"] = action.meta.defaults.layout;


### PR DESCRIPTION
Resolves #382 

@sidneymbell ---

I cherrypicked commit b23acd5b05d64aecf326d32fed47305757a3e883 as this is the commit that fixes the bug. Commit cfb5c4c6c66f781d8e0460fa529bfcd146501e0c is not actually affecting things and the merging of `master` in 803f95ba5249c1344617f744f9b316891e977559 makes for an unnecessarily messy repo history. Not a big deal. Just cleaning up.