### PR TITLE
Style tip stroke separately from branch stroke

### DIFF
--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -12,7 +12,7 @@ import HoverInfoPanel from "./infoPanels/hover";
 import TipClickedPanel from "./infoPanels/click";
 import { changePhyloTreeViaPropsComparison } from "./reactD3Interface";
 import * as callbacks from "./reactD3Interface/callbacks";
-import { calcStrokeCols } from "./treeHelpers";
+import { calcBranchStrokeCols } from "./treeHelpers";
 import { darkGrey, dataFont } from "../../globalStyles";
 
 const resetTreeButtonStyle = {
@@ -146,7 +146,8 @@ class Tree extends React.Component {
       props.tree.visibility,
       props.temporalConfidence.on, /* drawConfidence? */
       props.tree.vaccines,
-      calcStrokeCols(props.tree, props.colorByConfidence, props.colorBy),
+      calcBranchStrokeCols(props.tree, props.colorByConfidence, props.colorBy),
+      props.tree.nodeColors,
       props.tree.nodeColors.map((col) => rgb(col).brighter([0.65]).toString()),
       props.tree.tipRadii /* might be null */
     );

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -34,8 +34,8 @@ const setAttrViaNodeProps = {
   ".tip": new Set(["r"])
 };
 const setStyleViaNodeProps = {
-  ".branch": new Set(["stroke", "stroke-width"]),
-  ".tip": new Set(["fill", "visibility", "stroke"])
+  ".branch": new Set(["stroke-width"]),
+  ".tip": new Set(["fill", "visibility"])
 };
 const setAttrViaFunction = {
   ".tip": {
@@ -57,8 +57,14 @@ const setStyleViaFunction = {
     opacity: (d) => d.that.distance === "num_date" ? 1 : 0
   },
   ".conf": {
-    stroke: (d) => d.stroke,
+    stroke: (d) => d.branchStroke,
     "stroke-width": calcConfidenceWidth
+  },
+  ".branch": {
+    stroke: (d) => d.branchStroke
+  },
+  ".tip": {
+    stroke: (d) => d.tipStroke
   }
 };
 
@@ -91,7 +97,7 @@ const createUpdateCall = (treeElem, properties) => (selection) => {
   if (setStyleViaFunction[treeElem]) {
     [...properties].filter((x) => setStyleViaFunction[treeElem][x])
       .forEach((styleName) => {
-        selection.attr(styleName, setStyleViaFunction[treeElem][styleName]);
+        selection.style(styleName, setStyleViaFunction[treeElem][styleName]);
       });
   }
 };
@@ -245,7 +251,8 @@ export const change = function change({
   newLayout = undefined,
   newBranchLabellingKey = undefined,
   /* arrays of data (the same length as nodes) */
-  stroke = undefined,
+  branchStroke = undefined,
+  tipStroke = undefined,
   fill = undefined,
   visibility = undefined,
   tipRadii = undefined,
@@ -271,7 +278,8 @@ export const change = function change({
     /* check that fill & stroke are defined */
     elemsToUpdate.add(".branch").add(".tip").add(".conf");
     svgPropsToUpdate.add("stroke").add("fill");
-    nodePropsToModify.stroke = stroke;
+    nodePropsToModify.branchStroke = branchStroke;
+    nodePropsToModify.tipStroke = tipStroke;
     nodePropsToModify.fill = fill;
   }
   if (changeVisibility) {

--- a/src/components/tree/phyloTree/confidence.js
+++ b/src/components/tree/phyloTree/confidence.js
@@ -39,7 +39,7 @@ export const drawSingleCI = function drawSingleCI(selection, opacity) {
     .attr("class", "conf")
     .attr("id", (d) => "conf_" + d.n.clade)
     .attr("d", (d) => d.confLine)
-    .style("stroke", (d) => d.stroke || "#888")
+    .style("stroke", (d) => d.branchStroke || "#888")
     .style("opacity", opacity)
     .style("fill", "none")
     .style("stroke-width", calcConfidenceWidth);

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -10,12 +10,13 @@ import { timerStart, timerEnd } from "../../../util/perf";
  * @param {array} visibility      -- array of "visible" or "hidden" (same shape as tree nodes)
  * @param {bool} drawConfidence   -- should confidence intervals be drawn?
  * @param {bool} vaccines         -- should vaccine crosses (and dotted lines if applicable) be drawn?
- * @param {array} stroke          -- stroke colour for each node (set onto each node)
- * @param {array} fill            -- fill colour for each node (set onto each node)
+ * @param {array} branchStroke    -- branch stroke colour for each node (set onto each node)
+ * @param {array} tipStroke       -- tip stroke colour for each node (set onto each node)
+ * @param {array} tipFill         -- tip fill colour for each node (set onto each node)
  * @param {array|null} tipRadii   -- array of tip radius'
  * @return {null}
  */
-export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, stroke, fill, tipRadii) {
+export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, branchStroke, tipStroke, tipFill, tipRadii) {
   timerStart("phyloTree render()");
   this.svg = svg;
   this.params = Object.assign(this.params, parameters);
@@ -29,8 +30,9 @@ export const render = function render(svg, layout, distance, parameters, callbac
 
   /* set nodes stroke / fill */
   this.nodes.forEach((d, i) => {
-    d.stroke = stroke[i];
-    d.fill = fill[i];
+    d.branchStroke = branchStroke[i];
+    d.tipStroke = tipStroke[i];
+    d.tipFill = tipFill[i];
     d.visibility = visibility[i];
     d["stroke-width"] = branchThickness[i];
     d.r = tipRadii ? tipRadii[i] : this.params.tipRadius;
@@ -106,8 +108,8 @@ export const drawTips = function drawTips() {
     .on("click", (d) => this.callbacks.onTipClick(d))
     .style("pointer-events", "auto")
     .style("visibility", (d) => d["visibility"])
-    .style("fill", (d) => d.fill || params.tipFill)
-    .style("stroke", (d) => d.stroke || params.tipStroke)
+    .style("fill", (d) => d.tipFill || params.tipFill)
+    .style("stroke", (d) => d.tipStroke || params.tipStroke)
     .style("stroke-width", () => params.tipStrokeWidth) /* don't want branch thicknesses applied */
     .style("cursor", "pointer");
   timerEnd("drawTips");
@@ -128,7 +130,7 @@ export const drawBranches = function drawBranches() {
     .attr("class", "branch T")
     .attr("id", (d) => "branch_T_" + d.n.clade)
     .attr("d", (d) => d.branch[1])
-    .style("stroke", (d) => d.stroke || params.branchStroke)
+    .style("stroke", (d) => d.branchStroke || params.branchStroke)
     .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
     .style("fill", "none")
     .style("pointer-events", "auto");
@@ -140,7 +142,7 @@ export const drawBranches = function drawBranches() {
     .attr("class", "branch S")
     .attr("id", (d) => "branch_S_" + d.n.clade)
     .attr("d", (d) => d.branch[0])
-    .style("stroke", (d) => d.stroke || params.branchStroke)
+    .style("stroke", (d) => d.branchStroke || params.branchStroke)
     .style("stroke-linecap", "round")
     .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
     .style("fill", "none")

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -79,7 +79,6 @@ export const drawVaccines = function drawVaccines() {
     .attr("class", "vaccineDottedLine")
     .attr("d", (d) => d.vaccineLine)
     .style("stroke-dasharray", "5, 5")
-    // .style("stroke", (d) => d.stroke || this.params.branchStroke)
     .style("stroke", "black")
     .style("stroke-width", this.params.branchStrokeWidth)
     .style("fill", "none")

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -32,7 +32,7 @@ export const onBranchHover = function onBranchHover(d, x, y) {
         .style("stroke", (el) => { // eslint-disable-line no-loop-func
           const ramp = branchOpacityFunction(this.props.tree.nodes[el.n.arrayIdx].attr[this.props.colorBy + "_entropy"]);
           const raw = this.props.tree.nodeColors[el.n.arrayIdx];
-          const base = el["stroke"];
+          const base = el.branchStroke;
           return rgb(interpolateRgb(raw, base)(ramp)).toString();
         });
     } else {
@@ -59,7 +59,7 @@ export const onBranchClick = function onBranchClick(d) {
 export const onBranchLeave = function onBranchLeave(d) {
   for (const id of ["#branch_T_" + d.n.clade, "#branch_S_" + d.n.clade]) {
     this.state.tree.svg.select(id)
-      .style("stroke", (el) => el["stroke"]);
+      .style("stroke", (el) => el.branchStroke);
   }
   if (this.props.temporalConfidence.exists && this.props.temporalConfidence.display && !this.props.temporalConfidence.on) {
     this.state.tree.removeConfidence(mediumTransitionDuration);

--- a/src/components/tree/reactD3Interface/index.js
+++ b/src/components/tree/reactD3Interface/index.js
@@ -1,5 +1,5 @@
 import { rgb } from "d3-color";
-import { calcStrokeCols } from "../treeHelpers";
+import { calcBranchStrokeCols } from "../treeHelpers";
 
 export const changePhyloTreeViaPropsComparison = (reactThis, nextProps) => {
   const args = {};
@@ -17,7 +17,7 @@ export const changePhyloTreeViaPropsComparison = (reactThis, nextProps) => {
       (props.tree.nodeColorsVersion !== nextProps.tree.nodeColorsVersion ||
       nextProps.colorByConfidence !== props.colorByConfidence)) {
     args.changeColorBy = true;
-    args.stroke = calcStrokeCols(nextProps.tree, nextProps.colorByConfidence, nextProps.colorBy);
+    args.stroke = calcBranchStrokeCols(nextProps.tree, nextProps.colorByConfidence, nextProps.colorBy);
     args.fill = nextProps.tree.nodeColors.map((col) => rgb(col).brighter([0.65]).toString());
   }
 

--- a/src/components/tree/reactD3Interface/index.js
+++ b/src/components/tree/reactD3Interface/index.js
@@ -17,7 +17,8 @@ export const changePhyloTreeViaPropsComparison = (reactThis, nextProps) => {
       (props.tree.nodeColorsVersion !== nextProps.tree.nodeColorsVersion ||
       nextProps.colorByConfidence !== props.colorByConfidence)) {
     args.changeColorBy = true;
-    args.stroke = calcBranchStrokeCols(nextProps.tree, nextProps.colorByConfidence, nextProps.colorBy);
+    args.branchStroke = calcBranchStrokeCols(nextProps.tree, nextProps.colorByConfidence, nextProps.colorBy);
+    args.tipStroke = nextProps.tree.nodeColors;
     args.fill = nextProps.tree.nodeColors.map((col) => rgb(col).brighter([0.65]).toString());
   }
 

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -300,7 +300,7 @@ export const calcVisibility = (tree, controls, dates) => {
 };
 
 const branchInterpolateColour = "#BBB";
-const branchOpacityConstant = 0.4;
+const branchOpacityConstant = 0.6;
 export const branchOpacityFunction = scalePow()
   .exponent([0.3])
   .domain([0, 1])
@@ -318,7 +318,7 @@ export const branchOpacityFunction = scalePow()
  * @param {bool} confidence enabled?
  * @return {array} array of hex's. 1-1 with nodes.
  */
-export const calcStrokeCols = (tree, confidence, colorBy) => {
+export const calcBranchStrokeCols = (tree, confidence, colorBy) => {
   if (confidence === true) {
     return tree.nodeColors.map((col, idx) => {
       const entropy = tree.nodes[idx].attr[colorBy + "_entropy"];

--- a/src/components/tree/treeHelpers.js
+++ b/src/components/tree/treeHelpers.js
@@ -301,10 +301,11 @@ export const calcVisibility = (tree, controls, dates) => {
 
 const branchInterpolateColour = "#BBB";
 const branchOpacityConstant = 0.6;
+const branchOpacityLowerBound = 0.4;
 export const branchOpacityFunction = scalePow()
   .exponent([0.3])
   .domain([0, 1])
-  .range([branchOpacityConstant, 1])
+  .range([branchOpacityLowerBound, 1])
   .clamp(true);
 // entropy calculation precomputed in augur
 // export const calcEntropyOfValues = (vals) =>


### PR DESCRIPTION
Nextflu has tip stroke set to full color and branch stroke set to a grayer version. In the code here:

https://github.com/blab/nextflu/blob/master/auspice/js/auspice/colors.js#L224

I believe this makes for a significantly more distinguishable / poppy tree. Here's `master` for flu:

<img width="1009" alt="master" src="https://user-images.githubusercontent.com/1176109/36753177-48d78bb2-1bba-11e8-8a4d-593d4f7f363f.png">

And here's `tip-styles`:

<img width="1015" alt="tip-styles" src="https://user-images.githubusercontent.com/1176109/36753188-509f3480-1bba-11e8-819c-8c9fa9df7c1c.png">

The tips are not so blurred together. Also makes Zika, etc... look better.

I think this is a definite improvement. And I thought that my approach with separating existing `stroke` arrays into separate `tipStroke` and `branchStroke` arrays was the right approach. However, I got stuck when trying to modify PhyloTree.change to allow for this. I had tried using `setStyleViaFunction` without success.

@jameshadfield: Would you take a look at this at some point?