### PR TITLE
Separate Nucleotide and Gap/N Mutations in Hover infoPanel

### DIFF
--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -108,10 +108,36 @@ const getMutationsJSX = (d, mutType) => {
   if (mutType === "nuc") {
     if (typeof d.muts !== "undefined" && d.muts.length) {
       const nDisplay = 9; // max number of mutations to display
-      const n = d.muts.length; // number of mutations that exist
-      let m = d.muts.slice(0, Math.min(nDisplay, n)).join(", ");
-      m += n > nDisplay ? " + " + (n - nDisplay) + " more" : "";
-      return infoLineJSX("Nucleotide mutations:", m);
+	  const nGapDisp = 4; // max number of gaps/Ns to display
+
+	  //gather muts with N/-
+	  let ngaps = d.muts.filter(mut => {return mut.slice(-1) == "N" || mut.slice(-1) == "-"
+										|| mut.slice(0) == "N" || mut.slice(0) == "-";})
+	  const gapLen = ngaps.length; // number of mutations that exist with N/-
+	  //gather muts without N/-
+	  let nucs = d.muts.filter(mut => {return mut.slice(-1) != "N" && mut.slice(-1) != "-"
+										&& mut.slice(0) != "N" && mut.slice(0) != "-";})
+	  const nucLen = nucs.length; //number of mutations that exist without N/-
+	  
+	  let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");
+	  m += nucLen > nDisplay ? " + " + (nucLen - nDisplay) + " more" : "";
+	  let mGap = ngaps.slice(0, Math.min(nGapDisp, gapLen)).join(", ");
+	  mGap += gapLen > nGapDisp ? " + " + (gapLen - nGapDisp) + " more" : "";
+	  
+	  if (gapLen == 0) {
+		return infoLineJSX("Nucleotide mutations:", m);
+	  }
+	  if (nucLen == 0) {
+		return infoLineJSX("Gap/N mutations:", mGap);
+	  }
+	  return (
+	    <p>
+		  {infoLineJSX("Nucleotide mutations:", m)}
+		  <br/><br/>
+		  {infoLineJSX("Gap/N mutations:", mGap)}
+		</p>
+	  );
+
     }
     return infoLineJSX("No nucleotide mutations", "");
   } else if (typeof d.aa_muts !== "undefined") {

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -108,35 +108,35 @@ const getMutationsJSX = (d, mutType) => {
   if (mutType === "nuc") {
     if (typeof d.muts !== "undefined" && d.muts.length) {
       const nDisplay = 9; // max number of mutations to display
-	  const nGapDisp = 4; // max number of gaps/Ns to display
+      const nGapDisp = 4; // max number of gaps/Ns to display
 
-	  //gather muts with N/-
-	  let ngaps = d.muts.filter(mut => {return mut.slice(-1) == "N" || mut.slice(-1) == "-"
-										|| mut.slice(0) == "N" || mut.slice(0) == "-";})
-	  const gapLen = ngaps.length; // number of mutations that exist with N/-
-	  //gather muts without N/-
-	  let nucs = d.muts.filter(mut => {return mut.slice(-1) != "N" && mut.slice(-1) != "-"
-										&& mut.slice(0) != "N" && mut.slice(0) != "-";})
-	  const nucLen = nucs.length; //number of mutations that exist without N/-
-	  
-	  let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");
-	  m += nucLen > nDisplay ? " + " + (nucLen - nDisplay) + " more" : "";
-	  let mGap = ngaps.slice(0, Math.min(nGapDisp, gapLen)).join(", ");
-	  mGap += gapLen > nGapDisp ? " + " + (gapLen - nGapDisp) + " more" : "";
-	  
-	  if (gapLen == 0) {
-		return infoLineJSX("Nucleotide mutations:", m);
-	  }
-	  if (nucLen == 0) {
-		return infoLineJSX("Gap/N mutations:", mGap);
-	  }
-	  return (
-	    <p>
-		  {infoLineJSX("Nucleotide mutations:", m)}
-		  <br/><br/>
-		  {infoLineJSX("Gap/N mutations:", mGap)}
-		</p>
-	  );
+      //gather muts with N/-
+      let ngaps = d.muts.filter(mut => {return mut.slice(-1) == "N" || mut.slice(-1) == "-"
+                                        || mut.slice(0) == "N" || mut.slice(0) == "-";})
+      const gapLen = ngaps.length; // number of mutations that exist with N/-
+      //gather muts without N/-
+      let nucs = d.muts.filter(mut => {return mut.slice(-1) != "N" && mut.slice(-1) != "-"
+                                        && mut.slice(0) != "N" && mut.slice(0) != "-";})
+      const nucLen = nucs.length; //number of mutations that exist without N/-
+
+      let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");
+      m += nucLen > nDisplay ? " + " + (nucLen - nDisplay) + " more" : "";
+      let mGap = ngaps.slice(0, Math.min(nGapDisp, gapLen)).join(", ");
+      mGap += gapLen > nGapDisp ? " + " + (gapLen - nGapDisp) + " more" : "";
+
+      if (gapLen == 0) {
+        return infoLineJSX("Nucleotide mutations:", m);
+      }
+      if (nucLen == 0) {
+        return infoLineJSX("Gap/N mutations:", mGap);
+      }
+      return (
+        <p>
+        {infoLineJSX("Nucleotide mutations:", m)}
+        <br/><br/>
+        {infoLineJSX("Gap/N mutations:", mGap)}
+        </p>
+      );
 
     }
     return infoLineJSX("No nucleotide mutations", "");

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -110,31 +110,36 @@ const getMutationsJSX = (d, mutType) => {
       const nDisplay = 9; // max number of mutations to display
       const nGapDisp = 4; // max number of gaps/Ns to display
 
-      //gather muts with N/-
-      let ngaps = d.muts.filter(mut => {return mut.slice(-1) == "N" || mut.slice(-1) == "-"
-                                        || mut.slice(0) == "N" || mut.slice(0) == "-";})
+      // gather muts with N/-
+      const ngaps = d.muts.filter((mut) => {
+        return mut.slice(-1) === "N" || mut.slice(-1) === "-"
+          || mut.slice(0) === "N" || mut.slice(0) === "-";
+      });
       const gapLen = ngaps.length; // number of mutations that exist with N/-
-      //gather muts without N/-
-      let nucs = d.muts.filter(mut => {return mut.slice(-1) != "N" && mut.slice(-1) != "-"
-                                        && mut.slice(0) != "N" && mut.slice(0) != "-";})
-      const nucLen = nucs.length; //number of mutations that exist without N/-
+
+      // gather muts without N/-
+      const nucs = d.muts.filter((mut) => {
+        return mut.slice(-1) !== "N" && mut.slice(-1) !== "-"
+          && mut.slice(0) !== "N" && mut.slice(0) !== "-";
+      });
+      const nucLen = nucs.length; // number of mutations that exist without N/-
 
       let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");
       m += nucLen > nDisplay ? " + " + (nucLen - nDisplay) + " more" : "";
       let mGap = ngaps.slice(0, Math.min(nGapDisp, gapLen)).join(", ");
       mGap += gapLen > nGapDisp ? " + " + (gapLen - nGapDisp) + " more" : "";
 
-      if (gapLen == 0) {
+      if (gapLen === 0) {
         return infoLineJSX("Nucleotide mutations:", m);
       }
-      if (nucLen == 0) {
+      if (nucLen === 0) {
         return infoLineJSX("Gap/N mutations:", mGap);
       }
       return (
         <p>
-        {infoLineJSX("Nucleotide mutations:", m)}
-        <br/><br/>
-        {infoLineJSX("Gap/N mutations:", mGap)}
+          {infoLineJSX("Nucleotide mutations:", m)}
+          <div height="5"/>
+          {infoLineJSX("Gap/N mutations:", mGap)}
         </p>
       );
 


### PR DESCRIPTION
This separates nucleotide mutations into two groups, so that 'N's and '-'s do not prevent the user from seeing base-to-base changes. 

Example with both types of mutations:
![infopanel_n_4](https://user-images.githubusercontent.com/14290674/39698961-62cc6baa-51f7-11e8-8f61-c852cc9b491f.PNG)

If you only have Gaps/Ns, this is all that's shown:
![infopanel_n_2](https://user-images.githubusercontent.com/14290674/39698959-629a60ec-51f7-11e8-9557-dd65500bfc8a.PNG)

Similarly, if only nucleotide (base-to-base) mutations, that's only shown:
![infopanel_n_3](https://user-images.githubusercontent.com/14290674/39698960-62b3307c-51f7-11e8-98ff-b7dce3b2b962.PNG)

This is my first foray into javascript so there may be better/more standard ways to do some of this, please edit if so :)