### PR TITLE
Fix last narrative scroll issue 578

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -185,7 +185,7 @@ class App extends React.Component {
       height: availableHeight,
       width: sidebarWidth,
       maxWidth: sidebarWidth,
-      overflowY: "scroll",
+      overflowY: "auto",
       overflowX: "hidden",
       boxShadow: '-3px 0px 3px -3px rgba(0, 0, 0, 0.2) inset'
     };
@@ -220,7 +220,6 @@ class App extends React.Component {
             <Narrative
               height={availableHeight - narrativeNavBarHeight}
               width={sidebarStyles.width}
-              style={{overflow: "hidden"}}
             /> :
             <Controls mapOn={mapOn}/>
           }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -185,7 +185,8 @@ class App extends React.Component {
       height: availableHeight,
       width: sidebarWidth,
       maxWidth: sidebarWidth,
-      overflow: "scroll",
+      overflowY: "scroll",
+      overflowX: "hidden",
       boxShadow: '-3px 0px 3px -3px rgba(0, 0, 0, 0.2) inset'
     };
     const contentStyles = {
@@ -219,6 +220,7 @@ class App extends React.Component {
             <Narrative
               height={availableHeight - narrativeNavBarHeight}
               width={sidebarStyles.width}
+              style={{overflow: "hidden"}}
             /> :
             <Controls mapOn={mapOn}/>
           }


### PR DESCRIPTION
Should hopefully fix the last remaining bit of issue [578](https://github.com/nextstrain/auspice/issues/578)

I get the 'tiny useless scroll bar' in IE, Edge, Firefox, and Chrome on Windows 10.

This should hopefully fix this. The scroll bar is still there in Chrome, IE, and Firefox, but it greyed out:
![image](https://user-images.githubusercontent.com/14290674/44993254-37281c00-af9a-11e8-8e00-a352afd711c4.png)
(Chrome)

However in Edge it is full-length (doesn't scroll that weird tiny bit), but is still selectable - that's why it's dark-grey below:
![image](https://user-images.githubusercontent.com/14290674/44993292-532bbd80-af9a-11e8-9af4-12581c800829.png)

I haven't checked how this impacts long narrative paragraphs that scroll off the page, or mobile. Checking that this fixes it on Linux and doesn't impact how currently viewed in OS X would also be good!

(Also note in IE and Edge the blue dots all cluster to the left... but I don't know if this is an 'issue' - it doesn't really impact functionality.)