### PR TITLE
Show github links as dataset (in sidebar) for community URLs

### DIFF
--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -1,13 +1,15 @@
 import React from "react";
 import { connect } from "react-redux";
 import ChooseDatasetSelect from "./choose-dataset-select";
+import { darkGrey } from "../../globalStyles";
 
 const renderGithubInfo = () => {
   const parts = window.location.pathname.split("/");
   const repoURL = `github.com/${parts[2]}/${parts[3]}`;
   return (
-    <div style={{ fontSize: 14 }}>
-      {"Data sourced from "}
+    <div style={{ fontSize: 14, marginTop: 5, marginBottom: 5 }}>
+      <i className="fa fa-clone fa-lg" style={{color: darkGrey}} aria-hidden="true"/>
+      <span style={{position: "relative"}}>{" "}</span>
       <a href={`https://${repoURL}`} target="_blank">{repoURL}</a>
     </div>
   );

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -2,6 +2,17 @@ import React from "react";
 import { connect } from "react-redux";
 import ChooseDatasetSelect from "./choose-dataset-select";
 
+const renderGithubInfo = () => {
+  const parts = window.location.pathname.split("/");
+  const repoURL = `github.com/${parts[2]}/${parts[3]}`;
+  return (
+    <div style={{ fontSize: 14 }}>
+      {"Data sourced from "}
+      <a href={`https://${repoURL}`} target="_blank">{repoURL}</a>
+    </div>
+  );
+};
+
 const renderBareDataPath = (source, fields) => (
   <div style={{ fontSize: 14 }}>
     {`Source: ${source || "unknown"}`}
@@ -25,7 +36,9 @@ class ChooseDataset extends React.Component {
        This helps the user know what they're looking at.
      */
     if (!this.props.available) {
-      return renderBareDataPath(this.props.source, this.props.datasetFields);
+      return this.props.source === "github" ?
+        renderGithubInfo() :
+        renderBareDataPath(this.props.source, this.props.datasetFields);
     }
 
     const selected = this.props.datasetFields;


### PR DESCRIPTION
For community URLs, this would change the dataset text in the sidebar to:

![image](https://user-images.githubusercontent.com/8350992/43681745-c40a4968-9811-11e8-842b-a8e422b7aeb7.png)
