### PR TITLE
Fix frequencies x range

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -50,9 +50,9 @@ const getOrderedCategories = (matrixCategories, colorScale) => {
   return orderedCategories;
 };
 
-export const calcXScale = (chartGeom, ticks) => {
+export const calcXScale = (chartGeom, pivots, ticks) => {
   const x = scaleLinear()
-    .domain([ticks[0], ticks[ticks.length - 1]])
+    .domain([pivots[0], pivots[pivots.length - 1]])
     .range([chartGeom.spaceLeft, chartGeom.width - chartGeom.spaceRight]);
   return {x, numTicksX: ticks.length};
 };

--- a/src/components/frequencies/index.js
+++ b/src/components/frequencies/index.js
@@ -33,8 +33,8 @@ export class Frequencies extends React.Component {
     const data = processMatrix({...props});
     newState.maxY = data.maxY;
     newState.categories = data.categories;
+    const scalesX = calcXScale(chartGeom, props.pivots, props.ticks);
     const scalesY = calcYScale(chartGeom, data.maxY);
-    const scalesX = calcXScale(chartGeom, props.ticks);
     newState.scales = {...scalesX, ...scalesY};
     drawXAxis(newState.svg, chartGeom, scalesX);
     drawYAxis(newState.svg, chartGeom, scalesY);


### PR DESCRIPTION
This fixes the issue where frequencies panel didn't fill the axis. It was caused by basing xScale off of `ticks` rather than `pivots`. A simple replacement here solved the issue.

Before:

![freq-before](https://user-images.githubusercontent.com/1176109/39499327-05a1250e-4d62-11e8-8ede-1e5966d7706b.png)

After:

![freq-after](https://user-images.githubusercontent.com/1176109/39499331-09750484-4d62-11e8-80ad-1bcb110f241d.png)

_Fixes #542_