### PR TITLE
Time slicing

### DIFF
--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -4,6 +4,8 @@ import UnconnectedTree from "./tree";
 const Tree = connect((state) => ({
   tree: state.tree,
   treeToo: state.treeToo,
+  dateMinNumeric: state.controls.dateMinNumeric,
+  dateMaxNumeric: state.controls.dateMaxNumeric,
   quickdraw: state.controls.quickdraw,
   colorBy: state.controls.colorBy,
   colorByConfidence: state.controls.colorByConfidence,

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -29,7 +29,7 @@ const updateNodesWithNewData = (nodes, newNodeProps) => {
  * Note that only the relevant functions are called on a transition.
  */
 const svgSetters = {
-  "attrs": {
+  attrs: {
     ".tip": {
       r: (d) => d.r,
       cx: (d) => d.xTip,
@@ -44,19 +44,20 @@ const svgSetters = {
       d: (d) => d.confLine
     }
   },
-  "styles": {
+  styles: {
     ".tip": {
-      "fill": (d) => d.fill,
-      "stroke": (d) => d.tipStroke,
-      "visibility": (d) => d["visibility"]
+      fill: (d) => d.fill,
+      stroke: (d) => d.tipStroke,
+      visibility: (d) => d["visibility"]
     },
     ".conf": {
-      "stroke": (d) => d.branchStroke,
+      stroke: (d) => d.branchStroke,
       "stroke-width": calcConfidenceWidth
     },
     ".branch": {
-      "stroke": (d) => d.branchStroke,
-      "stroke-width": (d) => d["stroke-width"] + "px" // style - as per drawBranches()
+      stroke: (d) => d.branchStroke,
+      "stroke-width": (d) => d["stroke-width"] + "px", // style - as per drawBranches()
+      cursor: (d) => d.visibility === "visible" ? "pointer" : "default"
     }
   }
 };
@@ -275,7 +276,7 @@ export const change = function change({
     /* check that visibility is not undefined */
     /* in the future we also change the branch visibility (after skeleton merge) */
     elemsToUpdate.add(".tip");
-    svgPropsToUpdate.add("visibility");
+    svgPropsToUpdate.add("visibility").add("cursor");
     nodePropsToModify.visibility = visibility;
   }
   if (changeTipRadii) {

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -150,7 +150,7 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
     this.updateTipLabels();
   }
   if (elemsToUpdate.has('.grid')) {
-    if (this.grid && this.layout !== "unrooted") this.addGrid(this.layout);
+    if (this.grid && this.layout !== "unrooted") this.addGrid();
     else this.hideGrid();
   }
   if (elemsToUpdate.has('.regression')) {
@@ -170,6 +170,11 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
     } else {
       this.removeConfidence(); /* see comment above */
     }
+  }
+
+  /* background temporal time slice */
+  if (extras.timeSliceHasPotentiallyChanged) {
+    this.addTemporalSlice();
   }
 
   /* branch labels */
@@ -197,6 +202,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     this.svg.selectAll(".tip").remove();
     this.drawTips();
     if (this.vaccines) this.drawVaccines();
+    this.addTemporalSlice();
     if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
     if (elemsToUpdate.has(".branchLabel")) this.drawBranchLabels(this.params.branchLabelKey);
   };
@@ -218,6 +224,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     .remove()
     .on("start", () => inProgress++)
     .on("end", step2);
+  this.removeTemporalSlice();
   if (!transitionTimeFadeOut) timerFlush();
 };
 
@@ -336,6 +343,7 @@ export const change = function change({
 
   /* Finally, actually change the SVG elements themselves */
   const extras = {removeConfidences, showConfidences, newBranchLabellingKey};
+  extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   if (useModifySVGInStages) {
     this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 1000);
   } else {

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -91,5 +91,7 @@ PhyloTree.prototype.updateTipLabels = labels.updateTipLabels;
 /* G R I D */
 PhyloTree.prototype.hideGrid = grid.hideGrid;
 PhyloTree.prototype.addGrid = grid.addGrid;
+PhyloTree.prototype.addTemporalSlice = grid.addTemporalSlice;
+PhyloTree.prototype.removeTemporalSlice = grid.removeTemporalSlice;
 
 export default PhyloTree;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -16,12 +16,13 @@ import { timerStart, timerEnd } from "../../../util/perf";
  * @param {array|null} tipRadii   -- array of tip radius'
  * @return {null}
  */
-export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, branchStroke, tipStroke, tipFill, tipRadii) {
+export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, branchStroke, tipStroke, tipFill, tipRadii, dateRange) {
   timerStart("phyloTree render()");
   this.svg = svg;
   this.params = Object.assign(this.params, parameters);
   this.callbacks = callbacks;
   this.vaccines = vaccines ? vaccines.map((d) => d.shell) : undefined;
+  this.dateRange = dateRange;
 
   /* set x, y values & scale them to the screen */
   this.setDistance(distance);
@@ -39,7 +40,10 @@ export const render = function render(svg, layout, distance, parameters, callbac
   });
 
   /* draw functions */
-  if (this.params.showGrid) this.addGrid();
+  if (this.params.showGrid) {
+    this.addGrid();
+    this.addTemporalSlice();
+  }
   this.drawBranches();
   this.drawTips();
   if (this.params.branchLabelKey) this.drawBranchLabels(this.params.branchLabelKey);

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -162,7 +162,7 @@ export const drawBranches = function drawBranches() {
         .style("stroke-linecap", "round")
         .style("stroke-width", (d) => d['stroke-width']+"px" || params.branchStrokeWidth)
         .style("fill", "none")
-        .style("cursor", "pointer")
+        .style("cursor", (d) => d.visibility === "visible" ? "pointer" : "default")
         .style("pointer-events", "auto")
         .on("mouseover", this.callbacks.onBranchHover)
         .on("mouseout", this.callbacks.onBranchLeave)

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -7,6 +7,7 @@ import { branchOpacityFunction } from "../../../util/colorHelpers";
 /* Callbacks used by the tips / branches when hovered / selected */
 
 export const onTipHover = function onTipHover(d) {
+  if (d.visibility !== "visible") return;
   const phylotree = d.that.params.orientation[0] === 1 ?
     this.state.tree :
     this.state.treeToo;
@@ -18,6 +19,7 @@ export const onTipHover = function onTipHover(d) {
 };
 
 export const onTipClick = function onTipClick(d) {
+  if (d.visibility !== "visible") return;
   // console.log("tip click", d)
   this.setState({
     hovered: null,
@@ -32,6 +34,7 @@ export const onTipClick = function onTipClick(d) {
 
 
 export const onBranchHover = function onBranchHover(d) {
+  if (d.visibility !== "visible") return;
   /* emphasize the color of the branch */
   for (const id of ["#branch_S_" + d.n.clade, "#branch_T_" + d.n.clade]) {
     if (this.props.colorByConfidence) {
@@ -64,6 +67,7 @@ export const onBranchHover = function onBranchHover(d) {
 };
 
 export const onBranchClick = function onBranchClick(d) {
+  if (d.visibility !== "visible") return;
   const root = [undefined, undefined];
   if (d.that.params.orientation[0] === 1) root[0] = d.n.arrayIdx;
   else root[1] = d.n.arrayIdx;

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -8,6 +8,10 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
   const oldTreeRedux = mainTree ? oldProps.tree : oldProps.treeToo;
   const newTreeRedux = mainTree ? newProps.tree : newProps.treeToo;
 
+  /* do any properties on the tree object need to be updated?
+  Note that updating properties itself won't trigger any visual changes */
+  phylotree.dateRange = [newProps.dateMinNumeric, newProps.dateMaxNumeric];
+
   /* catch selectedStrain dissapearence seperately to visibility and remove modal */
   if (oldTreeRedux.selectedStrain && !newTreeRedux.selectedStrain) {
     /* TODO change back the tip radius */

--- a/src/components/tree/reactD3Interface/initialRender.js
+++ b/src/components/tree/reactD3Interface/initialRender.js
@@ -10,7 +10,6 @@ export const renderTree = (that, main, phylotree, props) => {
     console.warn("can't run renderTree (not loaded)");
     return;
   }
-
   /* simply the call to phylotree.render */
   phylotree.render(
     select(ref),
@@ -40,6 +39,7 @@ export const renderTree = (that, main, phylotree, props) => {
     calcBranchStrokeCols(treeState, props.colorByConfidence, props.colorBy),
     treeState.nodeColors,
     treeState.nodeColors.map((col) => rgb(col).brighter([0.65]).toString()),
-    treeState.tipRadii /* might be null */
+    treeState.tipRadii, /* might be null */
+    [props.dateMinNumeric, props.dateMaxNumeric]
   );
 };

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -28,7 +28,7 @@ const calcBranchThickness = (nodes, visibility, rootIdx) => {
     maxTipCount = 1;
   }
   return nodes.map((d, idx) => (
-    visibility[idx] === "visible" ? freqScale((d.tipCount + 5) / (maxTipCount + 5)) : 1
+    visibility[idx] === "visible" ? freqScale((d.tipCount + 5) / (maxTipCount + 5)) : 0.5
   ));
 };
 


### PR DESCRIPTION
Watching people interact with auspice has made it apparent that branches which are not in the selection (time slice, filters etc) are confusing to people. We currently draw them thinner, but they are still there, with on-hover info boxes etc. This PR improves the visual distinction between in-selection and out-of-selection branches / tips, especially for time slices.

* on-hover info boxes no longer appear for out-of-selection branches / tips
* There is no longer the ability to click on out-of-selection branches (and the cursor no longer implies this ability)
* out-of-selection branches are now thinner
* for rectangular layouts & temporal trees there is a grey background indicating the selected time slice. This looks especially good for animations and generally improves clarity (in my opinion). 
    * Note that a bunch of tips & parts-of-branches are rendered as "in-selection" but out of this grey-time-slice... this is issue #473, those tips are actually out of the current selection.