### PR TITLE
Add untangle flag and set to false

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -10,6 +10,7 @@ import * as callbacks from "./reactD3Interface/callbacks";
 import { tabSingle, darkGrey, lightGrey } from "../../globalStyles";
 import { renderTree } from "./reactD3Interface/initialRender";
 import Tangle from "./tangle";
+import { attemptUntangle } from "../../util/globals";
 import { untangleTreeToo } from "./tangle/untangling";
 
 class Tree extends React.Component {
@@ -36,7 +37,9 @@ class Tree extends React.Component {
     /* this.setState(newState) will be run sometime after this returns */
     /* modifies newState in place */
     newState.treeToo = new PhyloTree(props.treeToo.nodes, "RIGHT");
-    untangleTreeToo(newState.tree, newState.treeToo);
+    if (attemptUntangle) {
+      untangleTreeToo(newState.tree, newState.treeToo);
+    }
     renderTree(this, false, newState.treeToo, props);
   }
   componentDidMount() {

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -37,6 +37,7 @@ export const reallySmallNumber = -100000000;
 export const reallyBigNumber = 10000000;
 export const LBItime_window = 0.5;
 export const LBItau = 0.0005;
+export const attemptUntangle = false;
 export const mutType = "aa";
 export const default_gene = "nuc";
 export const plot_frequencies = false;


### PR DESCRIPTION
@jameshadfield and @rneher  ---

After looking at a number of flu tangletrees, I really think it's easier to understand whats going on with reassortment when TreeToo is left alone. I like seeing its proper branching structure. The detangling screws with this. For example compare:

#### WIthout detangling

![untangle-off](https://user-images.githubusercontent.com/1176109/41007990-5d9b423a-68dd-11e8-83cb-d71f69f7a619.png)

#### With detangling

![untangle-on](https://user-images.githubusercontent.com/1176109/41007996-6358de94-68dd-11e8-976a-0e4396025762.png)

Without detangling I can easily see that A2/re (in orange) is sister clade to A1a (in green) in NA. However, with detangling I can't really make this out to the same degree. There are a number of situations like this.

I think a big part of this that the objective function tries to make y coordinates similar. However, I think a better objective function may be about number of line crossings. After untangling there's still a lot of line crossing and not much cleaner, while distorting clade structure in TreeToo. Should be more about cleaning up clades near the tips and not near the root.

I suggest to turn off detangling for the time being. Or add a toggle to the sidebar. But still default to off.
