### PR TITLE
Vaccines crosses

### DIFF
--- a/src/components/tree/infoPanel.js
+++ b/src/components/tree/infoPanel.js
@@ -223,6 +223,18 @@ const tipDisplayColorByInfo = (d, colorBy, distanceMeasure, temporalConfidence, 
   return infoLineJSX(prettyString(colorBy) + ":", prettyString(d.n.attr[colorBy]));
 };
 
+const displayVaccineInfo = (d) => {
+  if (d.n.vaccineDate) {
+    return (
+      <g>
+        {infoLineJSX("Vaccine strain:", d.n.vaccineDate)}
+        <p/>
+      </g>
+    );
+  }
+  return null;
+};
+
 /* the actual component - a pure function, so we can return early if needed */
 const InfoPanel = ({tree, mutType, temporalConfidence, distanceMeasure,
   hovered, viewer, colorBy, colorByConfidence, colorScale}) => {
@@ -236,6 +248,7 @@ const InfoPanel = ({tree, mutType, temporalConfidence, distanceMeasure,
   if (tip) {
     inner = (
       <p>
+        {displayVaccineInfo(d)}
         {tipDisplayColorByInfo(d, colorBy, distanceMeasure, temporalConfidence, mutType, colorScale)}
         {distanceMeasure === "div" ? getBranchDivJSX(d.n) : getBranchTimeJSX(d.n, temporalConfidence)}
       </p>

--- a/src/components/tree/phyloTree.js
+++ b/src/components/tree/phyloTree.js
@@ -840,8 +840,9 @@ PhyloTree.prototype.drawVaccines = function() {
       .attr('dominant-baseline', 'central')
       .style("font-family", this.params.fontFamily)
       .style("font-size", "20px")
-      .style("stroke", darkGrey)
-      .text('\u2573')
+      .style("stroke", "#fff")
+      .style("fill", darkGrey)
+      .text('\u2716')
       // .style("cursor", "pointer")
       .on("mouseover", (d) => console.log("vaccine", d))
 };

--- a/src/components/tree/phyloTree.js
+++ b/src/components/tree/phyloTree.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import _debounce from "lodash/debounce";
 import { event } from "d3-selection";
 import { min, max, sum } from "d3-array";
@@ -167,7 +168,8 @@ PhyloTree.prototype.setDefaults = function () {
         tipLabelFill: "#555",
         tipLabelPadX: 8,
         tipLabelPadY: 2,
-      mapToScreenDebounceTime: 500
+        showVaccines: false,
+        mapToScreenDebounceTime: 500
     };
 };
 
@@ -182,16 +184,16 @@ PhyloTree.prototype.setDefaults = function () {
  * @param  visibility (OPTIONAL) -- array of "visible" or "hidden"
  * @return {null}
  */
-PhyloTree.prototype.render = function(svg, layout, distance, options, callbacks, branchThickness, visibility, drawConfidence) {
+PhyloTree.prototype.render = function(svg, layout, distance, options, callbacks, branchThickness, visibility, drawConfidence, vaccines) {
   if (branchThickness) {
     this.nodes.forEach(function(d, i) {
       d["stroke-width"] = branchThickness[i];
     });
   }
-
   this.svg = svg;
   this.params = Object.assign(this.params, options);
   this.callbacks = callbacks;
+  this.vaccines = vaccines ? vaccines.map((d) => d.shell) : undefined;
 
   this.clearSVG();
   this.setDistance(distance);
@@ -204,6 +206,9 @@ PhyloTree.prototype.render = function(svg, layout, distance, options, callbacks,
     this.drawBranches();
   }
   this.drawTips();
+  if (this.params.showVaccines) {
+    this.drawVaccines();
+  }
   this.drawCladeLabels();
   if (visibility) {
     this.nodes.forEach(function(d, i) {
@@ -816,8 +821,30 @@ PhyloTree.prototype.clearSVG = function() {
   this.svg.selectAll('.tip').remove();
   this.svg.selectAll('.branch').remove();
   this.svg.selectAll('.branchLabel').remove();
+  this.svg.selectAll(".vaccine").remove();
 };
 
+/**
+ * adds crosses to the vaccines
+ * @return {null}
+ */
+PhyloTree.prototype.drawVaccines = function() {
+  this.tipElements = this.svg.append("g").selectAll(".vaccine")
+    .data(this.vaccines)
+    .enter()
+    .append("text")
+      .attr("class", "vaccine")
+      .attr("x", (d) => d.xTip)
+      .attr("y", (d) => d.yTip)
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'central')
+      .style("font-family", this.params.fontFamily)
+      .style("font-size", "20px")
+      .style("stroke", darkGrey)
+      .text('\u2573')
+      // .style("cursor", "pointer")
+      .on("mouseover", (d) => console.log("vaccine", d))
+};
 
 /**
  * adds all the tip circles to the svg, they have class tip
@@ -1116,6 +1143,12 @@ PhyloTree.prototype.updateGeometryFade = function(dt) {
         .attr("cy", function(d) {
           return d.yTip;
         });
+      svg.selectAll(".vaccine")
+        .filter((d) => d.update)
+        .transition()
+          .duration(dt)
+          .attr("x", (d) => d.xTip)
+          .attr("y", (d) => d.yTip);
     };
   };
   setTimeout(tipTrans(this.svg, dt), 0.5 * dt);
@@ -1168,6 +1201,13 @@ PhyloTree.prototype.updateGeometry = function (dt) {
       .duration(dt)
       .attr("cx", (d) => d.xTip)
       .attr("cy", (d) => d.yTip);
+
+  this.svg.selectAll(".vaccine")
+    .filter((d) => d.update)
+    .transition()
+      .duration(dt)
+      .attr("x", (d) => d.xTip)
+      .attr("y", (d) => d.yTip);
 
   const branchEls = [".S", ".T"];
   for (let i = 0; i < 2; i++) {

--- a/src/components/tree/tipSelectedPanel.js
+++ b/src/components/tree/tipSelectedPanel.js
@@ -64,6 +64,18 @@ const justURL = (url) => (
   </tr>
 );
 
+const displayVaccineInfo = (d) => {
+  if (d.n.vaccineDate) {
+    return (
+      <tr>
+        <th>Vaccine strain</th>
+        <td>{d.n.vaccineDate}</td>
+      </tr>
+    );
+  }
+  return null;
+};
+
 const validValue = (value) => value !== "?" && value !== undefined && value !== "undefined";
 const validAttr = (attrs, key) => key in attrs && validValue(attrs[key]);
 
@@ -81,6 +93,7 @@ const TipSelectedPanel = ({tip, goAwayCallback, metadata}) => {
         </p>
         <table>
           <tbody>
+            {displayVaccineInfo(tip) /* vaccine information (if applicable) */}
             {/* the "basic" attributes (which may not exist in certain datasets) */}
             {["country", "region", "division"].map((x) => {
               return validAttr(tip.n.attr, x) ? item(prettyString(x), prettyString(tip.n.attr[x])) : null;

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import { scalePow } from "d3-scale";
 import { tipRadius, freqScale, tipRadiusOnLegendMatch } from "../../util/globals";
 
@@ -374,3 +376,18 @@ export const branchOpacityFunction = scalePow()
 // entropy calculation precomputed in augur
 // export const calcEntropyOfValues = (vals) =>
 //   vals.map((v) => v * Math.log(v + 1E-10)).reduce((a, b) => a + b, 0) * -1 / Math.log(vals.length);
+
+/**
+*  if the metadata JSON defines vaccine strains then create an array of the nodes
+*  @param nodes - nodes
+*  @param vaccineChoices - undefined or the object from the metadata JSON linking strain names to dates
+*  @returns array  - array of nodes that are vaccines. NOTE these are references to the nodes array
+*  side-effects: adds the vaccineDate property to the relevent nodes
+*/
+export const processVaccines = (nodes, vaccineChoices) => {
+  if (!vaccineChoices) {return false;}
+  const names = Object.keys(vaccineChoices);
+  const vaccines = nodes.filter((d) => names.indexOf(d.strain) !== -1);
+  vaccines.forEach((d) => d.vaccineDate = vaccineChoices[d.strain]);
+  return vaccines;
+}

--- a/src/components/tree/treeView.js
+++ b/src/components/tree/treeView.js
@@ -130,6 +130,7 @@ class TreeView extends React.Component {
         { /* options */
           grid: true,
           confidence: nextProps.temporalConfidence.display,
+          showVaccines: !!nextProps.tree.vaccines,
           branchLabels: true,      //generate DOM object
           showBranchLabels: false,  //hide them initially -> couple to redux state
           tipLabels: true,      //generate DOM object
@@ -149,7 +150,8 @@ class TreeView extends React.Component {
         },
         nextProps.tree.branchThickness, /* guarenteed to be in redux by now */
         nextProps.tree.visibility,
-        nextProps.temporalConfidence.on /* drawConfidence? */
+        nextProps.temporalConfidence.on, /* drawConfidence? */
+        nextProps.tree.vaccines
       );
       return myTree;
     } else {

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -1,4 +1,4 @@
-import { flattenTree, appendParentsToTree } from "../components/tree/treeHelpers";
+import { flattenTree, appendParentsToTree, processVaccines } from "../components/tree/treeHelpers";
 import { processNodes, calcLayouts } from "../components/tree/processNodes";
 import { getValuesAndCountsOfVisibleTraitsFromTree, getAllValuesAndCountsOfTraitsFromTree } from "../util/treeTraversals";
 import * as types from "../actions/types";
@@ -19,6 +19,7 @@ const getDefaultState = () => {
     tipRadiiVersion: 0,
     branchThickness: null,
     branchThicknessVersion: 0,
+    vaccines: false,
     version: 0,
     idxOfInViewRootNode: 0,
     visibleStateCounts: {},
@@ -43,13 +44,12 @@ const Tree = (state = getDefaultState(), action) => {
       appendParentsToTree(action.tree);
       const nodesArray = flattenTree(action.tree);
       const nodes = processNodes(nodesArray);
+      const vaccines = processVaccines(nodes, action.meta.vaccine_choices);
       calcLayouts(nodes, ["div", "num_date"]);
-      // getAllValuesAndCountsOfTraitFromTree
       return Object.assign({}, getDefaultState(), {
-        nodes: nodes,
-        attrs: getAttrsOnTerminalNodes(nodes),
-        totalStateCounts: {},
-        visibleStateCounts: {}
+        nodes,
+        vaccines,
+        attrs: getAttrsOnTerminalNodes(nodes)
       });
     }
     case types.DATA_VALID:


### PR DESCRIPTION
This PR adds the crosses over the vaccine strains and provides their dates in the hover / click info panels. It looks in the `meta.json` for the presence of `vaccine_choices` which i've just added to augur. If this is not present, no vaccine information is displayed.

Styling:
![image](https://user-images.githubusercontent.com/8350992/35708112-6de9fc04-0761-11e8-991f-542c5871906a.png)

Available to view here: https://auspice-dev.herokuapp.com/flu/h3n2/ha/3y -> staging server toggle. (The initial colorBy is black I think because you are developing augur or because I don't run with titers)
