### PR TITLE
Fix issue 619

### DIFF
--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -133,14 +133,12 @@ class ColorBy extends React.Component {
       if (gene==="nuc") return;
       position = "1"; /* if it's a gene, set position to trigger zoom */
     }
-    if (position.split(',').length === 1 && parseInt(position.split(','), 10) >= this.props.geneLength[gene]) {
-      position = "1"; /* if it's a position outside the gene, set to 1 to trigger zoom in another gene! */
+    let positions = position.split(',').filter((x) => parseInt(x, 10)); /* get rid of non-ints */
+    if (!positions.length) return; /* do nothing if no ints */
+    if (!(positions.every((x) => x > 0) && positions.every((x) => x < this.props.geneLength[gene]))) {
+      positions = [1];  /* is positions are outside gene, set to 1 to trigger zoom */
     }
-    const positions = position.split(',').filter((x) =>
-      parseInt(x, 10) > 0 && parseInt(x, 10) < this.props.geneLength[gene]
-    );
-    if (!positions.length) return;
-    const colorBy = "gt-"+gene+"_"+positions.join(','); 
+    const colorBy = "gt-"+gene+"_"+positions.join(',');
     analyticsControlsEvent("color-by-genotype");
     this.props.dispatch(changeColorBy(colorBy));
   }

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -222,7 +222,8 @@ export class Entropy extends React.Component {
             }
             /* if the zoom would be different enough, change it */
             if (!(startUpdate > zoomCoord[0]-maxNt*0.4 && startUpdate < zoomCoord[0]+maxNt*0.4) ||
-              !(endUpdate > zoomCoord[1]-maxNt*0.4 && endUpdate < zoomCoord[1]+maxNt*0.4)) {
+              !(endUpdate > zoomCoord[1]-maxNt*0.4 && endUpdate < zoomCoord[1]+maxNt*0.4) ||
+              !(positions.every((x) => x > zoomCoord[0]) && positions.every((x) => x < zoomCoord[1]))) {
               updateParams.gene = geneUpdate;
               updateParams.start = startUpdate;
               updateParams.end = endUpdate;


### PR DESCRIPTION
This fixes (hopefully) the issue [619](https://github.com/nextstrain/auspice/issues/619) where sometimes typing in a new nuc location would not zoom to that location. A test was added to check whether the nuc selected is within the visible region - if not, it re-zooms. 

I also improved the behaviour for when multiple nuc sites are selected and then the user switches to a gene whether none of those sites are inside the gene. Previously, it defaulted to "[gene] positions..." and didn't re-zoom. Now it sets position to 1 to trigger a colorBy event and thus a zoom to that gene. 

@jameshadfield can you check this seems to fix things?