### PR TITLE
Styles update

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@ rules:
   react/jsx-first-prop-new-line: off
   react/prop-types: off # possibly reinstate
   react/sort-comp: off # possibly reinstate
+  jsx-a11y/no-static-element-interactions: off
 parserOptions:
   ecmaVersion: 6
   sourceType: module

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -72,27 +72,22 @@ class App extends React.Component {
     return (
       <g>
         <DownloadModal/>
+        {this.state.sidebarOpen || this.state.sidebarDocked ?
+          <TitleBar minified/> :
+          <TitleBar minfied absent/>}
+        <ToggleSidebarTab
+          open={this.state.sidebarDocked}
+          handler={() => {this.setState({sidebarDocked: !this.state.sidebarDocked});}}
+        />
         <Sidebar
           sidebar={
-            <div>
-              <TitleBar minified={true}/>
-              <Controls/>
-              <ToggleSidebarTab
-                open={this.state.sidebarDocked}
-                handler={() => {this.setState({sidebarDocked: !this.state.sidebarDocked});}}
-              />
-            </div>
+            <Controls/>
           }
           open={this.state.sidebarOpen}
           docked={this.state.sidebarDocked}
-          onSetOpen={(a) => {this.setState({sidebarOpen: a});}}>
+          onSetOpen={(a) => {this.setState({sidebarOpen: a});}}
+        >
           <Background>
-            {this.state.sidebarOpen || this.state.sidebarDocked ? <div/> :
-              <ToggleSidebarTab
-                open={this.state.sidebarDocked}
-                handler={() => {this.setState({sidebarDocked: !this.state.sidebarDocked});}}
-              />
-            }
             <TreeView
               query={queryString.parse(this.context.router.history.location.search)}
               sidebar={this.state.sidebarOpen || this.state.sidebarDocked}

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -72,16 +72,16 @@ class App extends React.Component {
     return (
       <g>
         <DownloadModal/>
-        {this.state.sidebarOpen || this.state.sidebarDocked ?
-          <TitleBar minified/> :
-          <TitleBar minfied absent/>}
         <ToggleSidebarTab
           open={this.state.sidebarDocked}
           handler={() => {this.setState({sidebarDocked: !this.state.sidebarDocked});}}
         />
         <Sidebar
           sidebar={
-            <Controls/>
+            <div>
+              <TitleBar minified/>
+              <Controls/>
+            </div>
           }
           open={this.state.sidebarOpen}
           docked={this.state.sidebarDocked}

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -86,6 +86,7 @@ class App extends React.Component {
           open={this.state.sidebarOpen}
           docked={this.state.sidebarDocked}
           onSetOpen={(a) => {this.setState({sidebarOpen: a});}}
+          sidebarClassName={"sidebar"}
         >
           <Background>
             <TreeView

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -53,6 +53,7 @@ class Controls extends React.Component {
         alignItems="flex-start"
         style={{
           width: controlsWidth,
+          marginTop: "50px",
           padding: "0px 20px 20px 20px"
         }}
       >

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -53,7 +53,6 @@ class Controls extends React.Component {
         alignItems="flex-start"
         style={{
           width: controlsWidth,
-          marginTop: "50px",
           padding: "0px 20px 20px 20px"
         }}
       >

--- a/src/components/framework/background.js
+++ b/src/components/framework/background.js
@@ -11,7 +11,7 @@ class Background extends React.Component {
   getStyles() {
     return {
       base: {
-        backgroundColor: "#F8F8F8",
+        backgroundColor: "#F4F4F4",
         height: this.props.docHeight
       }
     };
@@ -19,7 +19,7 @@ class Background extends React.Component {
   render() {
     const styles = this.getStyles();
     return (
-      <div style={{ ...styles.base, ...this.props.style }}>
+      <div id="background" style={{ ...styles.base, ...this.props.style }}>
         {this.props.children}
       </div>
     );

--- a/src/components/framework/background.js
+++ b/src/components/framework/background.js
@@ -12,7 +12,8 @@ class Background extends React.Component {
     return {
       base: {
         backgroundColor: "#F4F4F4",
-        height: this.props.docHeight
+        height: this.props.docHeight,
+        overflowX: "hidden"
       }
     };
   }

--- a/src/components/framework/card.js
+++ b/src/components/framework/card.js
@@ -7,11 +7,11 @@ class Card extends React.Component {
       base: {
         backgroundColor: "#FFFFFF",
         display: "inline-block",
-        marginLeft: 10,
-        marginRight: 10,
-        marginTop: 5,
-        marginBottom: 5,
-        boxShadow: "2px 2px 4px 1px rgba(215,215,215,0.85)",
+        marginLeft: 12,
+        marginRight: 0,
+        marginTop: 8,
+        marginBottom: 2,
+        boxShadow: "0px 0px 4px 2px rgba(215,215,215,0.55)",
         borderRadius: 2,
         padding: 5,
         overflow: "hidden",
@@ -21,7 +21,9 @@ class Card extends React.Component {
         fontFamily: headerFont,
         color: medGrey,
         fontSize: 16,
-        margin: 5,
+        marginLeft: 2,
+        marginTop: 2,
+        marginBottom: 5,
         fontWeight: 500,
         backgroundColor: "#FFFFFF"
       }

--- a/src/components/framework/title-bar.js
+++ b/src/components/framework/title-bar.js
@@ -33,9 +33,14 @@ class TitleBar extends React.Component {
         height: titleBarHeight,
         justifyContent: "space-between",
         alignItems: "center",
-        background: "#fff",
-        marginBottom: 5,
-        overflow: "hidden"
+        overflow: "hidden",
+        left: this.props.absent ? -320 : 0,
+        zIndex: 1001,
+        transition: "left .3s ease-out",
+        background: this.props.minified ? "#AAA" : "#FFF",
+        width: this.props.minified ? 320 : "auto",
+        position: this.props.minified ? "fixed" : "inherit",
+        boxShadow: this.props.minified ? "0px 0px 8px 4px rgba(215,215,215,0.55)" : "0px"
       },
       logo: {
         paddingLeft: "8px",
@@ -56,7 +61,7 @@ class TitleBar extends React.Component {
       dataName: {
         alignSelf: "center",
         padding: "0px",
-        color: darkGrey,
+        color: this.props.minified ? "#fff" : darkGrey,
         textDecoration: "none",
         fontSize: 20,
         fontWeight: 400
@@ -66,12 +71,12 @@ class TitleBar extends React.Component {
         paddingRight: this.props.minified ? "6px" : "12px",
         paddingTop: "20px",
         paddingBottom: "20px",
-        color: darkGrey,
+        color: this.props.minified ? "#fff" : darkGrey,
         textDecoration: "none",
         cursor: "pointer",
         fontSize: this.props.minified ? 12 : 16,
         ':hover': {
-          color: "rgb(80, 151, 186)",
+          color: "rgb(80, 151, 186)"
         }
       },
       inactive: {
@@ -131,17 +136,15 @@ class TitleBar extends React.Component {
   render() {
     const styles = this.getStyles();
     return (
-      <div >
-        <Flex style={styles.main}>
-          {this.getLogo(styles)}
-          {this.getTitle(styles)}
-          {this.getDataName(styles)}
-          <div style={{flex: 5}}/>
-            {this.getLink("About", "/about", this.props.aboutSelected, styles)}
-            {this.getLink("Methods", "/methods", this.props.methodsSelected, styles)}
-          <div style={{width: this.props.minified ? 15 : 0 }}/>
-        </Flex>
-      </div>
+      <Flex style={styles.main}>
+        {this.getLogo(styles)}
+        {this.getTitle(styles)}
+        {this.getDataName(styles)}
+        <div style={{flex: 5}}/>
+          {this.getLink("About", "/about", this.props.aboutSelected, styles)}
+          {this.getLink("Methods", "/methods", this.props.methodsSelected, styles)}
+        <div style={{width: this.props.minified ? 15 : 0 }}/>
+      </Flex>
     );
   }
 }

--- a/src/components/framework/title-bar.js
+++ b/src/components/framework/title-bar.js
@@ -34,13 +34,11 @@ class TitleBar extends React.Component {
         justifyContent: "space-between",
         alignItems: "center",
         overflow: "hidden",
-        left: this.props.absent ? -320 : 0,
+        left: 0,
         zIndex: 1001,
         transition: "left .3s ease-out",
-        background: this.props.minified ? "#AAA" : "#FFF",
-        width: this.props.minified ? 320 : "auto",
-        position: this.props.minified ? "fixed" : "inherit",
-        boxShadow: this.props.minified ? "0px 0px 8px 4px rgba(215,215,215,0.55)" : "0px"
+        background: "#FFF",
+        width: this.props.minified ? 320 : "auto"
       },
       logo: {
         paddingLeft: "8px",
@@ -61,7 +59,7 @@ class TitleBar extends React.Component {
       dataName: {
         alignSelf: "center",
         padding: "0px",
-        color: this.props.minified ? "#fff" : darkGrey,
+        color: darkGrey,
         textDecoration: "none",
         fontSize: 20,
         fontWeight: 400
@@ -71,7 +69,7 @@ class TitleBar extends React.Component {
         paddingRight: this.props.minified ? "6px" : "12px",
         paddingTop: "20px",
         paddingBottom: "20px",
-        color: this.props.minified ? "#fff" : darkGrey,
+        color: darkGrey,
         textDecoration: "none",
         cursor: "pointer",
         fontSize: this.props.minified ? 12 : 16,

--- a/src/components/framework/toggle-sidebar-tab.js
+++ b/src/components/framework/toggle-sidebar-tab.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { controlsWidth, controlsPadding } from "../../util/globals";
 
 const ToggleSidebarTab = ({open, handler}) => {
 
@@ -13,11 +14,12 @@ const ToggleSidebarTab = ({open, handler}) => {
         position: "fixed",
         top: 0,
         zIndex: 1001,
-        backgroundColor: "#4b4e4e",
+        backgroundColor: "#AAA",
         cursor: "pointer",
-        left: open ? "auto" : 0,
-        right: open ? 0 : "auto"
-      }}>
+        left: open ? controlsWidth + controlsPadding - 15 : 0,
+        transition: "left .3s ease-out"
+      }}
+    >
       <svg
         style={{
           position: "relative",

--- a/src/components/framework/toggle-sidebar-tab.js
+++ b/src/components/framework/toggle-sidebar-tab.js
@@ -3,7 +3,7 @@ import { controlsWidth, controlsPadding } from "../../util/globals";
 
 const ToggleSidebarTab = ({open, handler}) => {
 
-  const transform = open ? "translate(374.000000, 167.500000) rotate(180.000000) translate(-374.000000, -167.500000)" : "none";
+  const degrees = open ? 180 : 0;
 
   return (
     <div
@@ -14,7 +14,7 @@ const ToggleSidebarTab = ({open, handler}) => {
         position: "fixed",
         top: 0,
         zIndex: 1001,
-        backgroundColor: "#AAA",
+        backgroundColor: "#4b4e4e",
         cursor: "pointer",
         left: open ? controlsWidth + controlsPadding - 15 : 0,
         transition: "left .3s ease-out"
@@ -24,18 +24,20 @@ const ToggleSidebarTab = ({open, handler}) => {
         style={{
           position: "relative",
           top: 20,
-          left: 4
+          left: 4,
+          transform: `rotate(${degrees}deg)`,
+          transition: "transform 0.3s ease-out"
         }}
         width="7px"
         height="10.5px"
-        viewBox="369 160 10 15">
+        viewBox="369 160 10 15"
+      >
         <polygon
           id="Triangle"
           stroke="none"
           fill="#FFFFFF"
-          transform={transform}
-          points="379 167.5 369 175 369 160">
-        </polygon>
+          points="379 167.5 369 175 369 160"
+        />
       </svg>
     </div>
   );

--- a/src/components/tree/legend.js
+++ b/src/components/tree/legend.js
@@ -202,7 +202,7 @@ class Legend extends React.Component {
       svg: {
         position: "absolute",
         left: 12,
-        top: 39,
+        top: 36,
         borderRadius: 2,
         zIndex: 1000
       }

--- a/src/util/computeResponsive.js
+++ b/src/util/computeResponsive.js
@@ -40,11 +40,18 @@ const computeResponsive = ({
   const horizontalPadding = horizontal === 1 ? 34 : 56; // derived from empirical testing, depends on Card margins
   const verticalPadding = 165;
 
+  // sidebar scrollbar has width equal to its offsetWidth - clientWidth
+  let scrollbarWidth = 0;
+  const classArray = document.getElementsByClassName("sidebar");
+  if (classArray.length > 0) {
+    scrollbarWidth = classArray[0].offsetWidth - classArray[0].clientWidth;
+  }
+
   if (browserDimensions) {
-    const computedControlWidth = sidebar ? controlsWidth + controlsPadding : 0;
-    width = horizontal * (browserDimensions.width - computedControlWidth - horizontalPadding);
+    const computedControlWidth = sidebar ? controlsWidth + controlsPadding + scrollbarWidth : 0;
+    width = horizontal * (browserDimensions.width - computedControlWidth - horizontalPadding - scrollbarWidth);
     if (width < cardMinimumWidth) {
-      width = horizontal * (browserDimensions.width - horizontalPadding);
+      width = horizontal * (browserDimensions.width - horizontalPadding - scrollbarWidth);
     }
     height = browserDimensions.height * vertical - verticalPadding;
   }

--- a/src/util/computeResponsive.js
+++ b/src/util/computeResponsive.js
@@ -1,4 +1,4 @@
-import { controlsWidth, controlsPadding } from "./globals";
+import { controlsWidth, controlsPadding, cardMinimumWidth } from "./globals";
 
 /*
   Why this function is here
@@ -43,6 +43,9 @@ const computeResponsive = ({
   if (browserDimensions) {
     const computedControlWidth = sidebar ? controlsWidth + controlsPadding : 0;
     width = horizontal * (browserDimensions.width - computedControlWidth - horizontalPadding);
+    if (width < cardMinimumWidth) {
+      width = horizontal * (browserDimensions.width - horizontalPadding);
+    }
     height = browserDimensions.height * vertical - verticalPadding;
   }
 

--- a/src/util/computeResponsive.js
+++ b/src/util/computeResponsive.js
@@ -27,7 +27,7 @@ import { controlsWidth } from "./globals";
 
 const computeResponsive = ({
   horizontal, /* multiplicative 1 (mobile, tablet, laptop) or .5 (2 column big monitor) */
-  vertical, /* multiplicative .5 (if splitting with another pane) or 1 (if full height of browser window)*/
+  vertical, /* multiplicative .5 (if splitting with another pane) or 1 (if full height of browser window) */
   browserDimensions, /* window.innerWidth & window.innerHeight as an object */
   sidebar, /* if open, subtract sidebar width from browser width? */
   minHeight, /* minimum height of element */
@@ -37,19 +37,18 @@ const computeResponsive = ({
   let width = null;
   let height = null;
 
-  const horizontalPadding = horizontal === 1 ? 45 : 75; /* could be more solid */
-  const headerFooterPadding = 300;
+  const horizontalPadding = horizontal === 1 ? 34 : 56; // derived from empirical testing, depends on Card margins
   const verticalPadding = 165;
-  const controlsPadding = 55;
+  const controlsPadding = 40; // derived from empirical testing, matches Sidebar padding
 
   if (browserDimensions) {
-    let controls = sidebar ? controlsWidth + controlsPadding : 0;
-    width = horizontal * (browserDimensions.width - controls - horizontalPadding);
+    const computedControlWidth = sidebar ? controlsWidth + controlsPadding : 0;
+    width = horizontal * (browserDimensions.width - computedControlWidth - horizontalPadding);
     height = browserDimensions.height * vertical - verticalPadding;
   }
 
-  if (maxAspectRatio && height > maxAspectRatio*width) {
-    height = maxAspectRatio*width;
+  if (maxAspectRatio && height > maxAspectRatio * width) {
+    height = maxAspectRatio * width;
   }
 
   // favor minHeight over maxAspectRatio
@@ -60,8 +59,8 @@ const computeResponsive = ({
   return {
     width,
     height
-  }
+  };
 
-}
+};
 
 export default computeResponsive;

--- a/src/util/computeResponsive.js
+++ b/src/util/computeResponsive.js
@@ -1,4 +1,4 @@
-import { controlsWidth } from "./globals";
+import { controlsWidth, controlsPadding } from "./globals";
 
 /*
   Why this function is here
@@ -39,7 +39,6 @@ const computeResponsive = ({
 
   const horizontalPadding = horizontal === 1 ? 34 : 56; // derived from empirical testing, depends on Card margins
   const verticalPadding = 165;
-  const controlsPadding = 40; // derived from empirical testing, matches Sidebar padding
 
   if (browserDimensions) {
     const computedControlWidth = sidebar ? controlsWidth + controlsPadding : 0;

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -17,6 +17,7 @@ export const controlsWidth = 280;
 export const controlsPadding = 40; // from Sidebar padding
 export const totalVerticalPadding = 160; // this includes the header + space between the bottom and the card (refactor.)
 export const controlsHiddenWidth = 1000;
+export const cardMinimumWidth = 300;
 export const entropyChartHeight = 300;
 export const twoColumnBreakpoint = 1600;
 export const maxMapWidth = 1000; /* just right for our default zoom level (which is also min) */

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -14,6 +14,7 @@ export const colorOptions = {
 export const width = 1126; /* no longer used */
 export const margin = 60;
 export const controlsWidth = 280;
+export const controlsPadding = 40; // from Sidebar padding
 export const totalVerticalPadding = 160; // this includes the header + space between the bottom and the card (refactor.)
 export const controlsHiddenWidth = 1000;
 export const entropyChartHeight = 300;


### PR DESCRIPTION
This PR addresses several smaller styles issues. Final look is very similar to what we have now:

<img width="1161" alt="final-look" src="https://user-images.githubusercontent.com/1176109/30068052-634dfd38-9211-11e7-82f0-18292d27c904.png">

1. It darkens the background very slightly and adds a more even drop shadow to cards. I definitely prefer this. 

*Before*:

<img width="719" alt="before-1" src="https://user-images.githubusercontent.com/1176109/30067156-de50fcfe-920e-11e7-993e-7c7f12f05057.png">

*After*:

<img width="747" alt="after-1" src="https://user-images.githubusercontent.com/1176109/30067163-e2c9bd70-920e-11e7-80b1-9e105ab6768c.png">

2. It fixes the persistent issue with cards being slightly too short on their right-hand sides. Gutters are now equal to left and right of cards and stay the same width after opening and closing sidebar. **Ideally, this needs to be tested on Windows and Linux, Max scrollbars are weird.**

3. The sidebar toggle is now properly affixed to top of screen, so that when sidebar is scrolled it stays put.

4. The sidebar toggle is now place _over_ the sidebar scrollbar. There had been a persistent issue where you couldn't click the toggle after scrolling.

5. The sidebar toggle now properly animates with the rest of the sidebar when opening and closing.

6. Sidebar behavior is improved in mobile so that cards slide left and right rather than compressing to a thin strip. It feels much better in practice.

----------------------------

Note that commit bf7d040d60ed8b2c1c7525204abac2e0c92422cf experiments with a fixed titlebar per issue #209, like so:

<img width="713" alt="fixed-titlebar" src="https://user-images.githubusercontent.com/1176109/30067799-b0cdd78c-9210-11e7-9b6d-6a0f19fd43e1.png">

I decided that I very much preferred the white background titlebar and just making the sidebar toggle fixed. But please speak up if you'd prefer the fixed titlebar. (I tried fixed titlebar and white and it really didn't work):

<img width="808" alt="white-background" src="https://user-images.githubusercontent.com/1176109/30067742-7ab86626-9210-11e7-8f74-b4b4c41b0f05.png">

----------------------------

Resolves #274 
