### PR TITLE
Move from React.propTypes to propTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "mousetrap": "^1.6.0",
     "outer-product": "0.0.4",
     "papaparse": "^4.3.5",
+    "prop-types": "^15.5.10",
     "query-string": "^4.2.3",
     "react": "15.6.1",
     "react-addons-css-transition-group": "^15.6.0",

--- a/src/components/COMPONENT_TEMPLATE.js
+++ b/src/components/COMPONENT_TEMPLATE.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 // import Flex from "./framework/flex";
 // import { connect } from "react-redux";
 // import { FOO } from "../actions";
@@ -16,18 +17,18 @@ class ComponentName extends React.Component {
   }
   static propTypes = {
     /* react */
-    // dispatch: React.PropTypes.func,
-    params: React.PropTypes.object,
-    routes: React.PropTypes.array,
+    // dispatch: PropTypes.func,
+    params: PropTypes.object,
+    routes: PropTypes.array,
     /* component api */
-    style: React.PropTypes.object,
-    // foo: React.PropTypes.string
+    style: PropTypes.object,
+    // foo: PropTypes.string
   }
   static defaultProps = {
     // foo: "bar"
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   getStyles() {
     return {
@@ -53,52 +54,52 @@ export default ComponentName;
 propTypes: {
     // You can declare that a prop is a specific JS primitive. By default, these
     // are all optional.
-    optionalArray: React.PropTypes.array,
-    optionalBool: React.PropTypes.bool,
-    optionalFunc: React.PropTypes.func,
-    optionalNumber: React.PropTypes.number,
-    optionalObject: React.PropTypes.object,
-    optionalString: React.PropTypes.string,
+    optionalArray: PropTypes.array,
+    optionalBool: PropTypes.bool,
+    optionalFunc: PropTypes.func,
+    optionalNumber: PropTypes.number,
+    optionalObject: PropTypes.object,
+    optionalString: PropTypes.string,
 
     // Anything that can be rendered: numbers, strings, elements or an array
     // (or fragment) containing these types.
-    optionalNode: React.PropTypes.node,
+    optionalNode: PropTypes.node,
 
     // A React element.
-    optionalElement: React.PropTypes.element,
+    optionalElement: PropTypes.element,
 
     // You can also declare that a prop is an instance of a class. This uses
     // JS's instanceof operator.
-    optionalMessage: React.PropTypes.instanceOf(Message),
+    optionalMessage: PropTypes.instanceOf(Message),
 
     // You can ensure that your prop is limited to specific values by treating
     // it as an enum.
-    optionalEnum: React.PropTypes.oneOf(['News', 'Photos']),
+    optionalEnum: PropTypes.oneOf(['News', 'Photos']),
 
     // An object that could be one of many types
-    optionalUnion: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.instanceOf(Message)
+    optionalUnion: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Message)
     ]),
 
     // An array of a certain type
-    optionalArrayOf: React.PropTypes.arrayOf(React.PropTypes.number),
+    optionalArrayOf: PropTypes.arrayOf(PropTypes.number),
 
     // An object with property values of a certain type
-    optionalObjectOf: React.PropTypes.objectOf(React.PropTypes.number),
+    optionalObjectOf: PropTypes.objectOf(PropTypes.number),
 
     // An object taking on a particular shape
-    optionalObjectWithShape: React.PropTypes.shape({
-      color: React.PropTypes.string,
-      fontSize: React.PropTypes.number
+    optionalObjectWithShape: PropTypes.shape({
+      color: PropTypes.string,
+      fontSize: PropTypes.number
     }),
 
     // You can chain any of the above with `isRequired` to make sure a warning
     // is shown if the prop isn't provided.
-    requiredFunc: React.PropTypes.func.isRequired,
+    requiredFunc: PropTypes.func.isRequired,
 
     // A value of any data type
-    requiredAny: React.PropTypes.any.isRequired,
+    requiredAny: PropTypes.any.isRequired,
 
 */

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Sidebar from "react-sidebar";
 import queryString from "query-string";
@@ -47,10 +48,10 @@ class App extends React.Component {
     analyticsNewPage();
   }
   static propTypes = {
-    dispatch: React.PropTypes.func.isRequired
+    dispatch: PropTypes.func.isRequired
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   componentWillMount() {
     this.props.dispatch(loadJSONs(this.context.router));

--- a/src/components/charts/entropy.js
+++ b/src/components/charts/entropy.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import _filter from "lodash/filter";
 import { genotypeColors } from "../../util/globals";
@@ -121,17 +122,17 @@ class Entropy extends React.Component {
     };
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   static propTypes = {
-    dispatch: React.PropTypes.func.isRequired,
-    entropy: React.PropTypes.object,
-    sidebar: React.PropTypes.bool.isRequired,
-    browserDimensions: React.PropTypes.object.isRequired,
-    loaded: React.PropTypes.bool.isRequired,
-    colorBy: React.PropTypes.string,
-    defaultColorBy: React.PropTypes.string,
-    mutType: React.PropTypes.string.isRequired
+    dispatch: PropTypes.func.isRequired,
+    entropy: PropTypes.object,
+    sidebar: PropTypes.bool.isRequired,
+    browserDimensions: PropTypes.object.isRequired,
+    loaded: PropTypes.bool.isRequired,
+    colorBy: PropTypes.string,
+    defaultColorBy: PropTypes.string,
+    mutType: PropTypes.string.isRequired
   }
 
   /* CALLBACKS */

--- a/src/components/charts/frequencies.js
+++ b/src/components/charts/frequencies.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { VictoryAxis } from "victory-chart";
 import Card from "../framework/card";
@@ -20,11 +21,10 @@ class Frequencies extends React.Component {
   }
   static propTypes = {
     /* react */
-    // dispatch: React.PropTypes.func,
-    params: React.PropTypes.object,
-    routes: React.PropTypes.array,
+    params: PropTypes.object,
+    routes: PropTypes.array,
     /* component api */
-    style: React.PropTypes.object,
+    style: PropTypes.object,
   }
   // static defaultProps = {
   //   genotype:["global", "HA1", "159F"]

--- a/src/components/controls/all-filter.js
+++ b/src/components/controls/all-filter.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import ChooseFilter from "./choose-filter";
 
@@ -15,7 +16,7 @@ const filterShortName = {
 @connect((state) => ({metadata: state.metadata}))
 class AllFilters extends React.Component {
   static propTypes = {
-    metadata: React.PropTypes.object.isRequired // should use shape here
+    metadata: PropTypes.object.isRequired // should use shape here
   }
   render() {
     const filters = [];

--- a/src/components/controls/analysis-date-slider.js
+++ b/src/components/controls/analysis-date-slider.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Slider from "./slider";
 import { controlsWidth } from "../../util/globals";
@@ -20,10 +21,10 @@ class AnalysisDateSlider extends React.Component {
     }
   }
   static propTypes = {
-    value: React.PropTypes.number.isRequired,
-    absoluteMinVal: React.PropTypes.number.isRequired,
-    absoluteMaxVal: React.PropTypes.number.isRequired,
-    dispatch: React.PropTypes.func.isRequired
+    value: PropTypes.number.isRequired,
+    absoluteMinVal: PropTypes.number.isRequired,
+    absoluteMaxVal: PropTypes.number.isRequired,
+    dispatch: PropTypes.func.isRequired
   }
   getStyles() {
     return {

--- a/src/components/controls/choose-filter.js
+++ b/src/components/controls/choose-filter.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { filterAbbrFwd } from "../../util/globals";
 import RecursiveFilter from "./recursive_filter";
 import SelectLabel from "../framework/select-label";
@@ -13,9 +14,9 @@ class ChooseFilter extends React.Component {
     super(props);
   }
   static propTypes = {
-    shortKey: React.PropTypes.string.isRequired,
-    filterType: React.PropTypes.string.isRequired,
-    filterOptions: React.PropTypes.object.isRequired
+    shortKey: PropTypes.string.isRequired,
+    filterType: PropTypes.string.isRequired,
+    filterOptions: PropTypes.object.isRequired
   }
 
   parseFilterQuery(query) {

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import * as icons from "../framework/svg-icons";
 import { materialButton, materialButtonSelected, medGrey } from "../../globalStyles";
@@ -13,11 +14,11 @@ import { analyticsControlsEvent } from "../../util/googleAnalytics";
 })
 class ChooseLayout extends React.Component {
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   static propTypes = {
-    layout: React.PropTypes.string.isRequired,
-    dispatch: React.PropTypes.func.isRequired
+    layout: PropTypes.string.isRequired,
+    dispatch: PropTypes.func.isRequired
   }
   getStyles() {
     return {

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { materialButton, materialButtonSelected } from "../../globalStyles";
 import Toggle from "./toggle";
@@ -19,9 +20,9 @@ import { toggleTemporalConfidence } from "../../actions/treeProperties";
  })
 class ChooseMetric extends React.Component {
   static propTypes = {
-    analysisSlider: React.PropTypes.any,
-    temporalConfidence: React.PropTypes.object.isRequired,
-    dispatch: React.PropTypes.func
+    analysisSlider: PropTypes.any,
+    temporalConfidence: PropTypes.object.isRequired,
+    dispatch: PropTypes.func
   }
   getStyles() {
     return {
@@ -39,7 +40,7 @@ class ChooseMetric extends React.Component {
     };
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   render() {

--- a/src/components/controls/choose-virus-select.js
+++ b/src/components/controls/choose-virus-select.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { select } from "../../globalStyles";
 import { loadJSONs } from "../../actions/loadData";
@@ -11,14 +12,14 @@ class ChooseVirusSelect extends React.Component {
     super(props);
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   static propTypes = {
-    dispatch: React.PropTypes.func.isRequired,
-    selected: React.PropTypes.string.isRequired,
-    choice_tree: React.PropTypes.array,
-    title: React.PropTypes.string.isRequired,
-    options: React.PropTypes.array.isRequired
+    dispatch: PropTypes.func.isRequired,
+    selected: PropTypes.string.isRequired,
+    choice_tree: PropTypes.array,
+    title: PropTypes.string.isRequired,
+    options: PropTypes.array.isRequired
   }
   getStyles() {
     return { base: {} };

--- a/src/components/controls/choose-virus.js
+++ b/src/components/controls/choose-virus.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { datasets } from "../../util/datasets";
 import ChooseVirusSelect from "./choose-virus-select";
@@ -28,7 +29,7 @@ class ChooseVirus extends React.Component {
   // static propTypes = {
   // }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   getStyles() {

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { defaultColorBy } from "../../util/globals";
 import { parseGenotype } from "../../util/getGenotype";
@@ -27,13 +28,13 @@ class ColorBy extends React.Component {
     };
   }
   static propTypes = {
-    colorBy: React.PropTypes.string.isRequired,
-    geneLength: React.PropTypes.object,
-    colorOptions: React.PropTypes.object.isRequired,
-    dispatch: React.PropTypes.func.isRequired
+    colorBy: PropTypes.string.isRequired,
+    geneLength: PropTypes.object,
+    colorOptions: PropTypes.object.isRequired,
+    dispatch: PropTypes.func.isRequired
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Flex from "../framework/flex";
 import SelectLabel from "../framework/select-label";
@@ -25,8 +26,8 @@ const header = (text) => (
 }))
 class Controls extends React.Component {
   static propTypes = {
-    analysisSlider: React.PropTypes.any,
-    dispatch: React.PropTypes.func
+    analysisSlider: PropTypes.any,
+    dispatch: PropTypes.func
   }
   getStyles() {
     return {};

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Slider from "./slider";
 import { controlsWidth } from "../../util/globals";
@@ -24,14 +25,14 @@ class DateRangeInputs extends React.Component {
     };
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   static propTypes = {
-    dateMin: React.PropTypes.string.isRequired,
-    dateMax: React.PropTypes.string.isRequired,
-    absoluteDateMin: React.PropTypes.string.isRequired,
-    absoluteDateMax: React.PropTypes.string.isRequired,
-    dispatch: React.PropTypes.func.isRequired
+    dateMin: PropTypes.string.isRequired,
+    dateMax: PropTypes.string.isRequired,
+    absoluteDateMin: PropTypes.string.isRequired,
+    absoluteDateMax: PropTypes.string.isRequired,
+    dispatch: PropTypes.func.isRequired
   }
   getStyles() {
     return {

--- a/src/components/controls/downloadModal.js
+++ b/src/components/controls/downloadModal.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { DISMISS_DOWNLOAD_MODAL } from "../../actions/types";
 import { materialButton, medGrey, infoPanelStyles } from "../../globalStyles";
@@ -64,11 +65,11 @@ class DownloadModal extends React.Component {
     };
   }
   static propTypes = {
-    show: React.PropTypes.bool.isRequired,
-    dispatch: React.PropTypes.func.isRequired,
-    metadata: React.PropTypes.object.isRequired,
-    datasetPathName: React.PropTypes.string,
-    browserDimensions: React.PropTypes.object.isRequired
+    show: PropTypes.bool.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    metadata: PropTypes.object.isRequired,
+    datasetPathName: PropTypes.string,
+    browserDimensions: PropTypes.object.isRequired
   }
 
   relevantPublications() {

--- a/src/components/controls/geo-resolution.js
+++ b/src/components/controls/geo-resolution.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import _keys from "lodash/keys";
 import { select } from "../../globalStyles";
@@ -19,7 +20,7 @@ import { analyticsControlsEvent } from "../../util/googleAnalytics";
 })
 class GeoResolution extends React.Component {
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   getStyles() {
     return {

--- a/src/components/controls/map-animation.js
+++ b/src/components/controls/map-animation.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import SelectLabel from "../framework/select-label";
 import { CHANGE_ANIMATION_TIME, CHANGE_ANIMATION_CUMULATIVE } from "../../actions/types";
@@ -17,7 +18,7 @@ import { materialButton, materialButtonSelected } from "../../globalStyles";
 class MapAnimationControls extends React.Component {
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
 
   // checkAndTransformAnimationDuration(input) {

--- a/src/components/controls/recursive_filter.js
+++ b/src/components/controls/recursive_filter.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Select from "react-select";
 import { controlsWidth } from "../../util/globals";
@@ -18,17 +19,17 @@ class RecursiveFilter extends React.Component {
     super(props);
   }
   static propTypes = {
-    filterTree: React.PropTypes.array.isRequired,
-    filterType: React.PropTypes.string.isRequired,
-    shortKey: React.PropTypes.string.isRequired,
-    counts: React.PropTypes.array.isRequired,
-    fields: React.PropTypes.array.isRequired,
-    options: React.PropTypes.array.isRequired,
-    dispatch: React.PropTypes.func.isRequired,
-    selections: React.PropTypes.object.isRequired
+    filterTree: PropTypes.array.isRequired,
+    filterType: PropTypes.string.isRequired,
+    shortKey: PropTypes.string.isRequired,
+    counts: PropTypes.array.isRequired,
+    fields: PropTypes.array.isRequired,
+    options: PropTypes.array.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    selections: PropTypes.object.isRequired
   }
   // static contextTypes = {
-  //   router: React.PropTypes.object.isRequired
+  //   router: PropTypes.object.isRequired
   // }
 
   setFilterQuery(e) {

--- a/src/components/controls/search.js
+++ b/src/components/controls/search.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import Autosuggest from 'react-autosuggest';
 
@@ -19,13 +20,13 @@ class SearchStrains extends React.Component {
   }
   static propTypes = {
     /* react */
-    dispatch: React.PropTypes.func,
-    params: React.PropTypes.object,
-    routes: React.PropTypes.array,
+    dispatch: PropTypes.func,
+    params: PropTypes.object,
+    routes: PropTypes.array,
     /* component api */
-    style: React.PropTypes.object,
-    tips: React.PropTypes.array
-    // foo: React.PropTypes.string
+    style: PropTypes.object,
+    tips: PropTypes.array
+    // foo: PropTypes.string
   }
   static defaultProps = {
     // foo: "bar"

--- a/src/components/controls/slider.js
+++ b/src/components/controls/slider.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import _assign from "lodash/assign";
 import _isArray from "lodash/isArray";
 
@@ -48,25 +49,25 @@ var Slider = React.createClass({
     /**
      * The minimum value of the slider.
      */
-    min: React.PropTypes.number,
+    min: PropTypes.number,
 
     /**
      * The maximum value of the slider.
      */
-    max: React.PropTypes.number,
+    max: PropTypes.number,
 
     /**
      * Value to be added or subtracted on each step the slider makes.
      * Must be greater than zero.
      * `max - min` should be evenly divisible by the step value.
      */
-    step: React.PropTypes.number,
+    step: PropTypes.number,
 
     /**
      * The minimal distance between any pair of handles.
      * Must be positive, but zero means they can sit on top of each other.
      */
-    minDistance: React.PropTypes.number,
+    minDistance: PropTypes.number,
 
     /**
      * Determines the initial positions of the handles and the number of handles if the component has no children.
@@ -76,28 +77,28 @@ var Slider = React.createClass({
      * The values in the array must be sorted.
      * If the component has children, the length of the array must match the number of children.
      */
-    defaultValue: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.arrayOf(React.PropTypes.number)
+    defaultValue: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.arrayOf(PropTypes.number)
     ]),
 
     /**
      * Like `defaultValue` but for [controlled components](http://facebook.github.io/react/docs/forms.html#controlled-components).
      */
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.arrayOf(React.PropTypes.number)
+    value: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.arrayOf(PropTypes.number)
     ]),
 
     /**
      * Determines whether the slider moves horizontally (from left to right) or vertically (from top to bottom).
      */
-    orientation: React.PropTypes.oneOf(['horizontal', 'vertical']),
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 
     /**
      * The css class set on the slider node.
      */
-    className: React.PropTypes.string,
+    className: PropTypes.string,
 
     /**
      * The css class set on each handle node.
@@ -105,66 +106,66 @@ var Slider = React.createClass({
      * In addition each handle will receive a numbered css class of the form `${handleClassName}-${i}`,
      * e.g. `handle-0`, `handle-1`, ...
      */
-    handleClassName: React.PropTypes.string,
+    handleClassName: PropTypes.string,
 
     /**
      * The css class set on the handle that is currently being moved.
      */
-    handleActiveClassName: React.PropTypes.string,
+    handleActiveClassName: PropTypes.string,
 
     /**
      * If `true` bars between the handles will be rendered.
      */
-    withBars: React.PropTypes.bool,
+    withBars: PropTypes.bool,
 
     /**
      * The css class set on the bars between the handles.
      * In addition bar fragment will receive a numbered css class of the form `${barClassName}-${i}`,
      * e.g. `bar-0`, `bar-1`, ...
      */
-    barClassName: React.PropTypes.string,
+    barClassName: PropTypes.string,
 
     /**
      * If `true` the active handle will push other handles
      * within the constraints of `min`, `max`, `step` and `minDistance`.
      */
-    pearling: React.PropTypes.bool,
+    pearling: PropTypes.bool,
 
     /**
      * If `true` the handles can't be moved.
      */
-    disabled: React.PropTypes.bool,
+    disabled: PropTypes.bool,
 
     /**
      * Disables handle move when clicking the slider bar
      */
-    snapDragDisabled: React.PropTypes.bool,
+    snapDragDisabled: PropTypes.bool,
 
     /**
      * Inverts the slider.
      */
-    invert: React.PropTypes.bool,
+    invert: PropTypes.bool,
 
     /**
      * Callback called before starting to move a handle.
      */
-    onBeforeChange: React.PropTypes.func,
+    onBeforeChange: PropTypes.func,
 
     /**
      * Callback called on every value change.
      */
-    onChange: React.PropTypes.func,
+    onChange: PropTypes.func,
 
     /**
      * Callback called only after moving a handle has ended.
      */
-    onAfterChange: React.PropTypes.func,
+    onAfterChange: PropTypes.func,
 
     /**
      *  Callback called when the the slider is clicked (handle or bars).
      *  Receives the value at the clicked position as argument.
      */
-    onSliderClick: React.PropTypes.func
+    onSliderClick: PropTypes.func
   },
 
   getDefaultProps: function () {

--- a/src/components/framework/browserDimensionMonitor.js
+++ b/src/components/framework/browserDimensionMonitor.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import _throttle from "lodash/throttle";
 import { BROWSER_DIMENSIONS } from "../../actions/types";
@@ -9,7 +10,7 @@ class BrowserDimensionMonitor extends React.Component {
     super(props);
   }
   static propTypes = {
-    dispatch: React.PropTypes.func.isRequired
+    dispatch: PropTypes.func.isRequired
   }
 
   componentDidMount() {

--- a/src/components/framework/choose-layout-button.js
+++ b/src/components/framework/choose-layout-button.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 class ChooseLayoutButton extends React.Component {
   constructor(props) {
@@ -9,12 +10,12 @@ class ChooseLayoutButton extends React.Component {
   }
   static propTypes = {
     /* react */
-    // dispatch: React.PropTypes.func,
-    params: React.PropTypes.object,
-    routes: React.PropTypes.array,
+    // dispatch: PropTypes.func,
+    params: PropTypes.object,
+    routes: PropTypes.array,
     /* component api */
-    style: React.PropTypes.object,
-    // foo: React.PropTypes.string
+    style: PropTypes.object,
+    // foo: PropTypes.string
   }
   static defaultProps = {
     // foo: "bar"

--- a/src/components/framework/flex.js
+++ b/src/components/framework/flex.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 /**
 
@@ -13,31 +14,31 @@ import React from "react";
 
 class Flex extends React.Component {
   static propTypes = {
-    direction: React.PropTypes.oneOf([
+    direction: PropTypes.oneOf([
       "row", "rowReverse", "column", "columnReverse"
     ]),
-    wrap: React.PropTypes.oneOf([
+    wrap: PropTypes.oneOf([
       "nowrap", "wrap", "wrap-reverse"
     ]),
-    justifyContent: React.PropTypes.oneOf([
+    justifyContent: PropTypes.oneOf([
       "flex-start", "flex-end", "center", "space-between", "space-around"
     ]),
-    alignItems: React.PropTypes.oneOf([
+    alignItems: PropTypes.oneOf([
       "flex-start", "flex-end", "center", "baseline", "stretch"
     ]),
-    alignContent: React.PropTypes.oneOf([
+    alignContent: PropTypes.oneOf([
       "flex-start", "flex-end", "center", "space-between", "space-around", "stretch"
     ]),
-    grow: React.PropTypes.number,
-    shrink: React.PropTypes.number,
-    basis: React.PropTypes.string,
-    order: React.PropTypes.number,
-    alignSelf: React.PropTypes.oneOf([
+    grow: PropTypes.number,
+    shrink: PropTypes.number,
+    basis: PropTypes.string,
+    order: PropTypes.number,
+    alignSelf: PropTypes.oneOf([
       "auto", "flex-start", "flex-end", "center", "baseline", "stretch"
     ]),
-    styleOverrides: React.PropTypes.object,
-    children: React.PropTypes.node,
-    clickHandler: React.PropTypes.func,
+    styleOverrides: PropTypes.object,
+    children: PropTypes.node,
+    clickHandler: PropTypes.func,
   }
   static defaultProps = {
     direction: "row",

--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { dataFont, medGrey, materialButton } from "../../globalStyles";
 import { prettyString } from "../../util/stringHelpers";
@@ -146,7 +147,7 @@ class Footer extends React.Component {
     };
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   shouldComponentUpdate(nextProps) {
     if (

--- a/src/components/framework/generic-button.js
+++ b/src/components/framework/generic-button.js
@@ -1,9 +1,10 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import Color from "color";
 
 class Button extends React.Component {
   static propTypes = {
-    style: React.PropTypes.object
+    style: PropTypes.object
   }
   static defaultProps = {
     style: {
@@ -62,8 +63,8 @@ class Button extends React.Component {
 }
 
 Button.propTypes = {
-  color: React.PropTypes.string,
-  onClick: React.PropTypes.func
+  color: PropTypes.string,
+  onClick: PropTypes.func
 };
 
 module.exports = Button;

--- a/src/components/framework/mono-font.js
+++ b/src/components/framework/mono-font.js
@@ -1,12 +1,13 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 class MonoFont extends React.Component {
 
   static propTypes = {
     /* react */
 
-    style: React.PropTypes.object,
-    size: React.PropTypes.string
+    style: PropTypes.object,
+    size: PropTypes.string
   }
   static defaultProps = {
     size: "small"

--- a/src/components/framework/move-icon.js
+++ b/src/components/framework/move-icon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 const MoveIcon = ({
   x,
@@ -32,11 +33,11 @@ const MoveIcon = ({
 };
 
 MoveIcon.propTypes = {
-  scale: React.PropTypes.number,
-  IconTranslateX: React.PropTypes.number,
-  IconTranslateY: React.PropTypes.number,
-  rectWidth: React.PropTypes.number,
-  rectHeight: React.PropTypes.number
+  scale: PropTypes.number,
+  IconTranslateX: PropTypes.number,
+  IconTranslateY: PropTypes.number,
+  rectWidth: PropTypes.number,
+  rectHeight: PropTypes.number
 };
 
 MoveIcon.defaultProps = {

--- a/src/components/framework/title-bar.js
+++ b/src/components/framework/title-bar.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import Flex from "./flex";
@@ -17,10 +18,10 @@ class TitleBar extends React.Component {
     super(props);
   }
   static propTypes = {
-    datasetPathName: React.PropTypes.string
+    datasetPathName: PropTypes.string
   }
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   getStyles() {
     return {

--- a/src/components/framework/zoom-in-icon.js
+++ b/src/components/framework/zoom-in-icon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 const ZoomInIcon = ({
   x,
@@ -33,11 +34,11 @@ const ZoomInIcon = ({
 }
 
 ZoomInIcon.propTypes = {
-  scale: React.PropTypes.number,
-  IconTranslateX: React.PropTypes.number,
-  IconTranslateY: React.PropTypes.number,
-  rectWidth: React.PropTypes.number,
-  rectHeight: React.PropTypes.number
+  scale: PropTypes.number,
+  IconTranslateX: PropTypes.number,
+  IconTranslateY: PropTypes.number,
+  rectWidth: PropTypes.number,
+  rectHeight: PropTypes.number
 }
 ZoomInIcon.defaultProps = {
   scale: .04,

--- a/src/components/framework/zoom-out-icon.js
+++ b/src/components/framework/zoom-out-icon.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 const ZoomOutIcon = ({
   x,
@@ -32,11 +33,11 @@ const ZoomOutIcon = ({
 }
 
 ZoomOutIcon.propTypes = {
-  scale: React.PropTypes.number,
-  IconTranslateX: React.PropTypes.number,
-  IconTranslateY: React.PropTypes.number,
-  rectWidth: React.PropTypes.number,
-  rectHeight: React.PropTypes.number
+  scale: PropTypes.number,
+  IconTranslateX: PropTypes.number,
+  IconTranslateY: PropTypes.number,
+  rectWidth: PropTypes.number,
+  rectHeight: PropTypes.number
 }
 ZoomOutIcon.defaultProps = {
   scale: .04,

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import _min from "lodash/min";
 import _max from "lodash/max";
@@ -52,12 +53,12 @@ import { incommingMapPNG } from "../../util/downloadDataFunctions";
 class Map extends React.Component {
 
   static contextTypes = {
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
   }
   static propTypes = {
-    treeVersion: React.PropTypes.number.isRequired,
-    treeLoaded: React.PropTypes.bool.isRequired,
-    colorScaleVersion: React.PropTypes.number.isRequired
+    treeVersion: PropTypes.number.isRequired,
+    treeLoaded: PropTypes.bool.isRequired,
+    colorScaleVersion: PropTypes.number.isRequired
   }
   constructor(props) {
     super(props);

--- a/src/components/notifications/notifications.js
+++ b/src/components/notifications/notifications.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 import { REMOVE_NOTIFICATION } from "../../actions/types";
@@ -49,9 +50,9 @@ class Notifications extends React.Component {
     super(props);
   }
   static propTypes = {
-    stack: React.PropTypes.array.isRequired,
-    dispatch: React.PropTypes.func.isRequired,
-    pageWidth: React.PropTypes.number.isRequired
+    stack: PropTypes.array.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    pageWidth: PropTypes.number.isRequired
   }
   closeIcon(d) {
     return(

--- a/src/components/tree/legend.js
+++ b/src/components/tree/legend.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { rgb } from "d3-color";
 import LegendItem from "./legend-item";
@@ -26,13 +27,13 @@ class Legend extends React.Component {
     };
   }
   static propTypes = {
-    colorOptions: React.PropTypes.object,
-    colorScale: React.PropTypes.object,
-    params: React.PropTypes.object,
-    routes: React.PropTypes.array,
-    colorBy: React.PropTypes.string.isRequired,
-    style: React.PropTypes.object,
-    sidebar: React.PropTypes.bool
+    colorOptions: PropTypes.object,
+    colorScale: PropTypes.object,
+    params: PropTypes.object,
+    routes: PropTypes.array,
+    colorBy: PropTypes.string.isRequired,
+    style: PropTypes.object,
+    sidebar: PropTypes.bool
   }
   // hide/show legend based on initial browserDimensions and legend length
   componentWillMount() {

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { select } from "d3-selection";
 import { ReactSVGPanZoom } from "react-svg-pan-zoom";
@@ -53,8 +54,8 @@ class TreeView extends React.Component {
     };
   }
   static propTypes = {
-    sidebar: React.PropTypes.bool.isRequired,
-    mutType: React.PropTypes.string.isRequired
+    sidebar: PropTypes.bool.isRequired,
+    mutType: PropTypes.string.isRequired
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
This PR mostly addresses issue #436. This moves all our `React.propTypes` calls to just `propTypes` in anticipation of React v16. However, the console warning remains. This is due to `redbox-react` still using `React.propTypes`. I ran into a lot of difficulty trying to upgrade `redbox-react` due to interaction with `react-transform-catch-errors`. I think the real solution is to upgrade from:

```
"react-transform-catch-errors": "^1.0.0"
"react-transform-hmr": "^1.0.1"
"redbox-react": "1.1.1"
```

to `react-hot-loader` (https://github.com/gaearon/react-hot-loader). This has taken over from these earlier modules and looks very slick. However, this will require some modification to our webpack build and to the `Root` component that I think is best left for a separate PR.

There isn't much to review here. I'll plan to merge unless I hear otherwise.