### PR TITLE
metadata reducer flattened

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -115,26 +115,26 @@ class App extends React.Component {
           }}
         >
           {
-            (!this.props.treeLoaded || !this.props.metadata.metadata) ? (
+            (!this.props.treeLoaded || !this.props.metadata.loaded) ? (
               <img className={"spinner"} src={nextstrainLogo} alt="loading" style={{marginTop: `${this.props.browserDimensions.height / 2 - 100}px`}}/>
             ) : (
               <Background>
                 <Info
                   sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
                 />
-                {this.props.metadata.metadata.panels.indexOf("tree") === -1 ? null : (
+                {this.props.metadata.panels.indexOf("tree") === -1 ? null : (
                   <TreeView
                     query={queryString.parse(this.context.router.history.location.search)}
                     sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
                   />
                 )}
-                {this.props.metadata.metadata.panels.indexOf("map") === -1 ? null : (
+                {this.props.metadata.panels.indexOf("map") === -1 ? null : (
                   <Map
                     sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
                     justGotNewDatasetRenderNewMap={false}
                   />
                 )}
-                {this.props.metadata.metadata.panels.indexOf("entropy") === -1 ? null : (
+                {this.props.metadata.panels.indexOf("entropy") === -1 ? null : (
                   <Entropy
                     sidebar={this.state.sidebarOpen || this.state.sidebarDocked}
                   />

--- a/src/components/controls/geo-resolution.js
+++ b/src/components/controls/geo-resolution.js
@@ -9,7 +9,7 @@ import { analyticsControlsEvent } from "../../util/googleAnalytics";
 
 @connect((state) => {
   return {
-    metadata: state.metadata.metadata,
+    metadata: state.metadata,
     geoResolution: state.controls.geoResolution
   };
 })
@@ -31,7 +31,7 @@ class GeoResolution extends React.Component {
 
   getGeoResolutionOptions() {
     let options = [];
-    if (this.props.metadata) {
+    if (this.props.metadata.loaded) {
       options = Object.keys(this.props.metadata.geo).map((key) => {
         return {
           value: key,

--- a/src/components/controls/map-animation.js
+++ b/src/components/controls/map-animation.js
@@ -9,7 +9,7 @@ import { materialButton, materialButtonSelected } from "../../globalStyles";
 
 @connect((state) => {
   return {
-    metadata: state.metadata.metadata,
+    // metadata: state.metadata,
     mapAnimationStartDate: state.controls.mapAnimationStartDate,
     mapAnimationDurationInMilliseconds: state.controls.mapAnimationDurationInMilliseconds,
     mapAnimationCumulative: state.controls.mapAnimationCumulative

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -79,7 +79,7 @@ class DownloadModal extends React.Component {
       ["Tree (newick)", (<icons.RectangularTree width={iconWidth} stroke={iconStroke} />), () => helpers.newick(this.props.dispatch, dataset, this.props.tree.nodes[0], false)],
       ["TimeTree (newick)", (<icons.RectangularTree width={iconWidth} stroke={iconStroke} />), () => helpers.newick(this.props.dispatch, dataset, this.props.tree.nodes[0], true)],
       ["Strain Metadata (CSV)", (<icons.Meta width={iconWidth} stroke={iconStroke} />), () => helpers.strainCSV(this.props.dispatch, dataset, this.props.tree.nodes, this.props.tree.attrs)],
-      ["Author Metadata (CSV)", (<icons.Meta width={iconWidth} stroke={iconStroke} />), () => helpers.authorCSV(this.props.dispatch, dataset, this.props.metadata.metadata)],
+      ["Author Metadata (CSV)", (<icons.Meta width={iconWidth} stroke={iconStroke} />), () => helpers.authorCSV(this.props.dispatch, dataset, this.props.metadata)],
       ["Screenshot (SGV)", (<icons.PanelsGrid width={iconWidth} stroke={iconStroke} />), () => helpers.SVG(this.props.dispatch, dataset)]
     ];
     return (
@@ -103,7 +103,7 @@ class DownloadModal extends React.Component {
       return null;
     }
     const styles = this.getStyles(this.props.browserDimensions.width, this.props.browserDimensions.height);
-    const meta = this.props.metadata.metadata;
+    const meta = this.props.metadata;
     return (
       <div style={styles.behind} onClick={this.dismissModal.bind(this)}>
         <div className="static container" style={styles.modal} onClick={(e) => stopProp(e)}>

--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -83,7 +83,7 @@ const removeFiltersButton = (dispatch, filterNames, outerClassName, label) => {
 @connect((state) => {
   return {
     tree: state.tree,
-    metadata: state.metadata.metadata,
+    metadata: state.metadata,
     colorOptions: state.metadata.colorOptions,
     browserDimensions: state.browserDimensions.browserDimensions,
     activeFilters: state.controls.filters
@@ -214,10 +214,8 @@ class Footer extends React.Component {
 
   getUpdated() {
     let updated = null;
-    if (this.props.metadata) {
-      if (this.props.metadata.updated) {
-        updated = this.props.metadata.updated;
-      }
+    if (this.props.metadata.updated) {
+      updated = this.props.metadata.updated;
     }
     if (!updated) return null;
     return (

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -26,7 +26,7 @@ const resetTreeButton = (dispatch) => {
     browserDimensions: state.browserDimensions.browserDimensions,
     filters: state.controls.filters,
     mapAnimationPlayPauseButton: state.controls.mapAnimationPlayPauseButton,
-    metadata: state.metadata.metadata,
+    metadata: state.metadata,
     nodes: state.tree.nodes,
     idxOfInViewRootNode: state.tree.idxOfInViewRootNode,
     visibility: state.tree.visibility

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -35,7 +35,7 @@ import { incommingMapPNG } from "../download/helperFunctions";
     nodeColors: state.tree.nodeColors,
     visibility: state.tree.visibility,
     visibilityVersion: state.tree.visibilityVersion,
-    metadata: state.metadata.metadata,
+    metadata: state.metadata,
     browserDimensions: state.browserDimensions.browserDimensions,
     colorScaleVersion: state.controls.colorScale.version,
     map: state.map,
@@ -133,7 +133,7 @@ class Map extends React.Component {
   }
   maybeCreateLeafletMap() {
     /* first time map, this sets up leaflet */
-    if (this.props.metadata && !this.state.map && document.getElementById("map")) {
+    if (this.props.metadata.loaded && !this.state.map && document.getElementById("map")) {
       this.createMap();
     }
   }
@@ -182,7 +182,7 @@ class Map extends React.Component {
 
   maybeDrawDemesAndTransmissions() {
     const mapIsDrawn = !!this.state.map;
-    const allDataPresent = !!(this.props.metadata && this.props.treeLoaded && this.state.responsive && this.state.d3DOMNode);
+    const allDataPresent = !!(this.props.metadata.loaded && this.props.treeLoaded && this.state.responsive && this.state.d3DOMNode);
     const demesTransmissionsNotComputed = !this.state.demeData && !this.state.transmissionData;
     /* if at any point we change dataset and app doesn't remount, we'll need these again */
     // const newColorScale = this.props.colorScale.version !== prevProps.colorScale.version;

--- a/src/old_code/all-filter.js
+++ b/src/old_code/all-filter.js
@@ -20,13 +20,13 @@ class AllFilters extends React.Component {
   }
   render() {
     const filters = [];
-    if (this.props.metadata.metadata) {
-      for (let key in this.props.metadata.metadata.controls) {
+    if (this.props.metadata.loaded) {
+      for (let key in this.props.metadata.controls) {
         // console.log("making filter", key, this.props.metadata.metadata.controls[key])
         filters.push(
           <ChooseFilter
             key={key}
-            filterOptions={this.props.metadata.metadata.controls[key]}
+            filterOptions={this.props.metadata.controls[key]}
             filterType={key}
             shortKey={filterShortName[key]}
           />

--- a/src/old_code/frequencies.js
+++ b/src/old_code/frequencies.js
@@ -129,7 +129,7 @@ class Frequencies extends React.Component {
   render() {
     const styles = this.getStyles();
     return (
-      (this.props.metadata && this.props.metadata.panels && this.props.metadata.panels.some((d)=>d==="frequencies"))
+      (this.props.metadata.panels && this.props.metadata.panels.some((d)=>d==="frequencies"))
       ?(
       <Card title={"Frequencies"}>
         {this.props.frequencies.frequencies ? this.drawFrequencies() : "Waiting on freq data"}

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -4,23 +4,30 @@ import * as types from "../actions/types";
 const Metadata = (state = {
   loaded: false, /* see comment in the sequences reducer for explination */
   metadata: null,
-  colorOptions
+  colorOptions // this can't be removed as the colorScale currently runs before it should
 }, action) => {
   switch (action.type) {
-  case types.NEW_DATASET:
-    return Object.assign({}, state, {
-      loaded: true,
-      metadata: action.meta,
-      colorOptions: action.meta.color_options
-    });
-  case types.ADD_COLOR_BYS:
-    const newColorOptions = JSON.parse(JSON.stringify(state.colorOptions));
-    for (const v of action.newColorBys) {
-      newColorOptions[v] = {menuItem: v, legendTitle: v, key: v, type: "discrete"};
-    }
-    return Object.assign({}, state, {colorOptions: newColorOptions});
-  default:
-    return state;
+    case types.DATA_INVALID:
+      return Object.assign({}, state, {
+        loaded: false
+      });
+    case types.NEW_DATASET:
+      const ret = action.meta;
+      if (Object.prototype.hasOwnProperty.call(ret, "loaded")) {
+        console.error("Metadata JSON must not contain the key \"loaded\"");
+      }
+      ret.colorOptions = ret.color_options;
+      // delete ret.color_options;
+      ret.loaded = true;
+      return ret;
+    case types.ADD_COLOR_BYS:
+      const newColorOptions = JSON.parse(JSON.stringify(state.colorOptions));
+      for (const v of action.newColorBys) {
+        newColorOptions[v] = {menuItem: v, legendTitle: v, key: v, type: "discrete"};
+      }
+      return Object.assign({}, state, {colorOptions: newColorOptions});
+    default:
+      return state;
   }
 };
 


### PR DESCRIPTION
This PR flattens the metadata reducer, which should improve the development effort and reduce bugs.

Before: `reduxState.metadata.metadata` held most of the information
After: `reduxState.metadata` holds everything, and `reduxState.metadata.loaded` can be relied upon. 