### PR TITLE
Make authors filter an explicit setting in auspice_filters

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -170,10 +170,10 @@ const modifyStateViaMetadata = (state, metadata) => {
     state["analysisSlider"] = {key: metadata.analysisSlider, valid: false};
   }
   if (metadata.author_info) {
-    state.filters.authors = [];
-    state.defaults.filters.authors = [];
+    // need authors in metadata.filters to include as filter
+    // but metadata.author_info is generally required for app functioning
   } else {
-    console.error("update meta.json to include author_info.");
+    console.error("the meta.json must include author_info");
   }
   if (metadata.filters) {
     metadata.filters.forEach((v) => {


### PR DESCRIPTION
@jameshadfield: This makes it so that `state.filters.authors` is only added if it's explicitly set in meta.json. I've added this to augur builds for [Zika](https://github.com/nextstrain/augur/blob/master/builds/zika/zika.prepare.py#L56), [Ebola](https://github.com/nextstrain/augur/blob/master/builds/ebola/ebola.prepare.py#L49), etc... Everything except seasonal flu and H7N9. I did this because currently, taking as `submitting_lab` as `authors` via GISAID is pretty broken. Take a look at this from H7N9:

<img width="1079" alt="authors" src="https://user-images.githubusercontent.com/1176109/37867313-824ba1d8-2f53-11e8-8cc0-1457bf172ddb.png">

A bunch of strange et als. But more severely, `Other Database Import et al` contributing most of the data. This just looks bad. We should clean this up in sacra (cc @barneypotter24) and don't rely on auspice appending "et al". 

All the necessary changes have been made to JSONs for this to work live.