### PR TITLE
Force default tree zoom to root

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -406,7 +406,7 @@ const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelect
     oldState.selectedStrain = tipSelected;
   }
   if (cladeSelected) {
-    const cladeSelectedIdx = cladeNameToIdx(oldState.nodes, cladeSelected);
+    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : cladeNameToIdx(oldState.nodes, cladeSelected);
     oldState.selectedClade = cladeSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState); // tipSelectedIdx, oldState);
   }
@@ -525,6 +525,8 @@ export const createStateFromQueryOrJSONs = ({
 
   if (query.clade) {
     tree = modifyTreeStateVisAndBranchThickness(tree, undefined, query.clade, controls);
+  } else { /* if not specifically given in URL, zoom to root */
+    tree = modifyTreeStateVisAndBranchThickness(tree, undefined, 'root', controls);
   }
   tree = modifyTreeStateVisAndBranchThickness(tree, query.s, undefined, controls);
   if (treeToo && treeToo.loaded) {


### PR DESCRIPTION
This is hopefully to resolve issue [643](https://github.com/nextstrain/auspice/issues/643).

If a clade zoom is not explicitly set in the URL, it forces the zoom to the root.

This shouldn't change now non-narrative builds work, as if you load via URL it will by default zoom to the root (if a clade isn't specified).

@jameshadfield would you mind checking this is ok, and if you think there's a better way?