### PR TITLE
fix narrative twitter errors

### DIFF
--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -70,7 +70,9 @@ class Narrative extends React.Component {
     this.blockRefs = [];
   }
   componentDidMount() {
-    window.twttr.widgets.load();
+    if (window.twttr && window.twttr.ready) {
+      window.twttr.widgets.load();
+    }
     if (this.state.focus !== 1) {
       this.blockRefs[this.state.focus].scrollIntoView({behavior: "instant", block: "center", inline: "center"});
     }


### PR DESCRIPTION
This removes fatal errors when using offline (as `window.twttr` was `undefined`), but not sure if it fixes your errors @tsibley.

Unfortunately we can't use `react-twitter-embed` (which we use on the static site) as the markdown is being turned into HTML on the server. I'm sure it'd be possible to run the twitter widget on the server side, but I'm hoping there's a simpler fix.