### PR TITLE
S3 staging

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ const devServer = process.argv.indexOf("dev") !== -1;
 global.LOCAL_DATA = process.argv.indexOf("localData") !== -1;
 global.LOCAL_DATA_PATH = path.join(__dirname, "/data/");
 global.REMOTE_DATA_LIVE_BASEURL = "http://data.nextstrain.org/";
-global.REMOTE_DATA_STAGING_BASEURL = "http://data.nextstrain.org/";
+global.REMOTE_DATA_STAGING_BASEURL = "http://staging.nextstrain.org/";
 global.LOCAL_STATIC = process.argv.indexOf("localStatic") !== -1;
 global.LOCAL_STATIC_PATH = path.join(__dirname, "/static/");
 global.REMOTE_STATIC_BASEURL = "http://cdn.rawgit.com/nextstrain/themis/master/files/";

--- a/server.js
+++ b/server.js
@@ -34,7 +34,8 @@ You probably want this on for development, off for testing before deploying.
 const devServer = process.argv.indexOf("dev") !== -1;
 global.LOCAL_DATA = process.argv.indexOf("localData") !== -1;
 global.LOCAL_DATA_PATH = path.join(__dirname, "/data/");
-global.REMOTE_DATA_BASEURL = "http://data.nextstrain.org/";
+global.REMOTE_DATA_LIVE_BASEURL = "http://data.nextstrain.org/";
+global.REMOTE_DATA_STAGING_BASEURL = "http://data.nextstrain.org/";
 global.LOCAL_STATIC = process.argv.indexOf("localStatic") !== -1;
 global.LOCAL_STATIC_PATH = path.join(__dirname, "/static/");
 global.REMOTE_STATIC_BASEURL = "http://cdn.rawgit.com/nextstrain/themis/master/files/";

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -14,6 +14,7 @@ import GeoResolution from "./geo-resolution";
 import MapAnimationControls from "./map-animation";
 import { controlsWidth, enableAnimationDisplay } from "../../util/globals";
 import { titleStyles } from "../../globalStyles";
+import DataSource from "./data-source";
 
 const header = (text) => (
   <span style={titleStyles.small}>
@@ -27,8 +28,7 @@ const header = (text) => (
 }))
 class Controls extends React.Component {
   static propTypes = {
-    analysisSlider: PropTypes.any,
-    dispatch: PropTypes.func
+    analysisSlider: PropTypes.any
   }
   getStyles() {
     return {};
@@ -85,6 +85,10 @@ class Controls extends React.Component {
         <SelectLabel text="Geographic resolution"/>
         <GeoResolution/>
         {enableAnimationDisplay ? <MapAnimationControls/> : null}
+
+        <div/>
+        {header("Data Source")}
+        <DataSource/>
 
       </Flex>
     );

--- a/src/components/controls/data-source.js
+++ b/src/components/controls/data-source.js
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from 'prop-types';
+import { connect } from "react-redux";
+import { changeS3Bucket } from "../../actions/loadData";
+import { analyticsControlsEvent } from "../../util/googleAnalytics";
+import Toggle from "./toggle";
+
+@connect((state) => ({
+  analysisSlider: state.controls.analysisSlider,
+  panels: state.metadata.panels,
+  s3bucket: state.datasets.s3bucket
+}))
+class DataSource extends React.Component {
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    s3bucket: PropTypes.string.isRequired
+  }
+  static contextTypes = {
+    router: PropTypes.object.isRequired
+  }
+  render() {
+    return (
+      <Toggle
+        display
+        on={this.props.s3bucket === "staging"}
+        callback={() => {
+          analyticsControlsEvent("change-s3-bucket");
+          this.props.dispatch(changeS3Bucket(this.context.router));
+        }}
+        label="Staging server (nightly builds)"
+      />
+    );
+  }
+}
+
+export default DataSource;

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -55,6 +55,7 @@ const styliseDateRange = (dateStr) => {
 
 @connect((state) => {
   return {
+    s3bucket: state.datasets.s3bucket,
     browserDimensions: state.browserDimensions.browserDimensions,
     filters: state.controls.filters,
     mapAnimationPlayPauseButton: state.controls.mapAnimationPlayPauseButton,
@@ -280,6 +281,10 @@ class Info extends React.Component {
             {title}
           </div>
           <div width={responsive.width} style={styles.n}>
+            {/* if staging, let the user know */}
+            {this.props.s3bucket === "staging" ? (
+              <span style={{color: darkGrey}}>{"Currently viewing data from the staging server. "}</span>
+            ) : null}
             {animating ? `Map animation in progress. ` : null}
             {/* part 1 - the summary */}
             {!animating ? summary.map((d, i) =>

--- a/src/reducers/datasets.js
+++ b/src/reducers/datasets.js
@@ -1,6 +1,7 @@
 import * as types from "../actions/types";
 
 const datasets = (state = {
+  s3bucket: "live",
   pathogen: undefined,
   splash: undefined,
   posts: undefined,
@@ -9,6 +10,7 @@ const datasets = (state = {
   switch (action.type) {
     case types.MANIFEST_RECEIVED: {
       return Object.assign({}, state, {
+        s3bucket: action.s3bucket,
         splash: action.splash,
         pathogen: action.pathogen,
         user: action.user,

--- a/src/server/util/getFiles.js
+++ b/src/server/util/getFiles.js
@@ -7,11 +7,15 @@ const request = require('request');
 
 const validUsers = ['guest', 'mumps'];
 
-const getDataFile = (res, filePath) => {
+const getDataFile = (res, filePath, s3) => {
   if (global.LOCAL_DATA) {
     res.sendFile(path.join(global.LOCAL_DATA_PATH, filePath));
+  } else if (s3 === "staging") {
+    request(global.REMOTE_DATA_LIVE_BASEURL + filePath).pipe(res);
+    /* TODO explore https://www.npmjs.com/package/cached-request */
   } else {
-    request(global.REMOTE_DATA_BASEURL + filePath).pipe(res);
+    // we deliberately don't ensure that s3===live, as this should be the default
+    request(global.REMOTE_DATA_STAGING_BASEURL + filePath).pipe(res);
     /* TODO explore https://www.npmjs.com/package/cached-request */
   }
 };
@@ -47,7 +51,7 @@ const getManifest = (query, res) => {
     res.status(404).send('Invalid user');
     return;
   }
-  getDataFile(res, 'manifest_' + query.user + '.json');
+  getDataFile(res, 'manifest_' + query.user + '.json', query.s3);
 };
 
 const getPostsManifest = (query, res) => {
@@ -55,7 +59,7 @@ const getPostsManifest = (query, res) => {
 };
 
 const getSplashImage = (query, res) => {
-  getDataFile(res, query.src);
+  getDataFile(res, query.src, query.s3);
 };
 
 const getImage = (query, res) => {
@@ -63,7 +67,7 @@ const getImage = (query, res) => {
 };
 
 const getDatasetJson = (query, res) => {
-  getDataFile(res, query.path);
+  getDataFile(res, query.path, query.s3);
 };
 
 module.exports = {

--- a/src/server/util/getFiles.js
+++ b/src/server/util/getFiles.js
@@ -11,11 +11,11 @@ const getDataFile = (res, filePath, s3) => {
   if (global.LOCAL_DATA) {
     res.sendFile(path.join(global.LOCAL_DATA_PATH, filePath));
   } else if (s3 === "staging") {
-    request(global.REMOTE_DATA_LIVE_BASEURL + filePath).pipe(res);
+    request(global.REMOTE_DATA_STAGING_BASEURL + filePath).pipe(res);
     /* TODO explore https://www.npmjs.com/package/cached-request */
   } else {
     // we deliberately don't ensure that s3===live, as this should be the default
-    request(global.REMOTE_DATA_STAGING_BASEURL + filePath).pipe(res);
+    request(global.REMOTE_DATA_LIVE_BASEURL + filePath).pipe(res);
     /* TODO explore https://www.npmjs.com/package/cached-request */
   }
 };

--- a/src/util/clientAPIInterface.js
+++ b/src/util/clientAPIInterface.js
@@ -3,7 +3,7 @@ import { MANIFEST_RECEIVED, POSTS_MANIFEST_RECEIVED } from "../actions/types";
 import { errorNotification } from "../actions/notifications";
 import { charonAPIAddress } from "./globals";
 
-export const getManifest = (router, dispatch) => {
+export const getManifest = (router, dispatch, s3bucket = "live") => {
   const charonErrorHandler = (e) => {
     dispatch(errorNotification({message: "Failed to get datasets from server"}));
     console.error(e);
@@ -13,6 +13,7 @@ export const getManifest = (router, dispatch) => {
     // console.log("SERVER API REQUEST RETURNED:", datasets);
     dispatch({
       type: MANIFEST_RECEIVED,
+      s3bucket,
       splash: datasets.splash,
       pathogen: datasets.pathogen,
       user: "guest"
@@ -33,7 +34,7 @@ export const getManifest = (router, dispatch) => {
     }
   };
   xmlHttp.onerror = charonErrorHandler;
-  xmlHttp.open("get", charonAPIAddress + 'request=manifest&user=' + user, true); // true for asynchronous
+  xmlHttp.open("get", `${charonAPIAddress}request=manifest&user=${user}&s3=${s3bucket}`, true); // true for asynchronous
   xmlHttp.send(null);
 };
 


### PR DESCRIPTION
This PR adds a toggle to the sidebar which changes the source of data from `data.nextstrain.org` to `staging.nextstrain.org`. A sentence is added to the info box when the staging server is enabled. If desired I can add a notification pop up (instead?). 

Charon API has been extended to take an extra query parameter `s3` to the manifest & dataset calls. Splash images are currently always sourced from `data.nextstrain.org`, this can be revisited in the future. 