### PR TITLE
"descendAnts" in infopanel

### DIFF
--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -147,7 +147,7 @@ const getBranchDescendents = (n) => {
   if (n.fullTipCount === 1) {
     return <g>{infoLineJSX("Branch leading to", n.strain)}<p/></g>;
   }
-  return <g>{infoLineJSX("Number of descendents:", n.fullTipCount)}<p/></g>;
+  return <g>{infoLineJSX("Number of descendants:", n.fullTipCount)}<p/></g>;
 };
 
 /**


### PR DESCRIPTION
Although both are legal, I believe this is the preferred spelling. http://grammarist.com/usage/descendant-descendent/