### PR TITLE
Change to simple y max for frequencies

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -182,15 +182,14 @@ const drawLabelsOverStream = (svgStreamGroup, series, pivots, labels, scales) =>
     .text((d, i) => xyPos[i][0] ? prettyString(d) : "");
 };
 
-const calcNiceMaxYValue = (series) => {
-  const max = series[series.length - 1].reduce((curMax, el) => Math.max(curMax, el[1]), 0);
-  return Math.ceil(max * 20) / 20;
+const calcMaxYValue = (series) => {
+  return series[series.length - 1].reduce((curMax, el) => Math.max(curMax, el[1]), 0);
 };
 
 export const processMatrix = ({matrix, pivots, colorScale}) => {
   const categories = getOrderedCategories(Object.keys(matrix), colorScale);
   const series = turnMatrixIntoSeries(categories, pivots.length, matrix);
-  const maxY = calcNiceMaxYValue(series);
+  const maxY = calcMaxYValue(series);
   return {categories, series, maxY};
 };
 


### PR DESCRIPTION
@jameshadfield ---

The function `calcNiceMaxYValue` wasn't working well for small frequency values. This PR makes a simple fix to just use the actual max y value. Behavior looks great to me. Here is an example for flu with 3 tips selected.

Before:

<img width="822" alt="freq-before" src="https://user-images.githubusercontent.com/1176109/39677198-bd1450a4-512b-11e8-856d-d49792f69a75.png">

<img width="818" alt="freq-after" src="https://user-images.githubusercontent.com/1176109/39677199-c11f8db2-512b-11e8-831c-767c08089834.png">

The smoothing that we're doing should always keep these looking decent, even at very low y values. And changes that @huddlej is making to frequencies should make these even smoother.