### PR TITLE
Adjust branch label and vaccine cross styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     https://codepen.io/tigt/post/async-css-without-javascript
     https://stackoverflow.com/questions/9271276/is-the-recommendation-to-include-css-before-javascript-invalid
     -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:100,200,300,400,500">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:100,200,300,400,500,700">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
 

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -26,7 +26,8 @@ export const defaultParams = {
   /* B R A N C H   L A B E L S */
   branchLabelKey: false,
   branchLabelFont: dataFont,
-  branchLabelFill: "#555",
+  branchLabelFill: "#777",
+  branchLabelFontWeight: 500,
   branchLabelPadX: 8,
   branchLabelPadY: 5,
   /* T I P   L A B E L S */

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -27,15 +27,20 @@ export const updateTipLabels = function updateTipLabels(dt) {
 
 /** branchLabelSize
  * @param {str} key e.g. "aa" or "clade"
- * @param  {int} nTips total number of nodes in current view (visible or invisible)
  * @return {str} font size of the branch label, e.g. "12px"
  */
-const branchLabelSize = (key, nTips) => {
-  if (key === "aa") return "12px";
-  const size = nTips > 1000 ? 14 :
-    nTips > 500 ? 16 :
-      20;
-  return `${size}px`;
+const branchLabelSize = (key) => {
+  if (key === "aa") return "10px";
+  return "14px";
+};
+
+/** branchLabelFontWeight
+ * @param {str} key e.g. "aa" or "clade"
+ * @return {str} font weight of the branch label, e.g. "500"
+ */
+const branchLabelFontWeight = (key) => {
+  if (key === "aa") return "500";
+  return "700";
 };
 
 /** createBranchLabelVisibility (the return value should be passed to d3 style call)
@@ -63,12 +68,14 @@ const createBranchLabelVisibility = (key, layout, totalTipsInView) => {
 
 export const updateBranchLabels = function updateBranchLabels(dt) {
   const visibility = createBranchLabelVisibility(this.params.branchLabelKey, this.layout, this.zoomNode.n.tipCount);
-  const labelSize = branchLabelSize(this.params.branchLabelKey, this.zoomNode.n.fullTipCount);
+  const labelSize = branchLabelSize(this.params.branchLabelKey);
+  const fontWeight = branchLabelFontWeight(this.params.branchLabelKey);
   this.svg.selectAll('.branchLabel')
     .transition().duration(dt)
     .attr("x", (d) => d.xTip - 5)
     .attr("y", (d) => d.yTip - this.params.branchLabelPadY)
     .style("visibility", visibility)
+    .style("font-weight", fontWeight)
     .style("font-size", labelSize);
   if (!dt) timerFlush();
 };
@@ -76,7 +83,8 @@ export const updateBranchLabels = function updateBranchLabels(dt) {
 export const drawBranchLabels = function drawBranchLabels(key) {
   /* salient props: this.zoomNode.n.tipCount, this.zoomNode.n.fullTipCount */
   this.params.branchLabelKey = key;
-  const labelSize = branchLabelSize(key, this.zoomNode.n.fullTipCount);
+  const labelSize = branchLabelSize(key);
+  const fontWeight = branchLabelFontWeight(key);
   const visibility = createBranchLabelVisibility(key, this.layout, this.zoomNode.n.tipCount);
   this.svg.append("g").selectAll('.branchLabel')
     .data(this.nodes.filter((d) => d.n.attr.labels && d.n.attr.labels[key]))
@@ -89,6 +97,7 @@ export const drawBranchLabels = function drawBranchLabels(key) {
     .style("visibility", visibility)
     .style("fill", this.params.branchLabelFill)
     .style("font-family", this.params.branchLabelFont)
+    .style("font-weight", fontWeight)
     .style("font-size", labelSize)
     .text((d) => d.n.attr.labels[key]);
 };

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -220,7 +220,8 @@ export const setDistance = function setDistance(distanceAttribute) {
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
-      d.crossDepth = tmp_dist === "div" ? d.depth : d.n.vaccineDateNumeric;
+      // this was d.n.vaccineDateNumeric, setting to d.depth for reasons of clarity
+      d.crossDepth = tmp_dist === "div" ? d.depth : d.depth;
     });
   }
   timerEnd("setDistance");
@@ -310,7 +311,7 @@ export const mapToScreen = function mapToScreen() {
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
-      const n = 5; /* half the number of pixels that the cross will take up */
+      const n = 6; /* half the number of pixels that the cross will take up */
       const xTipCross = this.xScale(d.xCross); /* x position of the center of the cross */
       const yTipCross = this.yScale(d.yCross); /* x position of the center of the cross */
       d.vaccineCross = ` M ${xTipCross-n},${yTipCross-n} L ${xTipCross+n},${yTipCross+n} M ${xTipCross-n},${yTipCross+n} L ${xTipCross+n},${yTipCross-n}`;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -42,8 +42,8 @@ export const render = function render(svg, layout, distance, parameters, callbac
   /* draw functions */
   if (this.params.showGrid) this.addGrid();
   this.drawBranches();
-  if (this.params.branchLabelKey) this.drawBranchLabels(this.params.branchLabelKey);
   this.drawTips();
+  if (this.params.branchLabelKey) this.drawBranchLabels(this.params.branchLabelKey);
   if (this.vaccines) this.drawVaccines();
   if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
   this.confidencesInSVG = false;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -64,7 +64,7 @@ export const drawVaccines = function drawVaccines() {
     .append("path")
     .attr("class", "vaccineCross")
     .attr("d", (d) => d.vaccineCross)
-    .style("stroke", "black")
+    .style("stroke", "#333")
     .style("stroke-width", 2 * this.params.branchStrokeWidth)
     .style("fill", "none")
     .style("cursor", "pointer")


### PR DESCRIPTION
@jameshadfield ---

The changes to branch label styling shouldn't be controversial. However, I've decided to remove the dashed lines from the vaccine crosses. I believe it was adding confusion rather than removing it. If we go in this direction I think we need the full description of choice and deployment. But even then I really feel like it will be overloading the tree. Perhaps the best thing to think toward is a separate vaccine panel.

Also, I think the symbols (vaccine crosses, serum gears) look much better with a bit of white space surrounding them. This was accomplished previously by using a character as the cross and giving a stroke of `#fff` and a fill of `#333`. Something to think about.

<img width="155" alt="old" src="https://user-images.githubusercontent.com/1176109/37742253-19f97eda-2d22-11e8-927a-bb3a2398ef15.png">

<img width="101" alt="new" src="https://user-images.githubusercontent.com/1176109/37742256-1bb3520a-2d22-11e8-875e-9d83b06be206.png">
