### PR TITLE
Clade zoom behavior

### DIFF
--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -7,18 +7,6 @@ import { prettyString } from "../../util/stringHelpers";
 import { months } from "../../util/globals";
 import { displayFilterValueAsButton } from "../framework/footer";
 
-const resetTreeButton = (dispatch) => {
-  return (
-    <div
-      className={`boxed-item active-clickable`}
-      style={{paddingLeft: '5px', paddingRight: '5px', display: "inline-block"}}
-      onClick={() => dispatch(updateVisibleTipsAndBranchThicknesses({root: [0, 0]}))}
-    >
-      {"View entire tree."}
-    </div>
-  );
-};
-
 const plurals = {
   country: "countries",
   authors: "authors"
@@ -48,11 +36,7 @@ const getNumSelectedTips = (nodes, visibility) => {
 export const createSummary = (virus_count, nodes, filters, visibility, visibleStateCounts, idxOfInViewRootNode, dateMin, dateMax) => {
   const nSelectedSamples = getNumSelectedTips(nodes, visibility);
   const summary = [];
-  if (idxOfInViewRootNode === 0) {
-    summary.push(`Showing ${nSelectedSamples} of ${virus_count} genomes`);
-  } else {
-    summary.push(`Showing ${nSelectedSamples} of ${nodes[idxOfInViewRootNode].fullTipCount} genomes in the selected clade`);
-  }
+  summary.push(`Showing ${nSelectedSamples} of ${virus_count} genomes`);
   Object.keys(filters).forEach((filterName) => {
     const n = Object.keys(visibleStateCounts[filterName]).length;
     summary.push((`from ${n} ${pluralise(filterName, n)}`));
@@ -300,9 +284,6 @@ class Info extends React.Component {
                 {". "}
               </span>
             ) : null}
-            {/* finally - is a branch selected? */}
-            {this.props.idxOfInViewRootNode === 0 && this.props.idxOfInViewRootNodeToo === 0 ? null :
-              resetTreeButton(this.props.dispatch)}
           </div>
         </div>
       </Card>

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -13,7 +13,7 @@ export const createDefaultParams = () => ({
   minorTicks: 4,
   orientation: [1, 1],
   margins: {left: 25, right: 15, top: 5, bottom: 25},
-  tipLabelMarginPadding: 100,
+  tipLabelMarginPaddingPerCharacter: 6.5,
   showGrid: true,
   fillSelected: "#A73",
   radiusSelected: 5,

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -13,6 +13,7 @@ export const createDefaultParams = () => ({
   minorTicks: 4,
   orientation: [1, 1],
   margins: {left: 25, right: 15, top: 5, bottom: 25},
+  tipLabelMarginPadding: 100,
   showGrid: true,
   fillSelected: "#A73",
   radiusSelected: 5,

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -268,8 +268,20 @@ export const setScales = function setScales(margins) {
 */
 export const mapToScreen = function mapToScreen() {
   timerStart("mapToScreen");
+
+  /* pad margins if tip labels are visible */
+  const tmpMargins = {
+    left: this.params.margins.left,
+    right: this.params.margins.right,
+    top: this.params.margins.top,
+    bottom: this.params.margins.bottom};
+  const inViewTerminalNodes = this.nodes.filter((d) => d.terminal).filter((d) => d.inView);
+  if (inViewTerminalNodes.length < 50) {
+    tmpMargins.right += this.params.tipLabelMarginPadding;
+  }
+
   /* set the range of the x & y scales */
-  this.setScales(this.params.margins);
+  this.setScales(tmpMargins);
 
   /* find minimum & maximum x & y values */
   let [minY, maxY, minX, maxX] = [1000000, 0, 1000000, 0];
@@ -279,6 +291,12 @@ export const mapToScreen = function mapToScreen() {
     if (d.x < minX) minX = d.x;
     if (d.y < minY) minY = d.y;
   });
+
+  /* fixes state of 0 length domain */
+  if (minX === maxX) {
+    minX -= 0.005;
+    maxX += 0.005;
+  }
 
   /* slightly pad min and max y to account for small clades */
   minY -= 0.2;

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -280,6 +280,10 @@ export const mapToScreen = function mapToScreen() {
     if (d.y < minY) minY = d.y;
   });
 
+  /* slightly pad min and max y to account for small clades */
+  minY -= 0.2;
+  maxY += 0.2;
+
   /* set the domain of the x & y scales */
   if (this.layout === "radial" || this.layout === "unrooted") {
     // handle "radial and unrooted differently since they need to be square

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -260,7 +260,6 @@ export const setScales = function setScales(margins) {
   }
 };
 
-
 /**
 * this function sets the xScale, yScale domains and maps precalculated x,y
 * coordinates to their places on the screen
@@ -270,6 +269,7 @@ export const mapToScreen = function mapToScreen() {
   timerStart("mapToScreen");
 
   /* pad margins if tip labels are visible */
+  /* padding width based on character count */
   const tmpMargins = {
     left: this.params.margins.left,
     right: this.params.margins.right,
@@ -277,7 +277,13 @@ export const mapToScreen = function mapToScreen() {
     bottom: this.params.margins.bottom};
   const inViewTerminalNodes = this.nodes.filter((d) => d.terminal).filter((d) => d.inView);
   if (inViewTerminalNodes.length < 50) {
-    tmpMargins.right += this.params.tipLabelMarginPadding;
+    let padBy = 0;
+    inViewTerminalNodes.forEach((d) => {
+      if (padBy < d.n.strain.length) {
+        padBy = d.n.strain.length * this.params.tipLabelMarginPaddingPerCharacter;
+      }
+    });
+    tmpMargins.right += padBy;
   }
 
   /* set the range of the x & y scales */

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -30,16 +30,9 @@ class Tree extends React.Component {
     this.onViewerChange = callbacks.onViewerChange.bind(this);
     // this.handleIconClickHOF = callbacks.handleIconClickHOF.bind(this);
     this.redrawTree = () => {
-      this.state.tree.clearSVG();
-      this.Viewer.fitToViewer();
-      renderTree(this, true, this.state.tree, this.props);
-      if (this.props.showTreeToo) {
-        this.state.treeToo.clearSVG();
-        this.ViewerToo.fitToViewer();
-        renderTree(this, false, this.state.treeToo, this.props);
-      }
-      this.setState({hover: null, selectedBranch: null, selectedTip: null});
-      this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root: [0, 0]}));
+      this.props.dispatch(updateVisibleTipsAndBranchThicknesses({
+        root: [0, 0]
+      }));
     };
   }
   componentDidMount() {


### PR DESCRIPTION
Improvements to clade zoom and tree reset.

1. Tree reset via `redrawTree` is much simpler. It just calls `updateVisibleTipsAndBranchThicknesses`. Nuking the tree was having bad side effects for me. Mainly it introduced a bug on branch lengths so that after zooming to a clade and clicking "reset tree" you'd get the following (from live):

<img width="1019" alt="zoom-clade-bug" src="https://user-images.githubusercontent.com/1176109/39733545-1a9e3abc-5228-11e8-848a-71ee9dadcaea.png">

This PR resolves this common issue. By not nuking the tree you also retain the animation. I'm able to break the tree rarely enough that I don't think we need to be nuking it here.

2. Remove "view entire tree" filter button. I thought that having "reset layout" and "view entire tree" were overly synonymous and that "reset layout" was the more obvious of the two.

3. Slightly pad y so that small clades don't look weird. Before this change we had:

<img width="1022" alt="before" src="https://user-images.githubusercontent.com/1176109/39733780-31b5485c-5229-11e8-8e1b-407c16f1b6dc.png">

After this change we have:

<img width="1014" alt="after" src="https://user-images.githubusercontent.com/1176109/39733781-34afa5d4-5229-11e8-9be9-d315bfbc30ec.png">

4. Pad x when tip labels are present so that tip labels do not overflow. I hacked this a bit by just using a multiple of character count. I don't think it's worth it investing in a `getBBox` style solution.

Before this change:

<img width="1021" alt="before-clade" src="https://user-images.githubusercontent.com/1176109/39733865-8ef71f5e-5229-11e8-9e9d-87c9f5e0e53a.png">

After this change:

<img width="1024" alt="after-clade" src="https://user-images.githubusercontent.com/1176109/39733871-9341901c-5229-11e8-943e-8c301fc9d529.png">

_Fixes #555_

