### PR TITLE
Multiple genotype color-by

### DIFF
--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -1,6 +1,6 @@
 import { parseGenotype } from "../util/getGenotype";
 import getColorScale from "../util/getColorScale";
-import { setGenotype, experimentalSetGenotype } from "../util/setGenotype";
+import { setGenotype } from "../util/setGenotype";
 import { calcNodeColor } from "../components/tree/treeHelpers";
 import { determineColorByGenotypeType } from "../util/colorHelpers";
 import { timerStart, timerEnd } from "../util/perf";
@@ -12,7 +12,7 @@ export const calcColorScaleAndNodeColors = (colorBy, controls, tree, metadata) =
   let genotype;
   if (colorBy.slice(0, 3) === "gt-" && controls.geneLength) {
     const x = parseGenotype(colorBy, controls.geneLength);
-    setGenotype(tree.nodes, x[0][0], x[0][1] + 1); /* modifies nodes recursively */
+    setGenotype(tree.nodes, x[0][0], [x[0][1] + 1]); /* modifies nodes recursively */
     genotype = parseGenotype(colorBy, controls.geneLength);
   }
 
@@ -32,7 +32,7 @@ export const experimentalChangeColorBy = (gene, positions) => (dispatch, getStat
   const colorBy = `gt-${gene}_${positions.join(',')}`;
 
   /* this is the function calcColorScaleAndNodeColors */
-  experimentalSetGenotype(tree.nodes, gene, positions); /* modifies nodes recursively */
+  setGenotype(tree.nodes, gene, positions); /* modifies nodes recursively */
   const genotype = positions.map((pos) => [gene, pos - 1]);
 
   console.log("experimentalChangeColorBy colorBy:", colorBy)

--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -1,4 +1,4 @@
-import { parseGenotype } from "../util/getGenotype";
+import { parseEncodedGenotype } from "../util/getGenotype";
 import getColorScale from "../util/getColorScale";
 import { setGenotype } from "../util/setGenotype";
 import { calcNodeColor } from "../components/tree/treeHelpers";
@@ -11,9 +11,12 @@ import * as types from "./types";
 export const calcColorScaleAndNodeColors = (colorBy, controls, tree, metadata) => {
   let genotype;
   if (colorBy.slice(0, 3) === "gt-" && controls.geneLength) {
-    const x = parseGenotype(colorBy, controls.geneLength);
-    setGenotype(tree.nodes, x[0][0], [x[0][1] + 1]); /* modifies nodes recursively */
-    genotype = parseGenotype(colorBy, controls.geneLength);
+    const x = parseEncodedGenotype(colorBy, controls.geneLength);
+    if (x.length > 1) {
+      console.warn("Cannot deal with multiple proteins yet - using first only.");
+    }
+    setGenotype(tree.nodes, x[0].prot, x[0].positions); /* modifies nodes recursively */
+    genotype = parseEncodedGenotype(colorBy, controls.geneLength);
   }
 
   /* step 1: calculate the required colour scale */
@@ -28,7 +31,6 @@ export const calcColorScaleAndNodeColors = (colorBy, controls, tree, metadata) =
 
 export const experimentalChangeColorBy = (gene, positions) => (dispatch, getState) => {
   const { controls, tree, metadata, frequencies } = getState();
-  console.log("EXP", controls.geneLength)
   const colorBy = `gt-${gene}_${positions.join(',')}`;
 
   /* this is the function calcColorScaleAndNodeColors */

--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -15,7 +15,7 @@ export const calcColorScaleAndNodeColors = (colorBy, controls, tree, metadata) =
     if (genotype.length > 1) {
       console.warn("Cannot deal with multiple proteins yet - using first only.");
     }
-    setGenotype(tree.nodes, genotype[0].prot, genotype[0].positions); /* modifies nodes recursively */
+    setGenotype(tree.nodes, genotype[0].prot || "nuc", genotype[0].positions); /* modifies nodes recursively */
   }
 
   /* step 1: calculate the required colour scale */
@@ -44,7 +44,9 @@ export const changeColorBy = (providedColorBy = undefined) => { // eslint-disabl
     const {nodeColors, colorScale, version} = calcColorScaleAndNodeColors(colorBy, controls, tree, metadata);
 
     /* step 3: change in mutType? */
-    const newMutType = determineColorByGenotypeType(colorBy) !== controls.mutType ? determineColorByGenotypeType(colorBy) : false;
+    const colorByMutType = determineColorByGenotypeType(colorBy);
+    const newMutType = colorByMutType !== controls.mutType ? colorByMutType : false;
+
     timerEnd("changeColorBy calculations"); /* end timer before dispatch */
     if (newMutType) {
       updateEntropyVisibility(dispatch, getState);

--- a/src/actions/colors.js
+++ b/src/actions/colors.js
@@ -48,12 +48,6 @@ export const changeColorBy = (providedColorBy = undefined) => { // eslint-disabl
     const newMutType = colorByMutType !== controls.mutType ? colorByMutType : false;
 
     timerEnd("changeColorBy calculations"); /* end timer before dispatch */
-    if (newMutType) {
-      updateEntropyVisibility(dispatch, getState);
-    }
-    if (frequencies.loaded) {
-      updateFrequencyDataDebounced(dispatch, getState);
-    }
 
     /* step 4: dispatch */
     dispatch({
@@ -64,6 +58,14 @@ export const changeColorBy = (providedColorBy = undefined) => { // eslint-disabl
       version,
       newMutType
     });
+
+    /* step 5 - entropy & frequency dispatches (maybe these could be combined) */
+    if (newMutType) {
+      updateEntropyVisibility(dispatch, getState);
+    }
+    if (frequencies.loaded) {
+      updateFrequencyDataDebounced(dispatch, getState);
+    }
 
     return null;
   };

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -7,6 +7,7 @@ import { getDefaultTreeState, getAttrsOnTerminalNodes } from "../reducers/tree";
 import { calculateVisiblityAndBranchThickness } from "./treeProperties";
 import { calcEntropyInView, getValuesAndCountsOfVisibleTraitsFromTree, getAllValuesAndCountsOfTraitsFromTree } from "../util/treeTraversals";
 import { calcColorScaleAndNodeColors } from "./colors";
+import { determineColorByGenotypeType } from "../util/colorHelpers";
 
 const getAnnotations = (jsonData) => {
   const annotations = [];
@@ -285,6 +286,10 @@ const checkAndCorrectErrorsInState = (state, metadata) => {
       state.temporalConfidence.on = false;
     }
   }
+
+  /* if colorBy is a genotype then we need to set mutType */
+  const maybeMutType = determineColorByGenotypeType(state.colorBy);
+  if (maybeMutType) state.mutType = maybeMutType;
 
   return state;
 };

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -134,7 +134,7 @@ class ColorBy extends React.Component {
     );
     if (!positions.length) return;
     const colorBy = "gt-" + gene + "_" + positions.join(',');
-    // console.log("setting to", colorBy)
+    console.log("setting to", colorBy)
     analyticsControlsEvent("color-by-genotype");
     this.props.dispatch(changeColorBy(colorBy));
   }

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import Select from "react-select";
 import { sidebarField } from "../../globalStyles";
 import { controlsWidth, colorByMenuPreferredOrdering } from "../../util/globals";
-import { changeColorBy } from "../../actions/colors";
+import { changeColorBy, experimentalChangeColorBy } from "../../actions/colors";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 
 /* the reason why we have colorBy as state (here) and in redux
@@ -120,6 +120,7 @@ class ColorBy extends React.Component {
           onChange={(e) => {
             const gene = this.state.geneSelected;
             const position = e.target.value;
+            console.log("gtPositionInput -> ", gene, position);
             this.setState({positionSelected: position});
             this.setGenotypeColoring(gene, position);
           }}
@@ -136,7 +137,12 @@ class ColorBy extends React.Component {
 
   setGenotypeColoring(gene, position) {
     // check if this is any sort of integer
-    if (!this.isNormalInteger(position)) {
+    if (!position) return;
+    if (position && !this.isNormalInteger(position)) {
+      console.log("INSIDE")
+      this.props.dispatch(experimentalChangeColorBy(
+        gene, position.split(',').map((x) => parseInt(x, 10)).filter((n) => !isNaN(parseFloat(n)) && isFinite(n))
+      ));
       return;
     }
     // check if integer is in range

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import Select from "react-select";
 import { sidebarField } from "../../globalStyles";
 import { controlsWidth, colorByMenuPreferredOrdering } from "../../util/globals";
-import { changeColorBy, experimentalChangeColorBy } from "../../actions/colors";
+import { changeColorBy } from "../../actions/colors";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 
 /* the reason why we have colorBy as state (here) and in redux
@@ -102,20 +102,12 @@ class ColorBy extends React.Component {
   }
 
   gtPositionInput() {
-
-    // let value = "";
-    // if (this.props.colorBy) {
-    //   if (this.props.colorBy.slice(0, 2) === "gt") {
-    //     value = this.props.colorBy.slice(3);
-    //   }
-    // }
-
     if (this.state.colorBySelected === "gt") {
       return (
         <input
           type="text"
           style={sidebarField}
-          placeholder={this.state.geneSelected + " position..."}
+          placeholder={this.state.geneSelected + " positions..."}
           value={this.state.positionSelected}
           onChange={(e) => {
             const gene = this.state.geneSelected;
@@ -136,20 +128,13 @@ class ColorBy extends React.Component {
   }
 
   setGenotypeColoring(gene, position) {
-    // check if this is any sort of integer
     if (!position) return;
-    if (position && !this.isNormalInteger(position)) {
-      console.log("INSIDE")
-      this.props.dispatch(experimentalChangeColorBy(
-        gene, position.split(',').map((x) => parseInt(x, 10)).filter((n) => !isNaN(parseFloat(n)) && isFinite(n))
-      ));
-      return;
-    }
-    // check if integer is in range
-    if (parseInt(position, 10) < 1 || parseInt(position, 10) > this.props.geneLength[gene]) {
-      return;
-    }
-    const colorBy = "gt-" + gene + "_" + position;
+    const positions = position.split(',').filter((x) =>
+      parseInt(x, 10) > 0 && parseInt(x, 10) < this.props.geneLength[gene]
+    );
+    if (!positions.length) return;
+    const colorBy = "gt-" + gene + "_" + positions.join(',');
+    // console.log("setting to", colorBy)
     analyticsControlsEvent("color-by-genotype");
     this.props.dispatch(changeColorBy(colorBy));
   }

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -134,7 +134,6 @@ class ColorBy extends React.Component {
     );
     if (!positions.length) return;
     const colorBy = "gt-" + gene + "_" + positions.join(',');
-    console.log("setting to", colorBy)
     analyticsControlsEvent("color-by-genotype");
     this.props.dispatch(changeColorBy(colorBy));
   }

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -101,6 +101,7 @@ EntropyChart.prototype._getSelectedNodes = function _getSelectedNodes(parsed) {
   }
   /* we fall through to here if the selected genotype (from URL or typed in)
   is not in the entropy data as it has no variation */
+  // console.log("get selected nodes returning", selectedNodes)
   return selectedNodes;
 };
 

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -9,6 +9,7 @@ import InfoPanel from "./infoPanel";
 import { changeMutType, showCountsNotEntropy } from "../../actions/entropy";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { timerStart, timerEnd } from "../../util/perf";
+import { parseEncodedGenotype } from "../../util/getGenotype";
 import "../../css/entropy.css";
 
 const getStyles = (width) => {
@@ -32,19 +33,10 @@ const getStyles = (width) => {
 };
 
 const constructEncodedGenotype = (aa, d) => {
+  // console.log("constructEncodedGenotype", aa, d)
+  // const gene = aa ? d.prot : "nuc";
+  // return `gt-${gene}_${d.positions.join(",")}`;
   return aa ? `gt-${d.prot}_${d.codon}` : `gt-nuc_${d.x}`;
-};
-
-export const parseEncodedGenotype = (colorBy) => {
-  const [name, num] = colorBy.slice(3).split('_');
-  const aa = name !== 'nuc';
-  const data = {aa, prot: aa ? name : false};
-  if (aa) {
-    data.codon = parseInt(num, 10);
-  } else {
-    data.x = parseInt(num, 10);
-  }
-  return data;
 };
 
 @connect((state) => {
@@ -191,7 +183,7 @@ export class Entropy extends React.Component {
         if (!nextProps.colorBy.startsWith("gt")) {
           updateParams.clearSelected = true;
         } else {
-          updateParams.selected = parseEncodedGenotype(nextProps.colorBy);
+          updateParams.selected = parseEncodedGenotype(nextProps.colorBy, nextProps.geneLength);
         }
       }
       if (Object.keys(updateParams).length) {

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -171,7 +171,7 @@ export class Entropy extends React.Component {
       timerStart("entropy initial render");
       this.state.chart.render(nextProps);
       timerEnd("entropy initial render");
-    } else { /* props changed, but a new render isn't required */
+    } else { /* props changed, but a new render probably isn't required */
       timerStart("entropy D3 update");
       const updateParams = {};
       if (this.props.bars !== nextProps.bars) { /* will always be true if mutType has changed */

--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -129,6 +129,7 @@ const getColorScale = (colorBy, tree, geneLength, colorOptions, version, absolut
     } else if (parseGenotype(colorBy, geneLength)) {
       // genotype coloring
       const gt = parseGenotype(colorBy, geneLength);
+      console.log("gentoype coloring", gt)
       if (gt) {
         const stateCount = {};
         tree.nodes.forEach((n) => {
@@ -138,6 +139,18 @@ const getColorScale = (colorBy, tree, geneLength, colorOptions, version, absolut
         domain.sort((a, b) => stateCount[a] > stateCount[b]);
         colorScale = scaleOrdinal().domain(domain).range(genotypeColors);
       }
+    } else {
+      console.log("bugger", colorBy, geneLength, parseGenotype(colorBy, geneLength));
+      const positions = colorBy.split('_')[1].split(',').map((x) => parseInt(x, 10));
+      const gene = colorBy.split('-')[1].split('_')[0];
+      const stateCount = {};
+      tree.nodes.forEach((n) => {
+        stateCount[n.currentGt] ? stateCount[n.currentGt]++ : stateCount[n.currentGt] = 1;
+      });
+      console.log("statecounts:", stateCount);
+      const domain = Object.keys(stateCount);
+      domain.sort((a, b) => stateCount[a] > stateCount[b]);
+      colorScale = scaleOrdinal().domain(domain).range(genotypeColors);
     }
   } else if (colorBy === "lbi") {
     try {

--- a/src/util/getColorScale.js
+++ b/src/util/getColorScale.js
@@ -3,7 +3,6 @@ import { min, max, range as d3Range } from "d3-array";
 import { rgb } from "d3-color";
 import { interpolateHcl } from "d3-interpolate";
 import { genericDomain, colors, genotypeColors, reallySmallNumber, reallyBigNumber } from "./globals";
-import { parseGenotype } from "./getGenotype";
 import { getAllValuesAndCountsOfTraitsFromTree } from "./treeTraversals";
 import { setLBI } from "./localBranchingIndex";
 
@@ -126,28 +125,12 @@ const getColorScale = (colorBy, tree, geneLength, colorOptions, version, absolut
     if (!geneLength) {
       continuous = true;
       colorScale = genericScale(0, 1);
-    } else if (parseGenotype(colorBy, geneLength)) {
-      // genotype coloring
-      const gt = parseGenotype(colorBy, geneLength);
-      console.log("gentoype coloring", gt)
-      if (gt) {
-        const stateCount = {};
-        tree.nodes.forEach((n) => {
-          stateCount[n.currentGt] ? stateCount[n.currentGt]++ : stateCount[n.currentGt] = 1;
-        });
-        const domain = Object.keys(stateCount);
-        domain.sort((a, b) => stateCount[a] > stateCount[b]);
-        colorScale = scaleOrdinal().domain(domain).range(genotypeColors);
-      }
     } else {
-      console.log("bugger", colorBy, geneLength, parseGenotype(colorBy, geneLength));
-      const positions = colorBy.split('_')[1].split(',').map((x) => parseInt(x, 10));
-      const gene = colorBy.split('-')[1].split('_')[0];
       const stateCount = {};
       tree.nodes.forEach((n) => {
         stateCount[n.currentGt] ? stateCount[n.currentGt]++ : stateCount[n.currentGt] = 1;
       });
-      console.log("statecounts:", stateCount);
+      // console.log("statecounts:", stateCount);
       const domain = Object.keys(stateCount);
       domain.sort((a, b) => stateCount[a] > stateCount[b]);
       colorScale = scaleOrdinal().domain(domain).range(genotypeColors);

--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -1,6 +1,6 @@
 
 export const setGenotype = (nodes, prot, pos) => {
-  // console.log('scanning for mutation', prot, pos)
+  console.log('scanning for mutation', prot, pos)
   let ancState; // initialised to undefined
   const ancNodes = [];
   const recurse = (node, state) => {
@@ -36,5 +36,54 @@ export const setGenotype = (nodes, prot, pos) => {
   for (const node of ancNodes) {
     node.currentGt = ancState;
   }
+  // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
+};
+
+export const experimentalSetGenotype = (nodes, prot, positions) => {
+  console.log('scanning for mutation', prot, positions)
+  /* set em all to '' */
+  nodes.forEach((n) => {n.currentGt = [];});
+  let currentGtIdx = 0;
+  let ancState; // initialised to undefined
+  const ancNodes = [];
+  const recurse = (node, state, pos) => {
+    let newState = state;
+    let data; // any potential mutations that would result in a state change
+    if (prot === "nuc" && node.muts && node.muts.length) {
+      data = node.muts;
+    } else if (node.aa_muts && node.aa_muts[prot]) {
+      data = node.aa_muts[prot];
+    }
+    if (data) {
+      for (let i = 0; i < data.length; i++) {
+        const m = data[i];
+        if (parseInt(m.slice(1, m.length - 1), 10) === pos) {
+          if (!ancState) {ancState = m.slice(0, 1);} // only set once. Unknowable until the 1st mutation is seen.
+          newState = m.slice(m.length - 1, m.length);
+        }
+      }
+    }
+    /* set for all nodes (terminal or not) */
+    if (newState !== undefined) {
+      node.currentGt[currentGtIdx] = newState;
+    } else {
+      ancNodes.push(node); // reference. cheap.
+    }
+    if (node.hasChildren) {
+      for (const child of node.children) {
+        recurse(child, newState, pos);
+      }
+    }
+  };
+  for (let pos of positions) { // eslint-disable-line
+    console.log("recursing for", pos);
+    recurse(nodes[0], undefined, pos);
+    for (const node of ancNodes) {
+      node.currentGt[currentGtIdx] = ancState;
+    }
+    ancState = undefined;
+    currentGtIdx++;
+  }
+  nodes.forEach((n) => {n.currentGt = n.currentGt.join('+');});
   // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
 };

--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -1,6 +1,6 @@
 
 export const setGenotype = (nodes, prot, positions) => {
-  console.time("setGenotype")
+  // console.time("setGenotype")
   const nPositions = positions.length;
   const ancState = positions.map(() => undefined);
   const ancNodes = positions.map(() => []);
@@ -45,6 +45,6 @@ export const setGenotype = (nodes, prot, positions) => {
     }
   }
   nodes.forEach((n) => {n.currentGt = n.currentGt.join(' / ');});
-  console.timeEnd("setGenotype")
+  // console.timeEnd("setGenotype")
   // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
 };

--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -1,10 +1,11 @@
 
-export const setGenotype = (nodes, prot, pos) => {
-  console.log('scanning for mutation', prot, pos)
-  let ancState; // initialised to undefined
-  const ancNodes = [];
+export const setGenotype = (nodes, prot, positions) => {
+  console.time("setGenotype")
+  const nPositions = positions.length;
+  const ancState = positions.map(() => undefined);
+  const ancNodes = positions.map(() => []);
   const recurse = (node, state) => {
-    let newState = state;
+    const newState = state; /* reference. cheap */
     let data; // any potential mutations that would result in a state change
     if (prot === "nuc" && node.muts && node.muts.length) {
       data = node.muts;
@@ -14,17 +15,22 @@ export const setGenotype = (nodes, prot, pos) => {
     if (data) {
       for (let i = 0; i < data.length; i++) {
         const m = data[i];
-        if (parseInt(m.slice(1, m.length - 1), 10) === pos) {
-          if (!ancState) {ancState = m.slice(0, 1);} // only set once. Unknowable until the 1st mutation is seen.
-          newState = m.slice(m.length - 1, m.length);
+        const mPos = parseInt(m.slice(1, m.length - 1), 10);
+        for (let j = 0; j < nPositions; j++) {
+          if (positions[j] === mPos) {
+            /* check if ancState is known / set */
+            if (!ancState[j]) ancState[j] = m.slice(0, 1); // only set once. Unknowable until the 1st mutation is seen.
+            newState[j] = m.slice(m.length - 1, m.length);
+          }
         }
       }
     }
-    /* set for all nodes (terminal or not) */
-    if (newState !== undefined) {
-      node.currentGt = newState;
-    } else {
-      ancNodes.push(node); // reference. cheap.
+    /* set for all nodes. will be undefined if ancestral */
+    node.currentGt = [...newState];
+    for (let j = 0; j < nPositions; j++) {
+      if (!newState[j]) {
+        ancNodes[j].push(node);
+      }
     }
     if (node.hasChildren) {
       for (const child of node.children) {
@@ -32,58 +38,13 @@ export const setGenotype = (nodes, prot, pos) => {
       }
     }
   };
-  recurse(nodes[0], undefined);
-  for (const node of ancNodes) {
-    node.currentGt = ancState;
+  recurse(nodes[0], positions.map(() => undefined), positions);
+  for (let j = 0; j < nPositions; j++) {
+    for (const node of ancNodes[j]) {
+      node.currentGt[j] = ancState[j];
+    }
   }
-  // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
-};
-
-export const experimentalSetGenotype = (nodes, prot, positions) => {
-  console.log('scanning for mutation', prot, positions)
-  /* set em all to '' */
-  nodes.forEach((n) => {n.currentGt = [];});
-  let currentGtIdx = 0;
-  let ancState; // initialised to undefined
-  const ancNodes = [];
-  const recurse = (node, state, pos) => {
-    let newState = state;
-    let data; // any potential mutations that would result in a state change
-    if (prot === "nuc" && node.muts && node.muts.length) {
-      data = node.muts;
-    } else if (node.aa_muts && node.aa_muts[prot]) {
-      data = node.aa_muts[prot];
-    }
-    if (data) {
-      for (let i = 0; i < data.length; i++) {
-        const m = data[i];
-        if (parseInt(m.slice(1, m.length - 1), 10) === pos) {
-          if (!ancState) {ancState = m.slice(0, 1);} // only set once. Unknowable until the 1st mutation is seen.
-          newState = m.slice(m.length - 1, m.length);
-        }
-      }
-    }
-    /* set for all nodes (terminal or not) */
-    if (newState !== undefined) {
-      node.currentGt[currentGtIdx] = newState;
-    } else {
-      ancNodes.push(node); // reference. cheap.
-    }
-    if (node.hasChildren) {
-      for (const child of node.children) {
-        recurse(child, newState, pos);
-      }
-    }
-  };
-  for (let pos of positions) { // eslint-disable-line
-    console.log("recursing for", pos);
-    recurse(nodes[0], undefined, pos);
-    for (const node of ancNodes) {
-      node.currentGt[currentGtIdx] = ancState;
-    }
-    ancState = undefined;
-    currentGtIdx++;
-  }
-  nodes.forEach((n) => {n.currentGt = n.currentGt.join('+');});
+  nodes.forEach((n) => {n.currentGt = n.currentGt.join(' / ');});
+  console.timeEnd("setGenotype")
   // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
 };


### PR DESCRIPTION
This allows specifying multiple (comma separated) positions within the selected protein / nuc, with the colour scale containing the permutations of the entries.

This is a first step to allowing generic multiple color-bys (#509), which is much harder.

![image](https://user-images.githubusercontent.com/8350992/36958619-037e40b0-1ff2-11e8-855c-d031d3374bc9.png)

I've tested this via the clade-defined branch labels, as well as the tip-hover mutations, but this needs a second pair of eyes.