### PR TITLE
Remove deprecated React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "dependencies": {
     "binomial": "^0.2.0",
     "color": "^0.7.3",
+    "create-react-class": "^15.6.0",
     "d3-array": "^1.2.0",
     "d3-axis": "^1.0.6",
     "d3-brush": "^1.0.4",
@@ -112,7 +113,7 @@
     "react-addons-css-transition-group": "^15.6.0",
     "react-autosuggest": "^3.9.0",
     "react-dom": "^15.6.1",
-    "react-ga": "^2.1.2",
+    "react-ga": "^2.2.0",
     "react-redux": "^4.0.0",
     "react-router-dom": "^4.0.0",
     "react-select": "^1.0.0-rc.5",

--- a/src/components/controls/slider.js
+++ b/src/components/controls/slider.js
@@ -1,4 +1,5 @@
 import React from "react";
+import createReactClass from "create-react-class";
 import _assign from "lodash/assign";
 import _isArray from "lodash/isArray";
 
@@ -41,7 +42,7 @@ function undoEnsureArray(x) {
 
 // undoEnsureArray(ensureArray(x)) === x
 
-var Slider = React.createClass({
+var Slider = createReactClass({
 
   propTypes: {
 


### PR DESCRIPTION
This resolves #435. There were just two instances:

1. `Slider`, resolved via https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass

2. `react-ga`, resolved via npm upgrade.

With these in place I'm no longer getting the console warning. I don't think this needs much review. I'll plan to merge.