### PR TITLE
Replace non-standard property srcElement

### DIFF
--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -418,8 +418,8 @@ EntropyChart.prototype._addBrush = function _addBrush() {
   this.brushFinished = function brushFinished() {
     this.brushed();
     /* if the brushes were moved by box, click drag, handle, or click, then update zoom coords */
-    if (d3event.sourceEvent instanceof MouseEvent && (!d3event.selection || d3event.sourceEvent.srcElement.id === "d3entropyParent" ||
-        d3event.sourceEvent.srcElement.id === "")) {
+    if (d3event.sourceEvent instanceof MouseEvent && (!d3event.selection || d3event.sourceEvent.target.id === "d3entropyParent" ||
+        d3event.sourceEvent.target.id === "")) {
       this.props.dispatch(changeZoom(this.zoomCoordinates));
     } else {
       /* If selected gene or clicked on entropy, hide zoom coords */


### PR DESCRIPTION
The event property `srcElement` is non-standard and originates in IE, but doesn't exist in Firefox. I've replaced this with standard property `target`.
Should fix issue [635](https://github.com/nextstrain/auspice/issues/635) where entropy zoom breaks auspice in Firefox. 