### PR TITLE
Add more visible toggle between narrative & interactive modes

### DIFF
--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -13,10 +13,9 @@ import MapAnimationControls from "./map-animation";
 import PanelToggles from "./panel-toggles";
 import SearchStrains from "./search";
 import ToggleTangle from "./toggle-tangle";
-import { materialButton } from "../../globalStyles";
 
 
-const Controls = ({mapOn, goBackToNarratives}) => (
+const Controls = ({mapOn}) => (
   <div
     style={{
       display: "flex",
@@ -32,12 +31,6 @@ const Controls = ({mapOn, goBackToNarratives}) => (
       padding: "0px 20px 20px 20px"
     }}
   >
-
-    {goBackToNarratives ? (
-      <button style={{...materialButton, textAlign: "left"}} onClick={goBackToNarratives}>
-        {"Return to Narrative"}
-      </button>
-    ) : null}
 
     <Header text="Dataset"/>
     <ChooseDataset/>

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -143,10 +143,10 @@ class Narrative extends React.Component {
           END OF NARRATIVE
         </h3>
         <div style={{...linkStyles, textAlign: "center"}} onClick={() => this.reactPageScroller.goToPage(0)}>
-          Click here to Scroll back to top
+          Scroll back to the beginning
         </div>
         <div style={{...linkStyles, textAlign: "center", marginTop: "10px"}} onClick={this.exitNarrativeMode}>
-          Click here to Exit narrative mode
+          Leave the narrative & explore the data yourself
         </div>
       </div>
     ));

--- a/src/components/narrative/renderNarrativeToggle.js
+++ b/src/components/narrative/renderNarrativeToggle.js
@@ -11,8 +11,8 @@ export const renderNarrativeToggle = (dispatch, narrativeIsDisplayed) => {
         fontSize: 14,
         backgroundColor: "inherit",
         zIndex: 100,
-        position: "absolute",
-        right: 20,
+        position: "fixed",
+        right: 5,
         top: -1,
         cursor: "pointer",
         color: darkGrey

--- a/src/components/narrative/renderNarrativeToggle.js
+++ b/src/components/narrative/renderNarrativeToggle.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { TOGGLE_NARRATIVE } from "../../actions/types";
+import { tabSingle, darkGrey } from "../../globalStyles";
+
+
+export const renderNarrativeToggle = (dispatch, narrativeIsDisplayed) => {
+  return (
+    <button
+      style={{
+        ...tabSingle,
+        fontSize: 14,
+        backgroundColor: "inherit",
+        zIndex: 100,
+        position: "absolute",
+        right: 20,
+        top: -1,
+        cursor: "pointer",
+        color: darkGrey
+      }}
+      onClick={() => dispatch({type: TOGGLE_NARRATIVE, display: !narrativeIsDisplayed})}
+    >
+      {narrativeIsDisplayed ? "explore the data yourself" : "return to the narrative"}
+    </button>
+  );
+};

--- a/src/components/navBar/index.js
+++ b/src/components/navBar/index.js
@@ -3,7 +3,6 @@ import React from "react";
 import { normalNavBarHeight, narrativeNavBarHeight, titleColors } from "../../util/globals";
 import { darkGrey } from "../../globalStyles";
 import SidebarChevron from "../framework/sidebar-chevron";
-import { TOGGLE_NARRATIVE } from "../../actions/types";
 
 const logoPNG = require("../../images/nextstrain-logo-small.png");
 
@@ -90,31 +89,8 @@ const renderNarrativeTitle = (text, style) => (
   </div>
 );
 
-const renderViewInteractiveLink = (dispatch, style) => (
-  <div
-    key="viewinteractivedata"
-    style={style}
-    onClick={() => dispatch({type: TOGGLE_NARRATIVE, display: false})}
-  >
-    View interactive data
-  </div>
-);
-
-
-const NavBar = ({minified, mobileDisplay, toggleHandler, narrativeTitle, width, dispatch}) => {
+const NavBar = ({minified, mobileDisplay, toggleHandler, narrativeTitle, width}) => {
   const styles = getStyles({minified, narrative: !!narrativeTitle, width});
-  let links = [
-    renderLink("About", "/about",   styles.link),
-    renderLink("Docs",  "/docs",    styles.link),
-    renderLink("Blog",  "/blog",    styles.link)
-  ];
-  if (narrativeTitle) {
-    if (mobileDisplay) {
-      links = [renderViewInteractiveLink(dispatch, styles.link)];
-    } else {
-      links.push(renderViewInteractiveLink(dispatch, styles.link));
-    }
-  }
   return (
     <div id="NavBarContainer" style={styles.mainContainer}>
       <div style={styles.flexColumns}>
@@ -122,10 +98,13 @@ const NavBar = ({minified, mobileDisplay, toggleHandler, narrativeTitle, width, 
           <img alt="splashPage" width="40px" src={logoPNG}/>
         </a>
         {minified ? null : renderNextstrainTitle(styles.title)}
-        <div id="spacer" style={{flex: 5}}/>
+        <div style={{flex: 5}}/>
         <div style={styles.flexRows}>
           <div style={styles.flexColumns}>
-            {links}
+            <div style={{flex: 5}}/>
+            {renderLink("About", "/about",   styles.link)}
+            {renderLink("Docs",  "/docs",    styles.link)}
+            {renderLink("Blog",  "/blog",    styles.link)}
           </div>
           {narrativeTitle ? renderNarrativeTitle(narrativeTitle, styles.narrativeTitle) : null}
         </div>


### PR DESCRIPTION
This PR changes the UI for the toggle between narrative mode & interactive mode, as user testing indicated that it was too hidden.

Before:
![image](https://user-images.githubusercontent.com/8350992/44887594-dfc83a00-ac81-11e8-9f3b-66491c17a472.png)

After:
![image](https://user-images.githubusercontent.com/8350992/44887601-e8207500-ac81-11e8-9925-97930d96d5be.png)


