### PR TITLE
don't calculate color scale before data is loaded

### DIFF
--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -20,7 +20,7 @@ export const updateColors = function (providedColorBy = undefined) {
     const colorBy = providedColorBy ? providedColorBy : controls.colorBy;
 
     /* step 1: calculate the required colour scale */
-    const version = controls.colorScale.version + 1;
+    const version = controls.colorScale === undefined ? 1 : controls.colorScale.version + 1;
     // console.log("updateColorScale setting colorScale to ", version);
     const colorScale = getColorScale(colorBy, tree, sequences, metadata.colorOptions, version);
     /*   */

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -1,7 +1,6 @@
 import { determineColorByGenotypeType } from "../util/urlHelpers";
 import { numericToCalendar, currentNumDate, currentCalDate } from "../util/dateHelpers";
 import { flattenTree } from "../components/tree/treeHelpers";
-import getColorScale from "../util/getColorScale";
 import { defaultGeoResolution,
   defaultColorBy,
   defaultDateRange,
@@ -61,7 +60,7 @@ const getDefaultState = () => {
     colorBy: defaultColorBy,
     defaultColorBy: defaultColorBy,
     colorByConfidence: {display: false, on: false},
-    colorScale: getColorScale(defaultColorBy, {}, {}, {}, 0),
+    colorScale: undefined,
     analysisSlider: false,
     geoResolution: defaultGeoResolution,
     datasetPathName: "",


### PR DESCRIPTION
`getColorScale` now only runs once upon dataset load, instead of 3+ times