### PR TITLE
Fix toggle position and remove extraneous whitespace

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -179,7 +179,7 @@ class App extends React.Component {
         <ToggleSidebarTab
           open={this.state.showSidebar}
           handler={() => {this.setState({showSidebar: !this.state.showSidebar});}}
-          widthWhenOpen={sidebarWidth - 15}
+          widthWhenOpen={sidebarWidth - 40}
           widthWhenShut={0}
           dontDisplay={this.props.displayNarrative}
         />

--- a/src/components/framework/card.js
+++ b/src/components/framework/card.js
@@ -26,7 +26,8 @@ class Card extends React.Component {
         marginBottom: 5,
         fontWeight: 500,
         backgroundColor: "#FFFFFF",
-        borderTop: "thin solid #AAA"
+        borderTop: "thin solid #AAA",
+        minHeight: "15px"
       }
     };
   }
@@ -52,8 +53,8 @@ class Card extends React.Component {
         color: "#fff",
         fontSize: 16,
         marginLeft: 2,
-        marginTop: 2,
-        marginBottom: 5,
+        marginTop: 0,
+        marginBottom: 0,
         fontWeight: 500,
         backgroundColor: "#FFFFFF"
       }
@@ -63,7 +64,7 @@ class Card extends React.Component {
     const styles = this.props.infocard ? this.getStylesInfoCard() : this.getStyles();
     return (
       <div style={{ ...styles.base, ...this.props.style }}>
-        <div style={{ ...styles.title, ...this.props.titleStyles, minHeight: "15px" }}>
+        <div style={{ ...styles.title, ...this.props.titleStyles }}>
           {this.props.title}
         </div>
         <div style={{


### PR DESCRIPTION
This is a small fix to placement of sidebar toggle and title.

Before (current `master`):

![before](https://user-images.githubusercontent.com/1176109/39498882-acf498b6-4d5f-11e8-882f-7d7d135289a2.png)

After (`fix-toggle`):

![after](https://user-images.githubusercontent.com/1176109/39498887-b44dec84-4d5f-11e8-8a2a-25c7e9f8fecf.png)


_Fixes #526_