### PR TITLE
specify zoom on tree by clade in URL

### DIFF
--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -62,6 +62,7 @@ export const createSummary = (virus_count, nodes, filters, visibility, visibleSt
     totalStateCounts: state.tree.totalStateCounts,
     visibility: state.tree.visibility,
     selectedStrain: state.tree.selectedStrain,
+    selectedClade: state.tree.selectedClade,
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     absoluteDateMin: state.controls.absoluteDateMin,
@@ -126,6 +127,7 @@ class Info extends React.Component {
     return this.props.filters.authors.length;
   }
   addFilteredDatesButton(buttons) {
+    console.log("this.props", this.props);
     buttons.push(
       <div key={"timefilter"} style={{display: "inline-block"}}>
         <div
@@ -164,7 +166,7 @@ class Info extends React.Component {
             className={'boxed-item-icon'}
             onClick={() => {
               this.props.dispatch(
-                updateVisibleTipsAndBranchThicknesses({tipSelected: {clear: true}})
+                updateVisibleTipsAndBranchThicknesses({tipSelected: {clear: true}, cladeSelected: this.props.selectedClade})
               );
             }}
             role="button"

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -28,7 +28,7 @@ export const addLeafCount = (node) => {
  */
 export const applyToChildren = (node, func) => {
   func(node);
-  if (node.terminal) {
+  if (node.terminal || node.children === undefined) { // in case clade set by URL, terminal hasn't been set yet!
     return;
   }
   for (let i = 0; i < node.children.length; i++) {

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -31,7 +31,7 @@ const PhyloTree = function PhyloTree(reduxNodes, debugId) {
       x: 0,
       y: 0,
       terminal: (typeof d.children === "undefined"),
-      inView: true /* each node is visible */
+      inView: d.inView !== undefined ? d.inView : true /* each node is visible, unless set earlier! */
     };
     d.shell = phyloNode; /* set the link from the redux node to the phylotree node */
     return phyloNode;

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -27,7 +27,7 @@ export const onTipClick = function onTipClick(d) {
   const tipSelected = d.that.params.orientation[0] === 1 ?
     {treeIdx: d.n.arrayIdx} :
     {treeTooIdx: d.n.arrayIdx};
-  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({tipSelected}));
+  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({tipSelected, cladeSelected: this.props.tree.selectedClade}));
 };
 
 
@@ -65,9 +65,13 @@ export const onBranchHover = function onBranchHover(d) {
 
 export const onBranchClick = function onBranchClick(d) {
   const root = [undefined, undefined];
+  let cladeSelected;
+  if (d.n.attr.labels !== undefined && d.n.attr.labels.clade !== undefined) {
+    cladeSelected = d.n.attr.labels.clade;
+  }
   if (d.that.params.orientation[0] === 1) root[0] = d.n.arrayIdx;
   else root[1] = d.n.arrayIdx;
-  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root}));
+  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root, cladeSelected}));
 };
 
 /* onBranchLeave called when mouse-off, i.e. anti-hover */
@@ -108,7 +112,7 @@ export const clearSelectedTip = function clearSelectedTip(d) {
   this.setState({selectedTip: null, hovered: null});
   /* restore the tip visibility! */
   this.props.dispatch(updateVisibleTipsAndBranchThicknesses(
-    {tipSelected: {clear: true}}
+    {tipSelected: {clear: true}, cladeSelected: this.props.tree.selectedClade}
   ));
 };
 

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -76,6 +76,7 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
     }
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS: {
       query.s = action.selectedStrain ? action.selectedStrain : undefined;
+      query.clade = action.cladeName ? action.cladeName : undefined;
       break;
     }
     case types.MAP_ANIMATION_PLAY_PAUSE_BUTTON:

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -23,7 +23,8 @@ export const getDefaultTreeState = () => {
     visibleStateCounts: {},
     totalStateCounts: {},
     availableBranchLabels: [],
-    selectedStrain: undefined
+    selectedStrain: undefined,
+    selectedClade: undefined
   };
 };
 
@@ -54,6 +55,8 @@ const Tree = (state = getDefaultTreeState(), action) => {
         branchThickness: action.branchThickness,
         branchThicknessVersion: action.branchThicknessVersion,
         idxOfInViewRootNode: action.idxOfInViewRootNode,
+        cladeName: action.cladeName,
+        selectedClade: action.cladeName,
         visibleStateCounts: countTraitsAcrossTree(state.nodes, action.stateCountAttrs, action.visibility, true),
         selectedStrain: action.selectedStrain
       };

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -12,6 +12,17 @@ export const strainNameToIdx = (nodes, name) => {
   return 0;
 };
 
+export const cladeNameToIdx = (nodes, name) => {
+  let i;
+  for (i = 0; i < nodes.length; i++) {
+    if (nodes[i].attr.labels !== undefined && nodes[i].attr.labels.clade !== undefined && nodes[i].attr.labels.clade === name) {
+      return i;
+    }
+  }
+  console.error("cladeNameToIdx couldn't find clade");
+  return 0;
+};
+
 /** calcBranchThickness **
 * returns an array of node (branch) thicknesses based on the tipCount at each node
 * If the node isn't visible, the thickness is 1.
@@ -104,7 +115,7 @@ const calcVisibility = (tree, controls, dates) => {
     try {
       inView = tree.nodes.map((d) => d.shell.inView);
     } catch (e) {
-      inView = tree.nodes.map(() => true);
+      inView = tree.nodes.map((d) => d.inView !== undefined ? d.inView : true);
     }
     /* intersect visibility and inView */
     visibility = visibility.map((cv, idx) => (cv && inView[idx]));


### PR DESCRIPTION
This PR should allow specification of the 'zoom' of the tree by specifying `clade=` in the URL. Clade is specified by `clade_annotation` in the tree.json and is what currently draws branch labels onto the tree (if specified). 

If the user zooms in on a clade this should change the URL, and if specified in the URL, should load accordingly. Could probably do with a bit more testing, but I think it plays nicely with everything else. 

This was a little tricky as `applyInViewNodesToTree` in `actions/tree.js` (sets visibility of nodes) modifies node.shell which does not yet exist at the point the URL queries are being 'read.' I've gotten around this by creating `node.inView` which is then used to set `shell` when it's created later (in `components/tree/phyloTree/phyloTree.js` constructor). I don't think this messes anything up, but perhaps there's a neater way. 

Should resolve issue [520](https://github.com/nextstrain/auspice/issues/520)

Allowing clades to be specified in modular augur by AA should hopefully be possible via the branch [clade ](https://github.com/nextstrain/augur/tree/clade) in augur