### PR TITLE
Tree vertical dimension scaling

### DIFF
--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -3,12 +3,14 @@ import getColorScale from "../util/getColorScale";
 import { setGenotype } from "../util/setGenotype";
 import { calcNodeColor } from "../components/tree/treeHelpers";
 import { determineColorByGenotypeType } from "../util/colorHelpers";
+import { timerStart, timerEnd } from "../util/perf";
 import { updateEntropyVisibility } from "./entropy";
 import * as types from "./types";
 
 /* providedColorBy: undefined | string */
 export const changeColorBy = (providedColorBy = undefined) => { // eslint-disable-line import/prefer-default-export
   return (dispatch, getState) => {
+    timerStart("changeColorBy calculations");
     const { controls, tree, metadata } = getState();
     /* step 0: bail if all required params aren't (yet) available! */
     /* note this *can* run before the tree is loaded - we only need the nodes */
@@ -41,6 +43,7 @@ export const changeColorBy = (providedColorBy = undefined) => { // eslint-disabl
 
     /* step 3: change in mutType? */
     const newMutType = determineColorByGenotypeType(colorBy) !== controls.mutType ? determineColorByGenotypeType(colorBy) : false;
+    timerEnd("changeColorBy calculations"); /* end timer before dispatch */
     if (newMutType) {
       updateEntropyVisibility(dispatch, getState);
     }

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -136,7 +136,6 @@ class Tree extends React.Component {
         { /* options */
           grid: true,
           confidence: nextProps.temporalConfidence.display,
-          showVaccines: !!nextProps.tree.vaccines,
           branchLabels: true,
           showBranchLabels: false,
           tipLabels: true,

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -35,6 +35,5 @@ export const defaultParams = {
   tipLabelFill: "#555",
   tipLabelPadX: 8,
   tipLabelPadY: 2,
-  showVaccines: false,
   mapToScreenDebounceTime: 500
 };

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -98,11 +98,9 @@ export const updateGeometry = function updateGeometry(dt) {
 
   if (this.vaccines) {
     this.svg.selectAll(".vaccineCross")
-      .transition()
-      .duration(dt)
-      .attr("x", (d) => d.xTipCross)
-      .attr("y", (d) => d.yTip);
-    if (this.layout === "rect") {
+      .transition().duration(dt)
+      .attr("d", (dd) => dd.vaccineCross);
+    if (this.layout === "rect") { /* we only have dotted lines on rect layout so far */
       this.svg.selectAll(".vaccineDottedLine")
         .transition().duration(dt)
         .style("opacity", 1)

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -99,7 +99,7 @@ export const updateGeometry = function updateGeometry(dt) {
     .filter((d) => d.update)
     .transition()
     .duration(dt)
-    .attr("x", (d) => d.xTip)
+    .attr("x", (d) => d.xTipCross)
     .attr("y", (d) => d.yTip);
 
   const branchEls = [".S", ".T"];
@@ -156,7 +156,7 @@ export const updateGeometryFade = function updateGeometryFade(dt) {
       .filter((d) => d.update)
       .transition()
       .duration(dtShadow)
-      .attr("x", (d) => d.xTip)
+      .attr("x", (d) => d.xTipCross)
       .attr("y", (d) => d.yTip);
   };
   setTimeout(tipTransHOF(this.svg, dt), 0.5 * dt);

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -88,6 +88,7 @@ export const updateLayout = function updateLayout(layout, dt) {
  * @return {[type]}
  */
 export const updateGeometry = function updateGeometry(dt) {
+  timerStart("updateGeometry");
   this.svg.selectAll(".tip")
     .filter((d) => d.update)
     .transition()
@@ -119,6 +120,7 @@ export const updateGeometry = function updateGeometry(dt) {
 
   this.updateBranchLabels(dt);
   this.updateTipLabels(dt);
+  timerEnd("updateGeometry");
 };
 
 

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -100,7 +100,7 @@ export const updateGeometry = function updateGeometry(dt) {
     this.svg.selectAll(".vaccineCross")
       .transition().duration(dt)
       .attr("d", (dd) => dd.vaccineCross);
-    if (this.layout === "rect") { /* we only have dotted lines on rect layout so far */
+    if (this.distance === "num_date") {
       this.svg.selectAll(".vaccineDottedLine")
         .transition().duration(dt)
         .style("opacity", 1)

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -87,10 +87,12 @@ export const updateLayout = function updateLayout(layout, dt) {
  * @param  dt -- time of transition in milliseconds
  * @return {[type]}
  */
-export const updateGeometry = function updateGeometry(dt) {
+export const updateGeometry = function updateGeometry(dt, forceAll = false) {
   timerStart("updateGeometry");
+  console.log(`updateGeometry dt: ${dt} forceAll: ${forceAll}`);
+  const filterFun = forceAll ? () => true : (d) => d.update;
   this.svg.selectAll(".tip")
-    .filter((d) => d.update)
+    .filter(filterFun)
     .transition()
     .duration(dt)
     .attr("cx", (d) => d.xTip)
@@ -117,14 +119,14 @@ export const updateGeometry = function updateGeometry(dt) {
   for (let i = 0; i < 2; i++) {
     this.svg.selectAll(".branch")
       .filter(branchEls[i])
-      .filter((d) => d.update)
+      .filter(filterFun)
       .transition()
       .duration(dt)
       .attr("d", (d) => d.branch[i]);
   }
 
   this.svg.selectAll(".conf")
-    .filter((d) => d.update)
+    .filter(filterFun)
     .transition().duration(dt)
     .attr("d", (dd) => dd.confLine);
 
@@ -240,6 +242,7 @@ export const updateGeometryFade = function updateGeometryFade(dt) {
  */
 export const updateMultipleArray = function updateMultipleArray(treeElem, attrs, styles, dt, quickdraw) {
   timerStart("updateMultipleArray");
+  console.log(`updateMultipleArray ${treeElem} attrs: ${Object.keys(attrs).join(",")} styles: ${Object.keys(styles).join(",")} dt: ${dt} quickdraw: ${quickdraw}}`)
   // assign new values and decide whether to update
   this.nodes.forEach((d, i) => {
     d.update = false;

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -96,12 +96,24 @@ export const updateGeometry = function updateGeometry(dt) {
     .attr("cx", (d) => d.xTip)
     .attr("cy", (d) => d.yTip);
 
-  this.svg.selectAll(".vaccine")
-    .filter((d) => d.update)
-    .transition()
-    .duration(dt)
-    .attr("x", (d) => d.xTipCross)
-    .attr("y", (d) => d.yTip);
+  if (this.vaccines) {
+    this.svg.selectAll(".vaccineCross")
+      .transition()
+      .duration(dt)
+      .attr("x", (d) => d.xTipCross)
+      .attr("y", (d) => d.yTip);
+    if (this.layout === "rect") {
+      this.svg.selectAll(".vaccineDottedLine")
+        .transition().duration(dt)
+        .style("opacity", 1)
+        .attr("d", (dd) => dd.vaccineLine);
+    } else {
+      this.svg.selectAll(".vaccineDottedLine")
+        .transition().duration(dt)
+        .style("opacity", 0)
+        .attr("d", (dd) => dd.vaccineLine);
+    }
+  }
 
   const branchEls = [".S", ".T"];
   for (let i = 0; i < 2; i++) {

--- a/src/components/tree/phyloTree/generalUpdates.js
+++ b/src/components/tree/phyloTree/generalUpdates.js
@@ -136,76 +136,98 @@ export const updateGeometry = function updateGeometry(dt) {
 
 /*
  * redraw the tree based on the current xTip, yTip, branch attributes
- * this function will remove branches, move the tips continuously
- * and add the new branches again after the tips arrived at their destination
- *  @params dt -- time of transition in milliseconds
+ * step 1: fade out everything except tips.
+ * step 2: when step 1 has finished, move tips across the screen.
+ * step 3: when step 2 has finished, move everything else (whilst hidden) and fasde back in.
+ *  @params dt -- time of tip move (ms). Note that this function will take a lot longer than this time!
  */
 export const updateGeometryFade = function updateGeometryFade(dt) {
-  this.removeConfidence(dt);
+  const fadeDt = dt * 0.5;
+  const moveDt = dt;
 
-  /* fade out branches, tip & branch labels, vaccine crosses & dotted lines */
+  let inProgress = 0; /* counter of transitions currently in progress */
+  const moveElementsAndFadeBackIn = () => {
+    if (!--inProgress) { /* decrement counter. When hits 0 run block */
+      this.svg.selectAll('.branch').filter('.S')
+        .filter((d) => d.update)
+        .attr("d", (d) => d.branch[0])
+        .transition()
+        .duration(fadeDt)
+        .style("opacity", 1.0);
+      this.svg.selectAll('.branch').filter('.T')
+        .filter((d) => d.update)
+        .attr("d", (d) => d.branch[1])
+        .transition()
+        .duration(fadeDt)
+        .style("opacity", 1.0);
+      if (this.vaccines) {
+        this.svg.selectAll('.vaccineCross')
+          .attr("d", (dd) => dd.vaccineCross)
+          .transition()
+          .duration(fadeDt)
+          .style("opacity", 1.0);
+        if (this.distance === "num_date") {
+          this.svg.selectAll('.vaccineDottedLine')
+            .attr("d", (dd) => dd.vaccineLine)
+            .transition()
+            .duration(fadeDt)
+            .style("opacity", 1.0);
+        } else {
+          this.svg.selectAll('.vaccineDottedLine')
+            .attr("d", (dd) => dd.vaccineLine);
+          /* opacity is already 0 */
+        }
+      }
+      this.updateBranchLabels(fadeDt);
+      this.updateTipLabels(fadeDt);
+    }
+  };
+  const moveTipsWhenFadedOut = () => {
+    if (!--inProgress) { /* decrement counter. When hits 0 run block */
+      this.svg.selectAll('.tip')
+        .filter((d) => d.update)
+        .transition()
+        .duration(moveDt)
+        .attr("cx", (d) => d.xTip)
+        .attr("cy", (d) => d.yTip)
+        .on("start", () => inProgress++)
+        .on("end", moveElementsAndFadeBackIn);
+    }
+  };
+
+  /* fade out branches, tip & branch labels, vaccine crosses & dotted lines.
+  When these fade outs are complete, the function moveTipsWhenFadedOut will fire */
+  this.removeConfidence();
   this.svg.selectAll('.branch')
     .filter((d) => d.update)
-    .transition().duration(dt * 0.5)
-    .style("opacity", 0.0);
+    .transition().duration(fadeDt)
+    .style("opacity", 0.0)
+    .on("start", () => inProgress++)
+    .on("end", moveTipsWhenFadedOut);
   this.svg.selectAll('.branchLabels')
     .filter((d) => d.update)
-    .transition().duration(dt * 0.5)
-    .style("opacity", 0.0);
+    .transition().duration(fadeDt)
+    .style("opacity", 0.0)
+    .on("start", () => inProgress++)
+    .on("end", moveTipsWhenFadedOut);
   this.svg.selectAll('.tipLabels')
     .filter((d) => d.update)
-    .transition().duration(dt * 0.5)
-    .style("opacity", 0.0);
+    .transition().duration(fadeDt)
+    .style("opacity", 0.0)
+    .on("start", () => inProgress++)
+    .on("end", moveTipsWhenFadedOut);
   if (this.vaccines) {
     this.svg.selectAll('.vaccineCross')
-      .transition().duration(dt * 0.5)
-      .style("opacity", 0.0);
+      .transition().duration(fadeDt)
+      .style("opacity", 0.0)
+      .on("start", () => inProgress++)
+      .on("end", moveTipsWhenFadedOut);
     this.svg.selectAll('.vaccineDottedLine')
-      .transition().duration(dt * 0.5)
-      .style("opacity", 0.0);
+      .transition().duration(fadeDt)
+      .style("opacity", 0.0)
+      .on("start", () => inProgress++)
+      .on("end", moveTipsWhenFadedOut);
   }
-
-  // closure to move the tips, called via the time out below
-  const moveTipsHOF = (svgShadow, dtShadow) => () => {
-    svgShadow.selectAll('.tip')
-      .filter((d) => d.update)
-      .transition().duration(dtShadow)
-      .attr("cx", (d) => d.xTip)
-      .attr("cy", (d) => d.yTip);
-  };
-
-  // closure to change the branches, called via time out after the tipTrans is done
-  const moveHiddenElementsHOF = (svgShadow, vaccines) => () => {
-    svgShadow.selectAll('.branch').filter('.S')
-      .filter((d) => d.update)
-      .attr("d", (d) => d.branch[0]);
-    svgShadow.selectAll('.branch').filter('.T')
-      .filter((d) => d.update)
-      .attr("d", (d) => d.branch[1]);
-    if (vaccines) {
-      svgShadow.selectAll('.vaccineCross').attr("d", (dd) => dd.vaccineCross);
-      svgShadow.selectAll('.vaccineDottedLine').attr("d", (dd) => dd.vaccineLine);
-    }
-  };
-
-  // closure to add the new branches after the tipTrans
-  const fadeBackElementsHOF = (svgShadow, dtShadow, vaccines) => () => {
-    svgShadow.selectAll('.branch')
-      .filter((dd) => dd.update)
-      .transition().duration(0.5 * dtShadow)
-      .style("opacity", 1.0);
-    if (vaccines) {
-      svgShadow.selectAll('.vaccineCross, .vaccineDottedLine')
-        .transition().duration(0.5 * dtShadow)
-        .style("opacity", 1.0);
-    }
-  };
-
-  setTimeout(moveTipsHOF(this.svg, dt), 0.5 * dt);
-  setTimeout(moveHiddenElementsHOF(this.svg, this.vaccines), 0.5 * dt);
-  setTimeout(fadeBackElementsHOF(this.svg, 0.2 * dt, this.vaccines), 1.5 * dt);
-  this.updateBranchLabels(dt);
-  this.updateTipLabels(dt);
 };
 
 

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -1,5 +1,6 @@
 /* eslint-disable space-infix-ops */
 import { max } from "d3-array";
+import { timerStart, timerEnd } from "../../../util/perf";
 
 export const removeGrid = function removeGrid() {
   this.svg.selectAll(".majorGrid").remove();
@@ -19,6 +20,7 @@ export const hideGrid = function hideGrid() {
  * @param {layout}
  */
 export const addGrid = function addGrid(layout, yMinView, yMaxView) {
+  timerStart("addGrid");
   if (typeof layout==="undefined") {layout=this.layout;} // eslint-disable-line no-param-reassign
 
   const xmin = (this.xScale.domain()[0]>0)?this.xScale.domain()[0]:0.0;
@@ -164,4 +166,5 @@ export const addGrid = function addGrid(layout, yMinView, yMaxView) {
     .attr("y", yTextPos(this.yScale, layout));
 
   this.grid=true;
+  timerEnd("addGrid");
 };

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -47,11 +47,13 @@ export const applyToChildren = (node, func) => {
 * modifies the nodes argument in place
 */
 export const createChildrenAndParents = (nodes) => {
+  let numTips = 0;
   nodes.forEach((d) => {
     d.parent = d.n.parent.shell;
     if (d.terminal) {
       d.yRange = [d.n.yvalue, d.n.yvalue];
       d.children = null;
+      numTips++;
     } else {
       d.yRange = [d.n.children[0].yvalue, d.n.children[d.n.children.length - 1].yvalue];
       d.children = [];
@@ -60,4 +62,5 @@ export const createChildrenAndParents = (nodes) => {
       }
     }
   });
+  return numTips;
 };

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -51,11 +51,11 @@ export const createChildrenAndParents = (nodes) => {
   nodes.forEach((d) => {
     d.parent = d.n.parent.shell;
     if (d.terminal) {
-      d.yRange = [d.n.yvalue, d.n.yvalue];
+      // d.yRange = [d.n.yvalue, d.n.yvalue];
       d.children = null;
       numTips++;
     } else {
-      d.yRange = [d.n.children[0].yvalue, d.n.children[d.n.children.length - 1].yvalue];
+      // d.yRange = [d.n.children[0].yvalue, d.n.children[d.n.children.length - 1].yvalue];
       d.children = [];
       for (let i = 0; i < d.n.children.length; i++) {
         d.children.push(d.n.children[i].shell);
@@ -63,4 +63,34 @@ export const createChildrenAndParents = (nodes) => {
     }
   });
   return numTips;
+};
+
+
+/**
+ * given nodes add y values (node.yvalue) to every node
+ * Nodes are the phyloTree nodes (i.e. node.n is the redux node)
+ * Nodes must have parent child links established (via createChildrenAndParents)
+ * PhyloTree can subsequently use this information. Accessed by prototypes
+ * rectangularLayout, radialLayout, createChildrenAndParents
+ * side effects: node.n.yvalue (i.e. in the redux node) and node.yRange (i.e. in the phyloTree node)
+ */
+export const calcYValues = (nodes) => {
+  console.time("calcYValues")
+  let count = 0;
+  const recurse = (node) => {
+    if (node.children) {
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        recurse(node.children[i]);
+      }
+    } else {
+      node.n.yvalue = ++count;
+      node.yRange = [count, count];
+      return;
+    }
+    /* if here, then all children have yvalues, but we dont. */
+    node.n.yvalue = node.children.reduce((acc, d) => acc + d.n.yvalue, 0) / node.children.length;
+    node.yRange = [node.n.children[0].yvalue, node.n.children[node.n.children.length - 1].yvalue];
+  };
+  recurse(nodes[0]);
+  console.timeEnd("calcYValues")
 };

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -45,17 +45,16 @@ export const applyToChildren = (node, func) => {
 /*
 * given nodes, create the children and parent properties.
 * modifies the nodes argument in place
+* returns num tips
 */
-export const createChildrenAndParents = (nodes) => {
+export const createChildrenAndParentsReturnNumTips = (nodes) => {
   let numTips = 0;
   nodes.forEach((d) => {
     d.parent = d.n.parent.shell;
     if (d.terminal) {
-      // d.yRange = [d.n.yvalue, d.n.yvalue];
       d.children = null;
       numTips++;
     } else {
-      // d.yRange = [d.n.children[0].yvalue, d.n.children[d.n.children.length - 1].yvalue];
       d.children = [];
       for (let i = 0; i < d.n.children.length; i++) {
         d.children.push(d.n.children[i].shell);

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -73,7 +73,7 @@ export const createChildrenAndParentsReturnNumTips = (nodes) => {
  * rectangularLayout, radialLayout, createChildrenAndParents
  * side effects: node.n.yvalue (i.e. in the redux node) and node.yRange (i.e. in the phyloTree node)
  */
-export const calcYValues = (nodes, spacing = "even", numberOfTips = undefined) => {
+export const calcYValues = (nodes, spacing = "even", numberOfTips = undefined, visibility = undefined) => {
   console.time("calcYValues")
   console.log("running calcYValues with spacing", spacing)
   let total = 0; /* cumulative counter of y value at tip */
@@ -89,6 +89,15 @@ export const calcYValues = (nodes, spacing = "even", numberOfTips = undefined) =
       total += node.inView ? yPerInView : yPerOutOfView;
       return total;
     };
+  } else if (spacing === "visibility") {
+    const numTipsVisible = nodes.map((d) => d.terminal && visibility[d.n.arrayIdx] === "visible").filter((x) => x).length
+    // console.log(`# tips visibile: ${numTipsVisible} / ${numberOfTips}`);
+    const yPerVisible = (0.8 * numberOfTips) / numTipsVisible;
+    const yPerNotVisible = (0.2 * numberOfTips) / (numberOfTips - numTipsVisible);
+    calcY = (node) => {
+      total += visibility[node.n.arrayIdx] === "visible" ? yPerVisible : yPerNotVisible;
+      return total;
+    }
   } else { /* fall back to even spacing */
     if (spacing !== "even") console.warn("falling back to even spacing of y values. Unknown arg:", spacing);
     calcY = () => ++total;

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -47,6 +47,7 @@ export const rectangularLayout = function rectangularLayout() {
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
       d.xCross = d.crossDepth;
+      d.yCross = d.y;
     });
   }
 };
@@ -65,8 +66,11 @@ export const timeVsRootToTip = function timeVsRootToTip() {
     d.px = d.n.parent.attr["num_date"];
     d.py = d.n.parent.attr["div"];
   });
-  if (this.vaccines) { /* where the tips should be */
-    this.vaccines.forEach((d) => {d.xCross = d.x;});
+  if (this.vaccines) { /* overlay vaccine cross on tip */
+    this.vaccines.forEach((d) => {
+      d.xCross = d.x;
+      d.yCross = d.y;
+    });
   }
   const nTips = this.numberOfTips;
   // REGRESSION WITH FREE INTERCEPT
@@ -145,7 +149,9 @@ export const unrootedLayout = function unrootedLayout() {
   }
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
-      d.xCross = d.x;
+      const bL = d.crossDepth - d.depth;
+      d.xCross = d.px + bL * Math.cos(d.tau + d.w * 0.5);
+      d.yCross = d.py + bL * Math.sin(d.tau + d.w * 0.5);
     });
   }
 };
@@ -175,7 +181,13 @@ export const radialLayout = function radialLayout() {
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
-      d.xCross = (d.crossDepth - offset) * Math.sin(d.angle);
+      if (this.distance === "div") {
+        d.xCross = d.x;
+        d.yCross = d.y;
+      } else {
+        d.xCross = (d.crossDepth - offset) * Math.sin(d.angle);
+        d.yCross = (d.crossDepth - offset) * Math.cos(d.angle);
+      }
     });
   }
 };

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -37,6 +37,7 @@ export const setLayout = function setLayout(layout) {
  * @return {null}
  */
 export const rectangularLayout = function rectangularLayout() {
+  console.log("rectangularLayout")
   this.nodes.forEach((d) => {
     d.y = d.n.yvalue; // precomputed y-values
     d.x = d.depth;    // depth according to current distance

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -41,6 +41,11 @@ export const rectangularLayout = function rectangularLayout() {
     d.py = d.y;
     d.x_conf = d.conf; // assign confidence intervals
   });
+  if (this.vaccines) {
+    this.vaccines.forEach((d) => {
+      d.xCross = d.crossDepth;
+    });
+  }
 };
 
 /**
@@ -57,6 +62,9 @@ export const timeVsRootToTip = function timeVsRootToTip() {
     d.px = d.n.parent.attr["num_date"];
     d.py = d.n.parent.attr["div"];
   });
+  if (this.vaccines) { /* where the tips should be */
+    this.vaccines.forEach((d) => {d.xCross = d.x;});
+  }
   const nTips = this.numberOfTips;
   // REGRESSION WITH FREE INTERCEPT
   // const meanDiv = d3.sum(this.nodes.filter((d)=>d.terminal).map((d)=>d.y))/nTips;
@@ -132,6 +140,11 @@ export const unrootedLayout = function unrootedLayout() {
     eta += this.nodes[0].children[i].w;
     unrootedPlaceSubtree(this.nodes[0].children[i], nTips);
   }
+  if (this.vaccines) {
+    this.vaccines.forEach((d) => {
+      d.xCross = d.x;
+    });
+  }
 };
 
 /**
@@ -157,6 +170,11 @@ export const radialLayout = function radialLayout() {
     d.xCBarEnd = (d.depth - offset) * Math.sin(angleCBar2);
     d.smallBigArc = Math.abs(angleCBar2 - angleCBar1) > Math.PI * 1.0;
   });
+  if (this.vaccines) {
+    this.vaccines.forEach((d) => {
+      d.xCross = (d.crossDepth - offset) * Math.sin(d.angle);
+    });
+  }
 };
 
 /*
@@ -182,6 +200,11 @@ export const setDistance = function setDistance(distanceAttribute) {
       d.conf = [d.depth, d.depth];
     }
   });
+  if (this.vaccines) {
+    this.vaccines.forEach((d) => {
+      d.crossDepth = tmp_dist === "div" ? d.depth : d.n.vaccineDateNumeric;
+    });
+  }
 };
 
 

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-multi-spaces */
 import { min, sum } from "d3-array";
 import { addLeafCount } from "./helpers";
+import { timerStart, timerEnd } from "../../../util/perf";
 
 /**
  * assigns the attribute this.layout and calls the function that
@@ -9,6 +10,7 @@ import { addLeafCount } from "./helpers";
  *                  ["rect", "radial", "unrooted", "clock"]
  */
 export const setLayout = function setLayout(layout) {
+  timerStart("setLayout");
   if (typeof layout === "undefined" || layout !== this.layout) {
     this.nodes.forEach((d) => {d.update = true;});
   }
@@ -26,6 +28,7 @@ export const setLayout = function setLayout(layout) {
   } else if (this.layout === "unrooted") {
     this.unrootedLayout();
   }
+  timerEnd("setLayout");
 };
 
 
@@ -183,6 +186,7 @@ export const radialLayout = function radialLayout() {
  * calculate coordinates. Parent depth is assigned as well.
  */
 export const setDistance = function setDistance(distanceAttribute) {
+  timerStart("setDistance");
   this.nodes.forEach((d) => {d.update = true;});
   if (typeof distanceAttribute === "undefined") {
     this.distance = "div"; // default is "div" for divergence
@@ -205,6 +209,7 @@ export const setDistance = function setDistance(distanceAttribute) {
       d.crossDepth = tmp_dist === "div" ? d.depth : d.n.vaccineDateNumeric;
     });
   }
+  timerEnd("setDistance");
 };
 
 

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -1,7 +1,7 @@
 import _debounce from "lodash/debounce";
 import { scaleLinear } from "d3-scale";
 import { defaultParams } from "./defaultParams";
-import { addLeafCount, createChildrenAndParents, calcYValues } from "./helpers";
+import { addLeafCount, createChildrenAndParentsReturnNumTips, calcYValues } from "./helpers";
 
 /* PROTOTYPES */
 import * as renderers from "./renderers";
@@ -36,7 +36,7 @@ const PhyloTree = function PhyloTree(reduxNodes) {
     d.shell = phyloNode; /* set the link from the redux node to the phylotree node */
     return phyloNode;
   });
-  this.numberOfTips = createChildrenAndParents(this.nodes); /* side effects: d.parent, d.children, d.yRange */
+  this.numberOfTips = createChildrenAndParentsReturnNumTips(this.nodes); /* side effects: d.parent, d.children */
   calcYValues(this.nodes);
 
   this.xScale = scaleLinear();

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -37,7 +37,7 @@ const PhyloTree = function PhyloTree(reduxNodes) {
     return phyloNode;
   });
   this.numberOfTips = createChildrenAndParentsReturnNumTips(this.nodes); /* side effects: d.parent, d.children */
-  calcYValues(this.nodes);
+  calcYValues(this.nodes, this.numberOfTips);
 
   this.xScale = scaleLinear();
   this.yScale = scaleLinear();

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -37,7 +37,6 @@ const PhyloTree = function PhyloTree(reduxNodes) {
     return phyloNode;
   });
   this.numberOfTips = createChildrenAndParentsReturnNumTips(this.nodes); /* side effects: d.parent, d.children */
-  calcYValues(this.nodes, this.numberOfTips);
 
   this.xScale = scaleLinear();
   this.yScale = scaleLinear();
@@ -48,6 +47,8 @@ const PhyloTree = function PhyloTree(reduxNodes) {
   this.debouncedMapToScreen = _debounce(this.mapToScreen, this.params.mapToScreenDebounceTime,
     {leading: false, trailing: true, maxWait: this.params.mapToScreenDebounceTime});
 };
+
+PhyloTree.prototype.recomputeYvaluesBasedOnVisibility = zoom.recomputeYvaluesBasedOnVisibility;
 
 /* I N I T I A L        R E N D E R       E T C */
 PhyloTree.prototype.render = renderers.render;

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -1,8 +1,7 @@
 import _debounce from "lodash/debounce";
-import { max } from "d3-array";
 import { scaleLinear } from "d3-scale";
 import { defaultParams } from "./defaultParams";
-import { addLeafCount, createChildrenAndParents } from "./helpers";
+import { addLeafCount, createChildrenAndParents, calcYValues } from "./helpers";
 
 /* PROTOTYPES */
 import * as renderers from "./renderers";
@@ -38,6 +37,8 @@ const PhyloTree = function PhyloTree(reduxNodes) {
     return phyloNode;
   });
   this.numberOfTips = createChildrenAndParents(this.nodes); /* side effects: d.parent, d.children, d.yRange */
+  calcYValues(this.nodes);
+
   this.xScale = scaleLinear();
   this.yScale = scaleLinear();
   this.zoomNode = this.nodes[0];

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -37,8 +37,7 @@ const PhyloTree = function PhyloTree(reduxNodes) {
     d.shell = phyloNode; /* set the link from the redux node to the phylotree node */
     return phyloNode;
   });
-  this.numberOfTips = max(this.nodes.map((d) => d.n.yvalue)); // total number of tips (we kinda cheat by finding the maximal yvalue, made by augur)
-  createChildrenAndParents(this.nodes);
+  this.numberOfTips = createChildrenAndParents(this.nodes); /* side effects: d.parent, d.children, d.yRange */
   this.xScale = scaleLinear();
   this.yScale = scaleLinear();
   this.zoomNode = this.nodes[0];

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -68,24 +68,22 @@ export const render = function render(svg, layout, distance, options, callbacks,
  * @return {null}
  */
 export const drawVaccines = function drawVaccines() {
-  this.svg.append("g").selectAll(".vaccine")
+  this.svg.append("g").selectAll(".vaccineCross")
     .data(this.vaccines)
     .enter()
-    .append("text")
+    .append("path")
     .attr("class", "vaccineCross")
-    .attr("x", (d) => d.xTipCross)
-    .attr("y", (d) => d.yTip)
-    .attr('text-anchor', 'middle')
-    .attr('dominant-baseline', 'central')
-    .style("font-family", this.params.fontFamily)
-    .style("font-size", "20px")
-    .style("stroke", "#fff")
-    .style("fill", darkGrey)
-    .text('\u2716');
-  // .style("cursor", "pointer")
-  // .on("mouseover", (d) => console.warn("vaccine mouseover", d));
+    .attr("d", (d) => d.vaccineCross)
+    .style("stroke", "black")
+    .style("stroke-width", 2 * this.params.branchStrokeWidth)
+    .style("fill", "none")
+    .style("cursor", "pointer")
+    .style("pointer-events", "auto")
+    .on("mouseover", (d) => this.callbacks.onTipHover(d, event.pageX, event.pageY))
+    .on("mouseout", (d) => this.callbacks.onTipLeave(d))
+    .on("click", (d) => this.callbacks.onTipClick(d));
 
-  this.svg.append("g").selectAll('.branch')
+  this.svg.append("g").selectAll('.vaccineDottedLine')
     .data(this.vaccines)
     .enter()
     .append("path")
@@ -94,9 +92,9 @@ export const drawVaccines = function drawVaccines() {
     .style("stroke-dasharray", "5, 5")
     // .style("stroke", (d) => d.stroke || this.params.branchStroke)
     .style("stroke", "black")
-    .style("stroke-width", (d) => d['stroke-width'] || this.params.branchStrokeWidth)
+    .style("stroke-width", this.params.branchStrokeWidth)
     .style("fill", "none")
-    .style("pointer-events", "none")
+    .style("pointer-events", "none");
 };
 
 

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -1,5 +1,6 @@
 import { darkGrey } from "../../../globalStyles";
 import { timerStart, timerEnd } from "../../../util/perf";
+import { calcYValues } from "./helpers";
 
 /**
  * @param  svg    -- the svg into which the tree is drawn
@@ -23,6 +24,7 @@ export const render = function render(svg, layout, distance, options, callbacks,
   this.clearSVG();
 
   /* set x, y values & scale them to the screen */
+  calcYValues(this.nodes, "visibility", this.numberOfTips, visibility);
   this.setDistance(distance);
   this.setLayout(layout);
   this.mapToScreen();

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -31,7 +31,7 @@ export const render = function render(svg, layout, distance, options, callbacks,
   if (this.params.showGrid) this.addGrid();
   if (this.params.branchLabels) this.drawBranches();
   this.drawTips();
-  if (this.params.showVaccines) this.drawVaccines();
+  if (this.vaccines) this.drawVaccines();
   this.drawCladeLabels();
 
   if (visibility) {
@@ -68,11 +68,11 @@ export const render = function render(svg, layout, distance, options, callbacks,
  * @return {null}
  */
 export const drawVaccines = function drawVaccines() {
-  this.tipElements = this.svg.append("g").selectAll(".vaccine")
+  this.svg.append("g").selectAll(".vaccine")
     .data(this.vaccines)
     .enter()
     .append("text")
-    .attr("class", "vaccine")
+    .attr("class", "vaccineCross")
     .attr("x", (d) => d.xTipCross)
     .attr("y", (d) => d.yTip)
     .attr('text-anchor', 'middle')
@@ -84,6 +84,19 @@ export const drawVaccines = function drawVaccines() {
     .text('\u2716');
   // .style("cursor", "pointer")
   // .on("mouseover", (d) => console.warn("vaccine mouseover", d));
+
+  this.svg.append("g").selectAll('.branch')
+    .data(this.vaccines)
+    .enter()
+    .append("path")
+    .attr("class", "vaccineDottedLine")
+    .attr("d", (d) => d.vaccineLine)
+    .style("stroke-dasharray", "5, 5")
+    // .style("stroke", (d) => d.stroke || this.params.branchStroke)
+    .style("stroke", "black")
+    .style("stroke-width", (d) => d['stroke-width'] || this.params.branchStrokeWidth)
+    .style("fill", "none")
+    .style("pointer-events", "none")
 };
 
 
@@ -94,7 +107,7 @@ export const drawVaccines = function drawVaccines() {
 export const drawTips = function drawTips() {
   timerStart("drawTips");
   const params = this.params;
-  this.tipElements = this.svg.append("g").selectAll(".tip")
+  this.svg.append("g").selectAll(".tip")
     .data(this.nodes.filter((d) => d.terminal))
     .enter()
     .append("circle")

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -73,7 +73,7 @@ export const drawVaccines = function drawVaccines() {
     .enter()
     .append("text")
     .attr("class", "vaccine")
-    .attr("x", (d) => d.xTip)
+    .attr("x", (d) => d.xTipCross)
     .attr("y", (d) => d.yTip)
     .attr('text-anchor', 'middle')
     .attr('dominant-baseline', 'central')

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -12,7 +12,7 @@ import { timerStart, timerEnd } from "../../../util/perf";
  * @return {null}
  */
 export const render = function render(svg, layout, distance, options, callbacks, branchThickness, visibility, drawConfidence, vaccines) {
-  timerStart("phyloTree render");
+  timerStart("phyloTree render()");
   if (branchThickness) {
     this.nodes.forEach((d, i) => {d["stroke-width"] = branchThickness[i];});
   }
@@ -21,19 +21,19 @@ export const render = function render(svg, layout, distance, options, callbacks,
   this.callbacks = callbacks;
   this.vaccines = vaccines ? vaccines.map((d) => d.shell) : undefined;
   this.clearSVG();
-  timerStart("setDistance"); this.setDistance(distance); timerEnd("setDistance");
 
-  timerStart("setLayout"); this.setLayout(layout); timerEnd("setLayout");
-
+  /* set x, y values & scale them to the screen */
+  this.setDistance(distance);
+  this.setLayout(layout);
   this.mapToScreen();
 
-  if (this.params.showGrid) {timerStart("addGrid"); this.addGrid(); timerEnd("addGrid");}
-  if (this.params.branchLabels) {timerStart("drawBranches"); this.drawBranches(); timerEnd("drawBranches");}
-
-  timerStart("drawTips"); this.drawTips(); timerEnd("drawTips");
-
-  if (this.params.showVaccines) {this.drawVaccines();}
+  /* draw functions */
+  if (this.params.showGrid) this.addGrid();
+  if (this.params.branchLabels) this.drawBranches();
+  this.drawTips();
+  if (this.params.showVaccines) this.drawVaccines();
   this.drawCladeLabels();
+
   if (visibility) {
     timerStart("setVisibility");
     this.nodes.forEach((d, i) => {d["visibility"] = visibility[i];});
@@ -51,7 +51,7 @@ export const render = function render(svg, layout, distance, options, callbacks,
   //   this.updateTipLabels(100);
   // }
 
-  timerStart("updateGeometry"); this.updateGeometry(10); timerEnd("updateGeometry");
+  this.updateGeometry(10);
 
   this.svg.selectAll(".regression").remove();
   if (this.layout === "clock" && this.distance === "num_date") {
@@ -60,7 +60,7 @@ export const render = function render(svg, layout, distance, options, callbacks,
   if (drawConfidence) {
     this.drawConfidence();
   }
-  timerEnd("phyloTree render");
+  timerEnd("phyloTree render()");
 };
 
 /**
@@ -92,6 +92,7 @@ export const drawVaccines = function drawVaccines() {
  * @return {null}
  */
 export const drawTips = function drawTips() {
+  timerStart("drawTips");
   const params = this.params;
   this.tipElements = this.svg.append("g").selectAll(".tip")
     .data(this.nodes.filter((d) => d.terminal))
@@ -110,6 +111,7 @@ export const drawTips = function drawTips() {
     .style("stroke", (d) => d.stroke || params.tipStroke)
     .style("stroke-width", () => params.tipStrokeWidth) /* don't want branch thicknesses applied */
     .style("cursor", "pointer");
+  timerEnd("drawTips");
 };
 
 
@@ -118,6 +120,7 @@ export const drawTips = function drawTips() {
  * @return {null}
  */
 export const drawBranches = function drawBranches() {
+  timerStart("drawBranches");
   const params = this.params;
   this.Tbranches = this.svg.append("g").selectAll('.branch')
     .data(this.nodes.filter((d) => !d.terminal))
@@ -147,6 +150,7 @@ export const drawBranches = function drawBranches() {
     .on("mouseover", (d) => this.callbacks.onBranchHover(d, event.pageX, event.pageY))
     .on("mouseout", (d) => this.callbacks.onBranchLeave(d))
     .on("click", (d) => this.callbacks.onBranchClick(d));
+  timerEnd("drawBranches");
 };
 
 

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -25,7 +25,7 @@ export const render = function render(svg, layout, distance, options, callbacks,
 
   timerStart("setLayout"); this.setLayout(layout); timerEnd("setLayout");
 
-  timerStart("mapToScreen"); this.mapToScreen(); timerEnd("mapToScreen");
+  this.mapToScreen();
 
   if (this.params.showGrid) {timerStart("addGrid"); this.addGrid(); timerEnd("addGrid");}
   if (this.params.branchLabels) {timerStart("drawBranches"); this.drawBranches(); timerEnd("drawBranches");}

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -99,9 +99,10 @@ export const mapToScreen = function mapToScreen() {
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
       const n = 5; /* half the number of pixels that the cross will take up */
-      d.xTipCross = this.xScale(d.xCross); /* x position of the center of the cross */
-      d.vaccineCross = ` M ${d.xTipCross-n},${d.yTip-n} L ${d.xTipCross+n},${d.yTip+n} M ${d.xTipCross-n},${d.yTip+n} L ${d.xTipCross+n},${d.yTip-n}`;
-      d.vaccineLine = ` M ${d.xTip},${d.yTip} L ${d.xTipCross},${d.yTip}`;
+      const xTipCross = this.xScale(d.xCross); /* x position of the center of the cross */
+      const yTipCross = this.yScale(d.yCross); /* x position of the center of the cross */
+      d.vaccineCross = ` M ${xTipCross-n},${yTipCross-n} L ${xTipCross+n},${yTipCross+n} M ${xTipCross-n},${yTipCross+n} L ${xTipCross+n},${yTipCross-n}`;
+      d.vaccineLine = ` M ${d.xTip},${d.yTip} L ${xTipCross},${yTipCross}`;
     });
   }
   if (this.params.confidence && this.layout==="rect") {

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -84,6 +84,7 @@ export const mapToScreen = function mapToScreen() {
   const tmp_xScale=this.xScale;
   const tmp_yScale=this.yScale;
   this.nodes.forEach((d) => {d.xTip = tmp_xScale(d.x);});
+  if (this.vaccines) this.vaccines.forEach((d) => {d.xTipCross = tmp_xScale(d.xCross);});
   this.nodes.forEach((d) => {d.yTip = tmp_yScale(d.y);});
   this.nodes.forEach((d) => {d.xBase = tmp_xScale(d.px);});
   this.nodes.forEach((d) => {d.yBase = tmp_yScale(d.py);});

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -98,7 +98,9 @@ export const mapToScreen = function mapToScreen() {
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
-      d.xTipCross = this.xScale(d.xCross);
+      const n = 5; /* half the number of pixels that the cross will take up */
+      d.xTipCross = this.xScale(d.xCross); /* x position of the center of the cross */
+      d.vaccineCross = ` M ${d.xTipCross-n},${d.yTip-n} L ${d.xTipCross+n},${d.yTip+n} M ${d.xTipCross-n},${d.yTip+n} L ${d.xTipCross+n},${d.yTip-n}`;
       d.vaccineLine = ` M ${d.xTip},${d.yTip} L ${d.xTipCross},${d.yTip}`;
     });
   }

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -96,7 +96,12 @@ export const mapToScreen = function mapToScreen() {
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
   });
-  if (this.vaccines) this.vaccines.forEach((d) => {d.xTipCross = this.xScale(d.xCross);});
+  if (this.vaccines) {
+    this.vaccines.forEach((d) => {
+      d.xTipCross = this.xScale(d.xCross);
+      d.vaccineLine = ` M ${d.xTip},${d.yTip} L ${d.xTipCross},${d.yTip}`;
+    });
+  }
   if (this.params.confidence && this.layout==="rect") {
     this.nodes.forEach((d) => {d.xConf = [this.xScale(d.conf[0]), this.xScale(d.conf[1])];});
   }
@@ -111,12 +116,8 @@ export const mapToScreen = function mapToScreen() {
       const stem_offset = 0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0;
       const childrenY = [this.yScale(d.yRange[0]), this.yScale(d.yRange[1])];
       d.branch =[` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip} M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`];
+      if (this.params.confidence) d.confLine =` M ${d.xConf[0]},${d.yBase} L ${d.xConf[1]},${d.yTip}`;
     });
-    if (this.params.confidence) {
-      this.nodes.forEach((d) => {
-        d.confLine =` M ${d.xConf[0]},${d.yBase} L ${d.xConf[1]},${d.yTip}`;
-      });
-    }
   } else if (this.layout==="radial") {
     const offset = this.nodes[0].depth;
     const stem_offset_radial = this.nodes.map((d) => {return (0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0);});

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -52,6 +52,12 @@ export const zoomToParent = function zoomToParent(dt) {
   }
 };
 
+export const recomputeYvaluesBasedOnVisibility = function recomputeYvaluesBasedOnVisibility(visibility) {
+  console.log("recomputeYvaluesBasedOnVisibility");
+  calcYValues(this.nodes, "visibility", this.numberOfTips, visibility);
+  this.setLayout(this.layout);
+};
+
 
 /**
 * this function sets the xScale, yScale domains and maps precalculated x,y
@@ -60,10 +66,12 @@ export const zoomToParent = function zoomToParent(dt) {
 */
 export const mapToScreen = function mapToScreen() {
   timerStart("mapToScreen");
+  console.log("mapToScreen")
   /* set the range of the x & y scales */
   this.setScales(this.params.margins);
 
   /* find minimum & maximum x & y values, as well as # tips in view */
+  /* TODO if we use the y-axis compression, these values can be hardcoded as "everthings" in view */
   this.nNodesInView = 0;
   let [minY, maxY, minX, maxX] = [1000000, 0, 1000000, 0];
   this.nodes.forEach((d) => {

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -1,6 +1,6 @@
 /* eslint-disable space-infix-ops */
-import { min, max } from "d3-array";
-import { applyToChildren } from "./helpers";
+import { max } from "d3-array";
+import { applyToChildren, calcYValues } from "./helpers";
 import { timerStart, timerEnd } from "../../../util/perf";
 
 /**
@@ -10,6 +10,7 @@ import { timerStart, timerEnd } from "../../../util/perf";
  * @return {null}
  */
 export const zoomIntoClade = function zoomIntoClade(clade, dt) {
+  timerStart("zoomIntoClade");
   // assign all nodes to inView false and force update
   this.zoomNode = clade;
   this.nodes.forEach((d) => {
@@ -23,6 +24,10 @@ export const zoomIntoClade = function zoomIntoClade(clade, dt) {
   } else {
     applyToChildren(clade, (d) => {d.inView = true;});
   }
+
+  calcYValues(this.nodes, "inView", this.numberOfTips);
+  this.setLayout(this.layout);
+
   // redraw
   this.mapToScreen();
   this.updateGeometry(dt);
@@ -33,6 +38,7 @@ export const zoomIntoClade = function zoomIntoClade(clade, dt) {
     this.updateBranchLabels(dt);
   }
   this.updateTipLabels(dt);
+  timerEnd("zoomIntoClade");
 };
 
 /**
@@ -60,7 +66,7 @@ export const mapToScreen = function mapToScreen() {
   /* find minimum & maximum x & y values, as well as # tips in view */
   this.nNodesInView = 0;
   let [minY, maxY, minX, maxX] = [1000000, 0, 1000000, 0];
-  this.nodes.filter((d) => d.inView).forEach((d) => {
+  this.nodes.forEach((d) => {
     if (d.x > maxX) maxX = d.x;
     if (d.y > maxY) maxY = d.y;
     if (d.x < minX) minX = d.x;

--- a/src/components/tree/phyloTree/zoom.js
+++ b/src/components/tree/phyloTree/zoom.js
@@ -1,6 +1,7 @@
 /* eslint-disable space-infix-ops */
 import { min, max } from "d3-array";
 import { applyToChildren } from "./helpers";
+import { timerStart, timerEnd } from "../../../util/perf";
 
 /**
  * zoom such that a particular clade fills the svg
@@ -52,20 +53,28 @@ export const zoomToParent = function zoomToParent(dt) {
 * @return {null}
 */
 export const mapToScreen = function mapToScreen() {
+  timerStart("mapToScreen");
+  /* set the range of the x & y scales */
   this.setScales(this.params.margins);
-  // determine x,y values of visibile nodes
-  const tmp_xValues = this.nodes.filter((d) => {return d.inView;}).map((d) => d.x);
-  const tmp_yValues = this.nodes.filter((d) => {return d.inView;}).map((d) => d.y);
-  this.nNodesInView = this.nodes.filter((d) => {return d.inView && d.terminal;}).length;
 
+  /* find minimum & maximum x & y values, as well as # tips in view */
+  this.nNodesInView = 0;
+  let [minY, maxY, minX, maxX] = [1000000, 0, 1000000, 0];
+  this.nodes.filter((d) => d.inView).forEach((d) => {
+    if (d.x > maxX) maxX = d.x;
+    if (d.y > maxY) maxY = d.y;
+    if (d.x < minX) minX = d.x;
+    if (d.y < minY) minY = d.y;
+    if (d.terminal) this.nNodesInView++;
+  });
+
+  /* set the domain of the x & y scales */
   if (this.layout === "radial" || this.layout === "unrooted") {
     // handle "radial and unrooted differently since they need to be square
     // since branch length move in x and y direction
     // TODO: should be tied to svg dimensions
-    const minX = min(tmp_xValues);
-    const minY = min(tmp_yValues);
-    const spanX = max(tmp_xValues)-minX;
-    const spanY = max(tmp_yValues)-minY;
+    const spanX = maxX-minX;
+    const spanY = maxY-minY;
     const maxSpan = max([spanY, spanX]);
     const ySlack = (spanX>spanY) ? (spanX-spanY)*0.5 : 0.0;
     const xSlack = (spanX<spanY) ? (spanY-spanX)*0.5 : 0.0;
@@ -73,23 +82,23 @@ export const mapToScreen = function mapToScreen() {
     this.yScale.domain([minY-ySlack, minY+maxSpan-ySlack]);
   } else if (this.layout==="clock") {
     // same as rectangular, but flipped yscale
-    this.xScale.domain([min(tmp_xValues), max(tmp_xValues)]);
-    this.yScale.domain([max(tmp_yValues), min(tmp_yValues)]);
+    this.xScale.domain([minX, maxX]);
+    this.yScale.domain([maxY, minY]);
   } else { // rectangular
-    this.xScale.domain([min(tmp_xValues), max(tmp_xValues)]);
-    this.yScale.domain([min(tmp_yValues), max(tmp_yValues)]);
+    this.xScale.domain([minX, maxX]);
+    this.yScale.domain([minY, maxY]);
   }
 
   // pass all x,y through scales and assign to xTip, xBase
-  const tmp_xScale=this.xScale;
-  const tmp_yScale=this.yScale;
-  this.nodes.forEach((d) => {d.xTip = tmp_xScale(d.x);});
-  if (this.vaccines) this.vaccines.forEach((d) => {d.xTipCross = tmp_xScale(d.xCross);});
-  this.nodes.forEach((d) => {d.yTip = tmp_yScale(d.y);});
-  this.nodes.forEach((d) => {d.xBase = tmp_xScale(d.px);});
-  this.nodes.forEach((d) => {d.yBase = tmp_yScale(d.py);});
+  this.nodes.forEach((d) => {
+    d.xTip = this.xScale(d.x);
+    d.yTip = this.yScale(d.y);
+    d.xBase = this.xScale(d.px);
+    d.yBase = this.yScale(d.py);
+  });
+  if (this.vaccines) this.vaccines.forEach((d) => {d.xTipCross = this.xScale(d.xCross);});
   if (this.params.confidence && this.layout==="rect") {
-    this.nodes.forEach((d) => {d.xConf = [tmp_xScale(d.conf[0]), tmp_xScale(d.conf[1])];});
+    this.nodes.forEach((d) => {d.xConf = [this.xScale(d.conf[0]), this.xScale(d.conf[1])];});
   }
 
   // assign the branches as path to each node for the different layouts
@@ -98,26 +107,21 @@ export const mapToScreen = function mapToScreen() {
       d.branch = [" M "+d.xBase.toString()+","+d.yBase.toString()+" L "+d.xTip.toString()+","+d.yTip.toString(), ""];
     });
   } else if (this.layout==="rect") {
-    this.nodes.forEach((d) => {d.cBarStart = tmp_yScale(d.yRange[0]);});
-    this.nodes.forEach((d) => {d.cBarEnd = tmp_yScale(d.yRange[1]);});
-    const stem_offset = this.nodes.map((d) => {return (0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0);});
-    this.nodes.forEach((d, i) => {
-      d.branch =[" M "+(d.xBase - stem_offset[i]).toString()
-      +","+d.yBase.toString()+
-      " L "+d.xTip.toString()+","+d.yTip.toString(),
-      " M "+d.xTip.toString()+","+d.cBarStart.toString()+
-      " L "+d.xTip.toString()+","+d.cBarEnd.toString()];
+    this.nodes.forEach((d) => {
+      const stem_offset = 0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0;
+      const childrenY = [this.yScale(d.yRange[0]), this.yScale(d.yRange[1])];
+      d.branch =[` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip} M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`];
     });
     if (this.params.confidence) {
       this.nodes.forEach((d) => {
-        d.confLine =" M "+d.xConf[0].toString()+","+d.yBase.toString()+" L "+d.xConf[1].toString()+","+d.yTip.toString();
+        d.confLine =` M ${d.xConf[0]},${d.yBase} L ${d.xConf[1]},${d.yTip}`;
       });
     }
   } else if (this.layout==="radial") {
     const offset = this.nodes[0].depth;
     const stem_offset_radial = this.nodes.map((d) => {return (0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0);});
-    this.nodes.forEach((d) => {d.cBarStart = tmp_yScale(d.yRange[0]);});
-    this.nodes.forEach((d) => {d.cBarEnd = tmp_yScale(d.yRange[1]);});
+    this.nodes.forEach((d) => {d.cBarStart = this.yScale(d.yRange[0]);});
+    this.nodes.forEach((d) => {d.cBarEnd = this.yScale(d.yRange[1]);});
     this.nodes.forEach((d, i) => {
       d.branch =[
         " M "+(d.xBase-stem_offset_radial[i]*Math.sin(d.angle)).toString()
@@ -125,12 +129,13 @@ export const mapToScreen = function mapToScreen() {
         + " L "+d.xTip.toString()+" "+d.yTip.toString(), ""
       ];
       if (!d.terminal) {
-        d.branch[1] =[" M "+tmp_xScale(d.xCBarStart).toString()+" "+tmp_yScale(d.yCBarStart).toString()+
-        " A "+(tmp_xScale(d.depth)-tmp_xScale(offset)).toString()+" "
-        +(tmp_yScale(d.depth)-tmp_yScale(offset)).toString()
+        d.branch[1] =[" M "+this.xScale(d.xCBarStart).toString()+" "+this.yScale(d.yCBarStart).toString()+
+        " A "+(this.xScale(d.depth)-this.xScale(offset)).toString()+" "
+        +(this.yScale(d.depth)-this.yScale(offset)).toString()
         +" 0 "+(d.smallBigArc?"1 ":"0 ") +" 1 "+
-        " "+tmp_xScale(d.xCBarEnd).toString()+","+tmp_yScale(d.yCBarEnd).toString()];
+        " "+this.xScale(d.xCBarEnd).toString()+","+this.yScale(d.yCBarEnd).toString()];
       }
     });
   }
+  timerEnd("mapToScreen");
 };

--- a/src/components/tree/reactD3Interface/index.js
+++ b/src/components/tree/reactD3Interface/index.js
@@ -69,7 +69,10 @@ export const updateStylesAndAttrs = (that, changes, nextProps, tree) => {
   const branchAttrToUpdate = {};
   const branchStyleToUpdate = {};
 
+  console.log("\n** react-D3 interface **\n\n");
+
   if (changes.visibility) {
+    tree.recomputeYvaluesBasedOnVisibility(nextProps.tree.visibility);
     tipStyleToUpdate["visibility"] = nextProps.tree.visibility;
   }
   if (changes.tipRadii) {
@@ -125,5 +128,8 @@ export const updateStylesAndAttrs = (that, changes, nextProps, tree) => {
   }
   if (changes.rerenderAllElements) {
     tree.rerenderAllElements();
+  }
+  if (changes.visibility) {
+    tree.updateGeometry(700, true);
   }
 };

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -354,11 +354,14 @@ export const processVaccines = (nodes, vaccineChoices) => {
  * side-effects: node.hasChildren (bool) and node.arrayIdx (INT) for each node in nodes
  */
 export const processNodes = (nodes) => {
+  console.time("processNodes")
   const rootNode = nodes[0];
   nodes.forEach((d) => {if (typeof d.attr === "undefined") {d.attr = {};} });
   calcFullTipCounts(rootNode);
   nodes.forEach((d) => {d.hasChildren = typeof d.children !== "undefined";});
   /* set an index so that we can access visibility / nodeColors if needed */
   nodes.forEach((d, idx) => {d.arrayIdx = idx;});
+  nodes.forEach((d) => {d.yvalue = undefined; /* calculate later in auspice */});
+  console.timeEnd("processNodes")
   return nodes;
 };

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -354,14 +354,12 @@ export const processVaccines = (nodes, vaccineChoices) => {
  * side-effects: node.hasChildren (bool) and node.arrayIdx (INT) for each node in nodes
  */
 export const processNodes = (nodes) => {
-  console.time("processNodes")
-  const rootNode = nodes[0];
-  nodes.forEach((d) => {if (typeof d.attr === "undefined") {d.attr = {};} });
-  calcFullTipCounts(rootNode);
-  nodes.forEach((d) => {d.hasChildren = typeof d.children !== "undefined";});
-  /* set an index so that we can access visibility / nodeColors if needed */
-  nodes.forEach((d, idx) => {d.arrayIdx = idx;});
-  nodes.forEach((d) => {d.yvalue = undefined; /* calculate later in auspice */});
-  console.timeEnd("processNodes")
+  calcFullTipCounts(nodes[0]);
+  nodes.forEach((d, idx) => {
+    if (typeof d.attr === "undefined") d.attr = {};
+    d.arrayIdx = idx; /* set an index so that we can access visibility / nodeColors if needed */
+    d.hasChildren = typeof d.children !== "undefined";
+    d.yvalue = undefined; /* calculate later in auspice */
+  });
   return nodes;
 };

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -2,6 +2,7 @@ import { rgb } from "d3-color";
 import { interpolateRgb } from "d3-interpolate";
 import { scalePow } from "d3-scale";
 import { tipRadius, freqScale, tipRadiusOnLegendMatch } from "../../util/globals";
+import { calendarToNumeric } from "../../util/dateHelpers";
 
 /**
 *  For each node visit if node not a hashMap key, insert
@@ -336,7 +337,10 @@ export const processVaccines = (nodes, vaccineChoices) => {
   if (!vaccineChoices) {return false;}
   const names = Object.keys(vaccineChoices);
   const vaccines = nodes.filter((d) => names.indexOf(d.strain) !== -1);
-  vaccines.forEach((d) => {d.vaccineDate = vaccineChoices[d.strain];});
+  vaccines.forEach((d) => {
+    d.vaccineDate = vaccineChoices[d.strain];
+    d.vaccineDateNumeric = calendarToNumeric(vaccineChoices[d.strain]);
+  });
   return vaccines;
 };
 


### PR DESCRIPTION
This PR contains some ideas that I would like to pursue regarding how subsetted data from big trees are visualised. The idea is that tips which are visible (i.e. filtered, or clade zoomed in) are given a larger amount of vertical space, but the rest of the tree is still visible. (This idea isn't new - see Tamara Munzner's work here http://www.cs.ubc.ca/~tmm/talks/think06/ad.hackers.pdf)

Note, this is just a prototype - there are plenty of bugs, bad transitions etc. The code would have to be fine tuned before it could be merged.

* Zika tree showing just USVI sequences: https://auspice-dev.herokuapp.com/zika?f_country=usvi
* 12y flu tree showing just sequences from 2010 https://auspice-dev.herokuapp.com/flu/h3n2/ha/12y?c=num_date&dmax=2011-01-01&dmin=2010-01-01&m=num_date
* zoom to clade - click on a branch to see this effect (in any tree)
* ebola sequences from Tong et al. https://auspice-dev.herokuapp.com/ebola?f_authors=Tong_et_al

cc @rneher @trvrb 