### PR TITLE
Entropy Zoom in URL

### DIFF
--- a/src/actions/entropy.js
+++ b/src/actions/entropy.js
@@ -23,3 +23,8 @@ export const showCountsNotEntropy = (showCounts) => (dispatch, getState) => {
   dispatch({type: types.ENTROPY_COUNTS_TOGGLE, showCounts});
   updateEntropyVisibility(dispatch, getState);
 };
+
+export const changeZoom = (zoomc) => (dispatch, getState) => {
+  dispatch({type: types.CHANGE_ZOOM, zoomc});
+  updateEntropyVisibility(dispatch, getState);
+};

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -270,7 +270,6 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
   /* The one (bigish) problem with this being in the reducer is that
   we can't have any side effects. So if we detect and error introduced by
   a URL QUERY (and correct it in state), we can't correct the URL */
-  console.log("check correct errors");
   /* colorBy */
   if (!metadata.colorOptions) {
     metadata.colorOptions = {};
@@ -321,6 +320,10 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
     /* if it's a _non_ genotype colorBy AND it's not a valid option, fall back to the default */
     fallBackToDefaultColorBy();
   }
+
+  /* zoom */
+  if (state.zoomMax > state["absoluteZoomMax"]) { state.zoomMax = state["absoluteZoomMax"]; }
+  if (state.zoomMin < state["absoluteZoomMin"]) { state.zoomMin = state["absoluteZoomMin"]; }
 
   /* colorBy confidence */
   state["colorByConfidence"] = checkColorByConfidence(state["attrs"], state["colorBy"]);
@@ -465,6 +468,8 @@ export const createStateFromQueryOrJSONs = ({
     controls = getDefaultControlsState();
     controls = modifyStateViaTree(controls, tree, treeToo);
     controls = modifyStateViaMetadata(controls, metadata);
+    controls["absoluteZoomMin"] = 0;
+    controls["absoluteZoomMax"] = entropy.lengthSequence;
     controls.available = json["_available"];
     controls.source = json["_source"];
     controls.datasetFields = json["_datasetFields"];
@@ -516,8 +521,6 @@ export const createStateFromQueryOrJSONs = ({
     entropy.bars = entropyBars;
     entropy.maxYVal = entropyMaxYVal;
     entropy.zoomCoordinates = [controls["zoomMin"], controls["zoomMax"]];
-    controls["absoluteZoomMin"] = 0;
-    controls["absoluteZoomMax"] = entropy.lengthSequence;
   }
 
   /* update frequencies if they exist (not done for new JSONs) */

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -44,11 +44,11 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.l) {
     state["layout"] = query.l;
   }
-  if (query.zmin) {
-    state["zoomMin"] = parseInt(query.zmin, 10);
+  if (query.gmin) {
+    state["zoomMin"] = parseInt(query.gmin, 10);
   }
-  if (query.zmax) {
-    state["zoomMax"] = parseInt(query.zmax, 10);
+  if (query.gmax) {
+    state["zoomMax"] = parseInt(query.gmax, 10);
   }
   if (query.m) {
     state["distanceMeasure"] = query.m;

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -324,6 +324,11 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
   /* zoom */
   if (state.zoomMax > state["absoluteZoomMax"]) { state.zoomMax = state["absoluteZoomMax"]; }
   if (state.zoomMin < state["absoluteZoomMin"]) { state.zoomMin = state["absoluteZoomMin"]; }
+  if (state.zoomMin > state.zoomMax) {
+    const tempMin = state.zoomMin;
+    state.zoomMin = state.zoomMax;
+    state.zoomMax = tempMin;
+  }
 
   /* colorBy confidence */
   state["colorByConfidence"] = checkColorByConfidence(state["attrs"], state["colorBy"]);

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -44,6 +44,12 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.l) {
     state["layout"] = query.l;
   }
+  if (query.zmin) {
+    state["zoomMin"] = parseInt(query.zmin, 10);
+  }
+  if (query.zmax) {
+    state["zoomMax"] = parseInt(query.zmax, 10);
+  }
   if (query.m) {
     state["distanceMeasure"] = query.m;
   }
@@ -264,7 +270,7 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
   /* The one (bigish) problem with this being in the reducer is that
   we can't have any side effects. So if we detect and error introduced by
   a URL QUERY (and correct it in state), we can't correct the URL */
-
+  console.log("check correct errors");
   /* colorBy */
   if (!metadata.colorOptions) {
     metadata.colorOptions = {};
@@ -509,6 +515,9 @@ export const createStateFromQueryOrJSONs = ({
     const [entropyBars, entropyMaxYVal] = calcEntropyInView(tree.nodes, tree.visibility, controls.mutType, entropy.geneMap, entropy.showCounts);
     entropy.bars = entropyBars;
     entropy.maxYVal = entropyMaxYVal;
+    entropy.zoomCoordinates = [controls["zoomMin"], controls["zoomMax"]];
+    controls["absoluteZoomMin"] = 0;
+    controls["absoluteZoomMax"] = entropy.lengthSequence;
   }
 
   /* update frequencies if they exist (not done for new JSONs) */

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -120,6 +120,8 @@ const restoreQueryableStateToDefaults = (state) => {
   state["dateMax"] = state["absoluteDateMax"];
   state["dateMinNumeric"] = state["absoluteDateMinNumeric"];
   state["dateMaxNumeric"] = state["absoluteDateMaxNumeric"];
+  state["zoomMax"] = undefined;
+  state["zoomMin"] = undefined;
 
   state["panelLayout"] = calcBrowserDimensionsInitialState().width > twoColumnBreakpoint ? "grid" : "full";
   state.panelsToDisplay = state.panelsAvailable.slice();
@@ -525,6 +527,8 @@ export const createStateFromQueryOrJSONs = ({
     const [entropyBars, entropyMaxYVal] = calcEntropyInView(tree.nodes, tree.visibility, controls.mutType, entropy.geneMap, entropy.showCounts);
     entropy.bars = entropyBars;
     entropy.maxYVal = entropyMaxYVal;
+    entropy.zoomMax = controls["zoomMax"];
+    entropy.zoomMin = controls["zoomMin"];
     entropy.zoomCoordinates = [controls["zoomMin"], controls["zoomMax"]];
   }
 

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -46,3 +46,4 @@ export const TREE_TOO_DATA = "TREE_TOO_DATA";
 export const REMOVE_TREE_TOO = "REMOVE_TREE_TOO";
 export const TOGGLE_TANGLE = "TOGGLE_TANGLE";
 export const UPDATE_PATHNAME = "UPDATE_PATHNAME";
+export const CHANGE_ZOOM = "CHANGE_ZOOM";

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -60,7 +60,9 @@ EntropyChart.prototype.update = function update({
   clearSelected = false,
   gene = undefined,
   start = undefined,
-  end = undefined
+  end = undefined,
+  zoomMax = undefined,
+  zoomMin = undefined
 }) {
   const aaChange = aa !== undefined && aa !== this.aa;
   if (newBars || aaChange) {
@@ -84,6 +86,14 @@ EntropyChart.prototype.update = function update({
       .call(this.brush.move, () => {  /* scale so genes are a decent size. stop brushes going off graph */
         return [Math.max(this.scales.xNav(start-multiplier), this.scales.xNav(0)),
           Math.min(this.scales.xNav(end+multiplier), this.scales.xNav(this.scales.xNav.domain()[1]))];
+      });
+  }
+  if (zoomMin !== undefined || zoomMax !== undefined) {
+    const zMin = zoomMin === undefined ? 0 : zoomMin;
+    const zMax = zoomMax === undefined ? this.scales.xNav.domain()[1] : zoomMax;
+    this.navGraph.select(".brush")
+      .call(this.brush.move, () => {
+        return [this.scales.xNav(zMin), this.scales.xNav(zMax)];
       });
   }
 };

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -413,7 +413,11 @@ EntropyChart.prototype._addBrush = function _addBrush() {
     } else {
       this._zoom(start_end[0], start_end[1]);
     }
-    /* if the brushes are moved (by box, click drag, handle, or click), update zoom coords */
+  };
+
+  this.brushFinished = function brushFinished() {
+    this.brushed();
+    /* if the brushes were moved by box, click drag, handle, or click, then update zoom coords */
     if (d3event.sourceEvent instanceof MouseEvent && (!d3event.selection || d3event.sourceEvent.srcElement.id === "d3entropyParent" ||
         d3event.sourceEvent.srcElement.id === "")) {
       this.props.dispatch(changeZoom(this.zoomCoordinates));
@@ -441,8 +445,11 @@ EntropyChart.prototype._addBrush = function _addBrush() {
   this.brush = brushX()
     /* the extent is relative to the navGraph group - the constants are a bit hacky... */
     .extent([[this.offsets.x1, 0], [this.offsets.width + 20, this.offsets.heightNav - 1 + 25]])
-    .on("brush end", () => { // https://github.com/d3/d3-brush#brush_on
+    .on("brush", () => { // https://github.com/d3/d3-brush#brush_on
       this.brushed();
+    })
+    .on("end", () => {
+      this.brushFinished();
     });
   this.gBrush = this.navGraph.append("g")
     .attr("class", "brush")

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -62,11 +62,14 @@ const constructEncodedGenotype = (aa, d) => {
     showCounts: state.entropy.showCounts,
     loaded: state.entropy.loaded,
     colorBy: state.controls.colorBy,
+    zoomMin: state.controls.zoomMin,
+    zoomMax: state.controls.zoomMax,
     defaultColorBy: state.controls.defaults.colorBy,
     shouldReRender: false,
     panelLayout: state.controls.panelLayout
   };
 })
+
 export class Entropy extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -189,6 +189,10 @@ export class Entropy extends React.Component {
     } else { /* props changed, but a new render probably isn't required */
       timerStart("entropy D3 update");
       const updateParams = {};
+      if (this.props.zoomMax !== nextProps.zoomMax || this.props.zoomMin !== nextProps.zoomMin) {
+        updateParams.zoomMax = nextProps.zoomMax;
+        updateParams.zoomMin = nextProps.zoomMin;
+      }
       if (this.props.bars !== nextProps.bars) { /* will always be true if mutType has changed */
         updateParams.aa = nextProps.mutType === "aa";
         updateParams.newBars = nextProps.bars;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -32,6 +32,10 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       query = action.query;
       if (query.tt) delete query.tt;
       break;
+    case types.CHANGE_ZOOM:
+      query.zmin = action.zoomc[0] === state.controls.absoluteZoomMin ? undefined : action.zoomc[0];
+      query.zmax = action.zoomc[1] >= state.controls.absoluteZoomMax ? undefined : action.zoomc[1];
+      break;
     case types.NEW_COLORS:
       query.c = action.colorBy === state.controls.defaults.colorBy ? undefined : action.colorBy;
       break;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -33,8 +33,8 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       if (query.tt) delete query.tt;
       break;
     case types.CHANGE_ZOOM:
-      query.zmin = action.zoomc[0] === state.controls.absoluteZoomMin ? undefined : action.zoomc[0];
-      query.zmax = action.zoomc[1] >= state.controls.absoluteZoomMax ? undefined : action.zoomc[1];
+      query.gmin = action.zoomc[0] === state.controls.absoluteZoomMin ? undefined : action.zoomc[0];
+      query.gmax = action.zoomc[1] >= state.controls.absoluteZoomMax ? undefined : action.zoomc[1];
       break;
     case types.NEW_COLORS:
       query.c = action.colorBy === state.controls.defaults.colorBy ? undefined : action.colorBy;

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -67,7 +67,9 @@ export const getDefaultControlsState = () => {
     panelsToDisplay: [],
     panelLayout: calcBrowserDimensionsInitialState().width > twoColumnBreakpoint ? "grid" : "full",
     showTreeToo: undefined,
-    showTangle: false
+    showTangle: false,
+    zoomMin: undefined,
+    zoomMax: undefined
   };
 };
 

--- a/src/reducers/entropy.js
+++ b/src/reducers/entropy.js
@@ -3,6 +3,11 @@ import * as types from "../actions/types";
 
 const Entropy = (state = {loaded: false, showCounts: false}, action) => {
   switch (action.type) {
+    case types.CHANGE_ZOOM:
+      return Object.assign({}, state, {
+        zoomMax: action.zoomc[1],
+        zoomMin: action.zoomc[0]
+      });
     case types.DATA_INVALID:
       return {loaded: false, showCounts: false};
     case types.URL_QUERY_CHANGE_WITH_COMPUTED_STATE: /* fallthrough */

--- a/src/util/entropyCreateStateFromJsons.js
+++ b/src/util/entropyCreateStateFromJsons.js
@@ -2,6 +2,7 @@ import { genotypeColors } from "./globals";
 
 const getAnnotations = (jsonData) => {
   const annotations = [];
+  const nuc = [];
   let aaCount = 0;
   for (const prot of Object.keys(jsonData)) {
     if (prot !== "nuc") {
@@ -13,9 +14,14 @@ const getAnnotations = (jsonData) => {
         readingFrame: jsonData[prot].strand,
         fill: genotypeColors[aaCount % 10]
       });
+    } else {
+      nuc.push({
+        start: jsonData[prot].start,
+        end: jsonData[prot].end
+      });
     }
   }
-  return annotations;
+  return [annotations, nuc];
 };
 
 const processAnnotations = (annotations) => {
@@ -34,11 +40,15 @@ const processAnnotations = (annotations) => {
 
 export const entropyCreateStateFromJsons = (metaJSON) => {
   if (metaJSON.annotations) {
-    const annotations = getAnnotations(metaJSON.annotations);
+    // const annotations = getAnnotations(metaJSON.annotations);
+    const ant = getAnnotations(metaJSON.annotations);
+    const annotations = ant[0];
+    const lengthSequence = ant[1][0].end;
     return {
       showCounts: false,
       loaded: true,
       annotations,
+      lengthSequence,
       geneMap: processAnnotations(annotations)
     };
   }


### PR DESCRIPTION
This PR allows zooming to change the URL and also allows zoom coordinates to be read from the URL. (Issue [623](https://github.com/nextstrain/auspice/issues/623))

To allow the existing zoom functionality to work without cluttering the URL too much, zoom coordinates (`zmin` & `zmax`) should only show in the URL when the zoom is set manually rather than automatically. For example, selecting a gene from the drop down (or typing a nuc/AA) or clicking on an entropy site should mean that no zoom coordinates appear in the URL - these are set by the `colorBy` (`c` in the URL). 

However, moving the handles of the brush, the sides of the brush, or click-and-drag to set the brushes does cause zoom coordinates to appear in the URL. 

If just a `colorBy`/`c` is present in the URL, zoom will be set by this, as previously. If both a `colorBy`/`c` and zoom coordinates are present, colouring is set by the colorBy and the zoom coordinates override whatever 'default' zoom might apply to the selected AA/nuc, and are used for the zoom instead. 

If min or max zoom are out of bounds, they are set to 0 or absoluteZoomMax, respectively. If min zoom is larger than max, they are reversed. 

I've tested on Zika and TB, but would appreciate testing on other datasets & in general :)