### PR TITLE
Replace all slashes with underscores when getting dataset path

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -17,7 +17,7 @@ export const getDatapath = (pathname, availableDatasets) => {
   if (parsedParams.valid) {
     return makeDataPathFromParsedParams(parsedParams);
   }
-  return pathname.replace(/^\//, '').replace(/\/$/, '').replace('/', '_');
+  return pathname.replace(/^\//, '').replace(/\/$/, '').replace(/\//g, '_');
 };
 
 export const chooseDisplayComponentFromPathname = (pathname) => {


### PR DESCRIPTION
Replaces all instances of forward slashes with underscores when parsing a URL to determine the path to search for JSONs. Previously only replaced the first occurrence with an underscore, causing files with multiple underscore-delimited fields to not be found except when added to `manifest.json`.

_Fixes #538._