### PR TITLE
Small improvements to tip labels

### DIFF
--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -36,5 +36,11 @@ export const createDefaultParams = () => ({
   tipLabelFill: "#555",
   tipLabelPadX: 8,
   tipLabelPadY: 2,
-  mapToScreenDebounceTime: 500
+  mapToScreenDebounceTime: 500,
+  tipLabelFontSizeL1: 8,
+  tipLabelFontSizeL2: 10,
+  tipLabelFontSizeL3: 12,
+  tipLabelBreakL1: 75,
+  tipLabelBreakL2: 50,
+  tipLabelBreakL3: 25
 });

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -13,7 +13,6 @@ export const createDefaultParams = () => ({
   minorTicks: 4,
   orientation: [1, 1],
   margins: {left: 25, right: 15, top: 5, bottom: 25},
-  tipLabelMarginPaddingPerCharacter: 6.5,
   showGrid: true,
   fillSelected: "#A73",
   radiusSelected: 5,

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -12,6 +12,12 @@ export const updateTipLabels = function updateTipLabels(dt) {
   // console.log(`there are ${inViewTerminalNodes.length} nodes in view`)
   if (inViewTerminalNodes.length < tipThresholdToDisplayLabels) {
     // console.log("DRAWING!", inViewTerminalNodes)
+    let fontSize = "12px";
+    if (inViewTerminalNodes.length > 50) {
+      fontSize = "8px";
+    } else if (inViewTerminalNodes.length > 25) {
+      fontSize = "10px";
+    }
     window.setTimeout(() => {
       this.tipLabels = this.svg.append("g").selectAll('.tipLabel')
         .data(inViewTerminalNodes)
@@ -21,7 +27,7 @@ export const updateTipLabels = function updateTipLabels(dt) {
         .attr("y", (d) => d.yTip + yPad)
         .text((d) => tLFunc(d))
         .attr("class", "tipLabel")
-        .style("font-size", inViewTerminalNodes.length > 80 ? "8px" : "10px")
+        .style("font-size", fontSize)
         .style('visibility', 'visible');
     }, dt);
   }

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -1,5 +1,4 @@
 import { timerFlush } from "d3-timer";
-import { tipThresholdToDisplayLabels } from "../../../util/globals";
 
 export const updateTipLabels = function updateTipLabels(dt) {
   this.svg.selectAll('.tipLabel').remove();
@@ -10,14 +9,16 @@ export const updateTipLabels = function updateTipLabels(dt) {
     .filter((d) => d.terminal)
     .filter((d) => d.inView);
   // console.log(`there are ${inViewTerminalNodes.length} nodes in view`)
-  if (inViewTerminalNodes.length < tipThresholdToDisplayLabels) {
-    // console.log("DRAWING!", inViewTerminalNodes)
-    let fontSize = "12px";
-    if (inViewTerminalNodes.length > 50) {
-      fontSize = "8px";
-    } else if (inViewTerminalNodes.length > 25) {
-      fontSize = "10px";
+  if (inViewTerminalNodes.length < this.params.tipLabelBreakL1) {
+
+    let fontSize = this.params.tipLabelFontSizeL1;
+    if (inViewTerminalNodes.length < this.params.tipLabelBreakL2) {
+      fontSize = this.params.tipLabelFontSizeL2;
     }
+    if (inViewTerminalNodes.length < this.params.tipLabelBreakL3) {
+      fontSize = this.params.tipLabelFontSizeL3;
+    }
+
     window.setTimeout(() => {
       this.tipLabels = this.svg.append("g").selectAll('.tipLabel')
         .data(inViewTerminalNodes)
@@ -27,7 +28,7 @@ export const updateTipLabels = function updateTipLabels(dt) {
         .attr("y", (d) => d.yTip + yPad)
         .text((d) => tLFunc(d))
         .attr("class", "tipLabel")
-        .style("font-size", fontSize)
+        .style("font-size", fontSize.toString()+"px")
         .style('visibility', 'visible');
     }, dt);
   }

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -3,6 +3,7 @@
 import { min, max, sum } from "d3-array";
 import { addLeafCount } from "./helpers";
 import { timerStart, timerEnd } from "../../../util/perf";
+import { tipThresholdToDisplayLabels } from "../../../util/globals";
 
 /**
  * assigns the attribute this.layout and calls the function that
@@ -276,11 +277,17 @@ export const mapToScreen = function mapToScreen() {
     top: this.params.margins.top,
     bottom: this.params.margins.bottom};
   const inViewTerminalNodes = this.nodes.filter((d) => d.terminal).filter((d) => d.inView);
-  if (inViewTerminalNodes.length < 50) {
+  if (inViewTerminalNodes.length < tipThresholdToDisplayLabels) {
+    let fontSize = 12;
+    if (inViewTerminalNodes.length > 50) {
+      fontSize = 8;
+    } else if (inViewTerminalNodes.length > 25) {
+      fontSize = 10;
+    }
     let padBy = 0;
     inViewTerminalNodes.forEach((d) => {
       if (padBy < d.n.strain.length) {
-        padBy = d.n.strain.length * this.params.tipLabelMarginPaddingPerCharacter;
+        padBy = 0.65 * d.n.strain.length * fontSize;
       }
     });
     tmpMargins.right += padBy;

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -3,7 +3,6 @@
 import { min, max, sum } from "d3-array";
 import { addLeafCount } from "./helpers";
 import { timerStart, timerEnd } from "../../../util/perf";
-import { tipThresholdToDisplayLabels } from "../../../util/globals";
 
 /**
  * assigns the attribute this.layout and calls the function that
@@ -277,13 +276,16 @@ export const mapToScreen = function mapToScreen() {
     top: this.params.margins.top,
     bottom: this.params.margins.bottom};
   const inViewTerminalNodes = this.nodes.filter((d) => d.terminal).filter((d) => d.inView);
-  if (inViewTerminalNodes.length < tipThresholdToDisplayLabels) {
-    let fontSize = 12;
-    if (inViewTerminalNodes.length > 50) {
-      fontSize = 8;
-    } else if (inViewTerminalNodes.length > 25) {
-      fontSize = 10;
+  if (inViewTerminalNodes.length < this.params.tipLabelBreakL1) {
+
+    let fontSize = this.params.tipLabelFontSizeL1;
+    if (inViewTerminalNodes.length < this.params.tipLabelBreakL2) {
+      fontSize = this.params.tipLabelFontSizeL2;
     }
+    if (inViewTerminalNodes.length < this.params.tipLabelBreakL3) {
+      fontSize = this.params.tipLabelFontSizeL3;
+    }
+
     let padBy = 0;
     inViewTerminalNodes.forEach((d) => {
       if (padBy < d.n.strain.length) {

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -11,7 +11,6 @@ export const colorOptions = {
 };
 
 /* static for now, then hand rolled version of https://github.com/digidem/react-dimensions */
-export const tipThresholdToDisplayLabels = 75;
 export const width = 1126; /* no longer used */
 export const margin = 60;
 export const controlsWidth = 220;

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -11,7 +11,7 @@ export const colorOptions = {
 };
 
 /* static for now, then hand rolled version of https://github.com/digidem/react-dimensions */
-export const tipThresholdToDisplayLabels = 100;
+export const tipThresholdToDisplayLabels = 75;
 export const width = 1126; /* no longer used */
 export const margin = 60;
 export const controlsWidth = 220;


### PR DESCRIPTION
@jameshadfield ---

I think this is safe to not review. This just cleans up the logic of tip label padding and moves breakpoint and fontsize size parameters to `PhyloTree.params`. Better to not have any references to `globals` in PhyloTree.