### PR TITLE
panels defined by meta.json

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -4,6 +4,7 @@ import { updateColors } from "./colors";
 import { updateVisibleTipsAndBranchThicknesses } from "./treeProperties";
 import { turnURLtoDataPath } from "../util/urlHelpers";
 import { charonAPIAddress } from "../util/globals";
+import { errorNotification } from "./notifications";
 
 // /* if the metadata specifies an analysis slider, this is where we process it */
 // const addAnalysisSlider = (dispatch, tree, controls) => {
@@ -141,6 +142,11 @@ export const loadJSONs = (router) => { // eslint-disable-line import/prefer-defa
         any error from the reducers AND, confusingly,
         errors from the lifecycle methods of components
         that run while in the middle of this thunk */
+        dispatch(errorNotification({
+          message: "Couldn't load data JSONs",
+          details: router.history.location.pathname.replace(/^\//, '') + " doesn't exist."
+        }));
+        router.history.push({pathname: '/', search: ''});
         console.error("loadMetaAndTreeJSONs error:", err);
         // dispatch error notification
         // but, it would seem, you can't have the reducer return AND

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -19,6 +19,8 @@ import DownloadModal from "./download/downloadModal";
 import { analyticsNewPage } from "../util/googleAnalytics";
 import filesDropped from "../actions/filesDropped";
 
+const nextstrainLogo = require("../images/nextstrain-logo-small.png");
+
 /* BRIEF REMINDER OF PROPS AVAILABLE TO APP:
   React-Router v4 injects length, action, location, push etc into props,
     but perhaps it's more consistent if we access these through
@@ -30,6 +32,9 @@ import filesDropped from "../actions/filesDropped";
 @connect((state) => ({
   datasetPathName: state.controls.datasetPathName,
   readyToLoad: state.datasets.ready,
+  metadata: state.metadata,
+  treeLoaded: state.tree.loaded,
+  browserDimensions: state.browserDimensions.browserDimensions
 }))
 class App extends React.Component {
   constructor(props) {
@@ -81,6 +86,7 @@ class App extends React.Component {
       this.props.dispatch(loadJSONs(this.context.router));
     }
   }
+
   render() {
     return (
       <g>
@@ -101,22 +107,34 @@ class App extends React.Component {
           onSetOpen={(a) => {this.setState({sidebarOpen: a});}}
           sidebarClassName={"sidebar"}
         >
-          <Background>
-            <TreeView
-              query={queryString.parse(this.context.router.history.location.search)}
-              sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
-            />
-            <Map
-              sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
-              justGotNewDatasetRenderNewMap={false}
-            />
-            <Entropy
-              sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
-            />
-            <Footer
-              sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
-            />
-          </Background>
+          {
+            (!this.props.treeLoaded || !this.props.metadata.metadata) ? (
+              <img className={"spinner"} src={nextstrainLogo} alt="loading" style={{marginTop: `${this.props.browserDimensions.height / 2 - 100}px`}}/>
+            ) : (
+              <Background>
+                {this.props.metadata.metadata.panels.indexOf("tree") === -1 ? null : (
+                  <TreeView
+                    query={queryString.parse(this.context.router.history.location.search)}
+                    sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
+                  />
+                )}
+                {this.props.metadata.metadata.panels.indexOf("map") === -1 ? null : (
+                  <Map
+                    sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
+                    justGotNewDatasetRenderNewMap={false}
+                  />
+                )}
+                {this.props.metadata.metadata.panels.indexOf("entropy") === -1 ? null : (
+                  <Entropy
+                    sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
+                  />
+                )}
+                <Footer
+                  sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
+                />
+              </Background>
+            )
+          }
         </Sidebar>
       </g>
     );

--- a/src/components/charts/entropy.js
+++ b/src/components/charts/entropy.js
@@ -183,26 +183,32 @@ class Entropy extends React.Component {
       </div>
     );
   }
+  setUp(props) {
+    const chart = new EntropyChart(
+      this.d3entropy,
+      calcEntropy(props.entropy),
+      { /* callbacks */
+        onHover: this.onHover.bind(this),
+        onLeave: this.onLeave.bind(this),
+        onClick: this.onClick.bind(this)
+      }
+    );
+    chart.render(this.getChartGeom(props), props.mutType);
+    this.setState({
+      chart,
+      chartGeom: this.getChartGeom(props)
+    });
+    chart.update({aa: props.mutType === "aa"}); // why is this necessary straight after an initial render?!
+  }
+  componentDidMount() {
+    this.setUp(this.props);
+  }
   componentWillReceiveProps(nextProps) {
     if (!nextProps.loaded) {
       this.setState({chart: false});
     }
     if (!this.state.chart && nextProps.loaded) {
-      const chart = new EntropyChart(
-        this.d3entropy,
-        calcEntropy(nextProps.entropy),
-        { /* callbacks */
-          onHover: this.onHover.bind(this),
-          onLeave: this.onLeave.bind(this),
-          onClick: this.onClick.bind(this)
-        }
-      );
-      chart.render(this.getChartGeom(nextProps), nextProps.mutType);
-      this.setState({
-        chart,
-        chartGeom: this.getChartGeom(nextProps)
-      });
-      chart.update({aa: nextProps.mutType === "aa"}); // why is this necessary straight after an initial render?!
+      this.setUp(nextProps);
       return;
     }
     if (this.state.chart) {

--- a/src/components/charts/entropy.js
+++ b/src/components/charts/entropy.js
@@ -201,7 +201,9 @@ class Entropy extends React.Component {
     chart.update({aa: props.mutType === "aa"}); // why is this necessary straight after an initial render?!
   }
   componentDidMount() {
-    this.setUp(this.props);
+    if (this.props.loaded) {
+      this.setUp(this.props);
+    }
   }
   componentWillReceiveProps(nextProps) {
     if (!nextProps.loaded) {

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -98,8 +98,12 @@ class Map extends React.Component {
       };
     }
   }
-  // componentDidMount() {
-  // }
+  componentDidMount() {
+    this.maybeComputeResponsive(this.props);
+    this.maybeRemoveAllDemesAndTransmissions(this.props); /* geographic resolution just changed (ie., country to division), remove everything. this change is upstream of maybeDraw */
+    this.maybeUpdateDemesAndTransmissions(this.props); /* every time we change something like colorBy */
+    this.maybeInvalidateMapSize(this.props);
+  }
   componentWillReceiveProps(nextProps) {
     this.maybeComputeResponsive(nextProps);
     this.maybeRemoveAllDemesAndTransmissions(nextProps); /* geographic resolution just changed (ie., country to division), remove everything. this change is upstream of maybeDraw */

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -91,6 +91,15 @@ class TreeView extends React.Component {
     return null;
   }
 
+  componentDidMount() {
+    const tree = this.makeTree(this.props);
+    funcs.updateStylesAndAttrs({colorBy: true}, this.props, tree);
+    this.setState({tree});
+    if (this.Viewer) {
+      this.Viewer.fitToViewer();
+    }
+  }
+
   componentDidUpdate(prevProps) {
     /* if the  SVG has changed size, call zoomIntoClade so that the tree rescales to fit the SVG */
     if (

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -150,6 +150,11 @@ const Controls = (state = getDefaultState(), action) => {
         base.temporalConfidence.display = false;
       }
 
+      /* if only map or only tree, then panelLayout must be full */
+      if (action.meta.panels.indexOf("map") === -1 || action.meta.panels.indexOf("tree") === -1) {
+        base["panelLayout"] = "full";
+      }
+
       /* we now check that the set values (meta.json defaults, hardcoded defaults, URL queries) are "valid" */
       /* colorBy */
       const colorByValid = Object.keys(action.meta.color_options).indexOf(base["colorBy"]) !== -1;

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -50,6 +50,10 @@ const Tree = (state = getDefaultState(), action) => {
         loaded: true,
         version: state.version + 1
       });
+    case types.DATA_INVALID:
+      return Object.assign({}, state, {
+        loaded: false,
+      });
     case types.CHANGE_DATES_VISIBILITY_THICKNESS: /* fall-through */
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS:
       return Object.assign({}, state, {

--- a/src/util/parseParams.js
+++ b/src/util/parseParams.js
@@ -37,7 +37,7 @@ const parseParams = (path, datasets) => {
       // elemType will be "pathogen", "lineage" or "segment"
       if (typeof datasetSlice[elemType][elem] === "undefined") {
         // the elem (the param requested) is NOT available in the dataset. BAIL.
-        console.log(elem, " not found at level of ", elemType);
+        console.warn("in manifest, ", elem, " not found at level of ", elemType);
         config.valid = false;
         return config;
       }

--- a/src/util/urlHelpers.js
+++ b/src/util/urlHelpers.js
@@ -69,7 +69,7 @@ export const turnURLtoDataPath = (router, datasets) => {
   if (parsedParams.valid) {
     return makeDataPathFromParsedParams(parsedParams);
   }
-  return undefined;
+  return router.history.location.pathname.replace(/^\//, '').replace(/\/$/, '').replace('/', '_');
 };
 
 export const determineColorByGenotypeType = (colorBy) => {


### PR DESCRIPTION
## This PR
* adds a spinner which replaces the (empty) map & tree until they load
* only loads components specified in `meta.json` (all builds currently specify entropy, map & tree)
* closes #356 

Tested on all live data on the dev server. No problems.

cc @sidneymbell this will affect the timeline. 