### PR TITLE
Gap/N Excluded from Count/Entropy

### DIFF
--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -117,7 +117,6 @@ const getMutationsJSX = (d, mutType) => {
         return mut.slice(-1) === "N" || mut.slice(-1) === "-"
           || mut.slice(0, 1) === "N" || mut.slice(0, 1) === "-";
       });
-      console.log("ngaps", ngaps);
       const gapLen = ngaps.length; // number of mutations that exist with N/-
 
       // gather muts without N/-
@@ -125,7 +124,6 @@ const getMutationsJSX = (d, mutType) => {
         return mut.slice(-1) !== "N" && mut.slice(-1) !== "-"
           && mut.slice(0, 1) !== "N" && mut.slice(0, 1) !== "-";
       });
-      console.log("nucs", nucs);
       const nucLen = nucs.length; // number of mutations that exist without N/-
 
       let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -115,15 +115,17 @@ const getMutationsJSX = (d, mutType) => {
       // gather muts with N/-
       const ngaps = d.muts.filter((mut) => {
         return mut.slice(-1) === "N" || mut.slice(-1) === "-"
-          || mut.slice(0) === "N" || mut.slice(0) === "-";
+          || mut.slice(0, 1) === "N" || mut.slice(0, 1) === "-";
       });
+      console.log("ngaps", ngaps);
       const gapLen = ngaps.length; // number of mutations that exist with N/-
 
       // gather muts without N/-
       const nucs = d.muts.filter((mut) => {
         return mut.slice(-1) !== "N" && mut.slice(-1) !== "-"
-          && mut.slice(0) !== "N" && mut.slice(0) !== "-";
+          && mut.slice(0, 1) !== "N" && mut.slice(0, 1) !== "-";
       });
+      console.log("nucs", nucs);
       const nucLen = nucs.length; // number of mutations that exist without N/-
 
       let m = nucs.slice(0, Math.min(nDisplay, nucLen)).join(", ");

--- a/src/util/entropy.js
+++ b/src/util/entropy.js
@@ -28,7 +28,11 @@ const calcMutationCounts = (nodes, visibility, geneMap, isAA) => {
     } else if (n.muts) {
       n.muts.forEach((m) => {
         const pos = parseInt(m.slice(1, m.length - 1), 10);
-        sparse[pos] ? sparse[pos]++ : sparse[pos] = 1;
+        const A = m.slice(0, 1);
+        const B = m.slice(-1);
+        if (A !== "N" && A !== "-" && B !== "N" && B !== "-") {
+          sparse[pos] ? sparse[pos]++ : sparse[pos] = 1;
+        }
       });
     }
   });
@@ -88,6 +92,7 @@ const calcEntropy = (nodes, visibility, geneMap, isAA) => {
     const A = m.slice(0, 1);
     const B = m.slice(m.length - 1, m.length);
     // console.log("mut @ ", pos, ":", A, " -> ", B)
+    if (A === "N" || A === "-" || B === "N" || B === "-") return;
     if (!anc_state[prot][pos]) {
       // if we don't know the ancestral state, set it via the first encountered state
       anc_state[prot][pos] = A;


### PR DESCRIPTION
Addresses issue [199](https://github.com/nextstrain/augur/issues/199) (in augur). 

This change means mutations to/from 'N' or '-' (gap) aren't included in entropy and count calculations in the entropy graph. (Note that for the Lee TB dataset this means all nucleotide counts go to 1 - that's not a bug, it's real.) 

I also fixed a bug I noticed yesterday where 'N' or '-' at the start of a mutation wasn't being filtered correctly in the branch hover:
![image](https://user-images.githubusercontent.com/14290674/43957177-2f39c706-9ca7-11e8-8c2f-1ff99e4fe2a4.png)

This now shows correctly:
![image](https://user-images.githubusercontent.com/14290674/43957195-4ad2c670-9ca7-11e8-9c7d-3ccc142f20e0.png)
