### PR TITLE
Allow npm global install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ s3/
 ### npm ###
 node_modules/
 npm-debug.log
+*tgz

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ s3/
 
 src/*
 !src/server/*
+!src/version.js
 
 ### OSX ###
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+### App specific ###
+big_flu
+/data/
+/releases/
+/static/
+s3/
+/local_narratives/
+
+src/*
+!src/server/*
+
+### OSX ###
+.DS_Store
+
+### npm ###
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: node_js
 sudo: false
 node_js:
-  - "9"
+- '9'
 install:
-  - npm install
-  - pip install --user awscli
+- npm install
+- pip install --user awscli
 script:
-  - npm run build
+- npm run build
 after_success:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "release" ]]; then
-      npm run gzip-and-upload;
-      npm run redeploy-site;
-      npm run rebuild-docker-image;
-    fi
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "release" ]]; then
+  npm run gzip-and-upload; npm run redeploy-site; npm run rebuild-docker-image; fi
+deploy:
+  provider: npm
+  email: jhadfiel@fredhutch.org
+  api_key:
+    secure: q3E48VryY2/SnW0fjuAlVbl6xoib9U6RvbuXF1hiyyuAnFq/YA3lr9sFEfQFVs6GyBZ5baus/yqWi4MNJyR3d7F89Zz2eGSLN8HdBPKk0br1xmdB8apczghzZDvSNijGVvfTneTS1WhoM+0Ta35slZ0nIBqHTfyY4sHDzaib9X6ztIdp3niwOy1/XK0W8caX32QH0q3chsE+5aLG41brLRSqMkGOx/ScNdOCnvEKd1B7NmAshcA3+vy0Ev4S1l3MMLgsXEeYEeV9dDEbGzV7vB5VLPw6oSSwK/tNgdFPtx/ycScUqT2sxmlZB2F3DD0iG1b/DoeCYby8zA801JwDCjhtbCyZDWqHuDK/PScy4VELPCVDZSGxPpuRsH8ijdsunAw3K+s1uehITGl+cJ64f3+8iymdEIcNp1moRA6YoavSYb7iar3fi1gpT3MpdYGszcpVCo7diuHCcDo19uUeevDDdTq8xXBrkqySiA3k2H2QuWyk7bzNDj3Oc+H6JoCyKvI6Jmb35Rfe87qMYCfVMCQGLCSvhLvhG3qt/AwBY4uWvubjoAZok9op1Jj8hFBiQCKzDJ492mumwVdGQ32+9qHUQIh5CMMm4cODk489DCtQ/D6CAuVzIR5ZdPeJLxRT7JGr9Zi7sZRkM+XaLzjPu0VbRTZil+7WHpVkapBnsR8=
+  skip_cleanup: true
+  on:
+    branch: release
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Master: [![Build Status](https://travis-ci.com/nextstrain/auspice.svg?branch=master)](https://travis-ci.com/nextstrain/auspice)
 Release: [![Build Status](https://travis-ci.com/nextstrain/auspice.svg?branch=release)](https://travis-ci.com/nextstrain/auspice)
+npm: [![NPM version](https://img.shields.io/npm/v/auspice.svg?style=flat-square)](https://www.npmjs.com/package/auspice)
+
 
 ## Introduction
 
@@ -44,13 +46,27 @@ The commands `auspice`, `npm run server` and `npm run dev` accept the following 
 * `data:<path>` sets the source of local datasets, viewable via [localhost:4000/local](http://localhost:4000/local)
 * `narratives:<path>` sets the source of local narratives, viewable via [localhost:4000/local/narratives](http://localhost:4000/local/narratives)
 
-## How to install Node.js and npm
 
+## How to install Node.js and npm
 If you are comfortable using [conda](https://bioconda.github.io/), installing nodejs is as simple as `conda install -c conda-forge nodejs=9.11.1`.
 If you'd prefer not to use conda, `nvm` is an easy way to manage nodejs & npm versions -- [this guide walks you through the installation](https://nodesource.com/blog/installing-node-js-tutorial-using-nvm-on-mac-os-x-and-ubuntu/).
 
-## License and copyright
 
+## Releasing new versions.
+Make sure you are on `master` and are up-to-date with [github.com/nextstrain/auspice](http://github.com/nextstrain/auspice).
+Releasing should be as simple as then running `./releaseNewVersion` and following the prompts.
+
+
+## Deploying to npm
+This should be handled automatically when releases happen (assuming that the TravisCI build passes).
+To do this manually:
+* ensure your npm account is registered with [npmjs.com/package/auspice](https://www.npmjs.com/package/auspice)
+* build the `bundle.js` via `npm run build`
+* ensure the version number (`node server.js --version`) is different to [npmjs.com/package/auspice](https://www.npmjs.com/package/auspice)
+* `npm publish`
+
+
+## License and copyright
 Copyright 2014-2018 Trevor Bedford and Richard Neher.
 
 Source code to Nextstrain is made available under the terms of the [GNU Affero General Public License](LICENSE.txt) (AGPL). Nextstrain is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.

--- a/README.md
+++ b/README.md
@@ -3,53 +3,51 @@ Release: [![Build Status](https://travis-ci.com/nextstrain/auspice.svg?branch=re
 
 ## Introduction
 
-Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data. We provide a continually-updated view of publicly available data with powerful analytics and visualizations showing pathogen evolution and epidemic spread. Our goal is to aid epidemiological understanding and improve outbreak response. See [nextstrain.org/docs](https://nextstrain.org/docs) for more details.
+Auspice is an open-source interactive web app for visualising phylogenomic data.
+It is the app that powers all the vlisualisation on [nextstrain.org](https://nextstrain.org), which aims to provide a continually-updated view of publicly available pathogen genome data.
+Auspice was designed to aid epidemiological understanding and improve outbreak response, but is able to visualise a diverse range of datasets.
 
 
-Auspice is the code which powers all the nextstrain data viz -- e.g. [nextstrain.org/zika](https://nextstrain.org/zika).
-It is a javascript-based web app that gives an interactive visualization of genomic data (which is normally, but not necessarily, produced by [augur](https://github.com/nextstrain/augur)).
+Please see [nextstrain.org/docs/visualisation/introduction](https://nextstrain.org/docs/visualisation/introduction) for more information, including input file formats.
 
 
-## Local Installs
+## Local Installs via NPM
 
-#### Step 1: clone the git repository
+```
+npm install -g auspice
+```
+
+Then run the server via the `auspice` command and access local datasets in a web browser at [localhost:4000/local](http://localhost:4000/local).
+
+The source for the input JSONs defaults to the `<current_working_directory>/auspice` (or `<current_working_directory>` if that's not available).
+
+
+## Local Installs via GitHub
 
 ```
 cd nextstrain # or whichever folder you'd like to contain nextstrain repos in
 git clone https://github.com/nextstrain/auspice.git
 cd auspice
+npm install     # install package dependencies
+npm run build   # build the client javascript bundle
+npm run server  # start a local instance of the server
 ```
 
-#### Step 2: Install Node.js
+Then access the app via [localhost:4000/local](http://localhost:4000/local).
 
-If you are comfortable using conda, installing nodejs is as simple as `conda install -c conda-forge nodejs=9.11.1`. If you'd prefer not to use conda, I recommend using `nvm` in order to manage nodejs & npm versions -- [here's](https://nodesource.com/blog/installing-node-js-tutorial-using-nvm-on-mac-os-x-and-ubuntu/) a great guide to help you do this.
+By default, datasets and narratives are sourced out of the `auspice/data` and `auspice/local_narratives` directories (see below for how to change this).
 
+If you are modifying the code, running `npm run dev` (instead of `npm run build` and `npm run server`) will modify the bundle on-the-fly, allowing you to see changes without rebuilding. Note that changes to the server code require restarting the server to take effect.
 
-#### Step 3: Install required dependencies
+## Selecting the local datasets / narratives directory:
+The commands `auspice`, `npm run server` and `npm run dev` accept the following arguments:
+* `data:<path>` sets the source of local datasets, viewable via [localhost:4000/local](http://localhost:4000/local)
+* `narratives:<path>` sets the source of local narratives, viewable via [localhost:4000/local/narratives](http://localhost:4000/local/narratives)
 
-`npm install`
+## How to install Node.js and npm
 
-#### Step 4: Create / obtain data files (if you'd like to view local datasets)
-
-Auspice can either source data from your computer or from a server.
-If you'd like to view data files locally, the JSON(s) need to be present in the `data` directory (see [the docs](https://nextstrain.org/docs/bioinformatics/output-jsons) for the format of these).
-If you have local data files (e.g. produced via [augur](https://github.com/nextstrain/augur)) then copy them into this directory.
-If you'd like to download the latest JSONs which we are using for [nextstrain.org](nextstrain.org) then run `npm run get-data` which will download JSONs into `data`
-
-#### Step 5: Build auspice & server the server
-
-* Simplest: `npm run build && npm run server:local`.
-This builds the relevant bundles & starts the server accessing the datasets in `./data`.
-
-* To access datasets online (e.g. to mimic the live nextstrain site), instead run `npm run build && npm run server`.
-
-* In order to run the development server, which allows you to edit the source code on-the-fly, run `npm run dev` or `npm run dev:local` (the latter sources data from `./data`)
-
-
-#### Step 6: Open a browser
-Auspice can now be used via `localhost:4000`.
-If you have JSONS in `data` named `flu_europe_tree.json` & `flu_europe_meta.json`, then these can be viewed at `localhost:4000/flu/europe`.
-
+If you are comfortable using [conda](https://bioconda.github.io/), installing nodejs is as simple as `conda install -c conda-forge nodejs=9.11.1`.
+If you'd prefer not to use conda, `nvm` is an easy way to manage nodejs & npm versions -- [this guide walks you through the installation](https://nodesource.com/blog/installing-node-js-tutorial-using-nvm-on-mac-os-x-and-ubuntu/).
 
 ## License and copyright
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "node": "9.6.x",
     "npm": "5.6.x"
   },
+  "bin": {
+    "auspice": "./server.js"
+  },
   "scripts": {
     "postinstall": "npm run create-data-dir",
     "server": "node server.js",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "server:debug": "node --inspect server.js",
     "build": "rimraf dist && NODE_ENV=production BABEL_ENV=production webpack --config webpack.config.prod.js",
     "build:timing": "rimraf dist && NODE_ENV=production BABEL_ENV=timing  webpack --config webpack.config.prod.js",
-    "dev": "node server.js dev",
-    "start": "echo \"DEPRECATION WARNING: please use npm run dev instead of npm run start\" && npm run dev",
-    "start:local": "echo \"Please run 'npm run dev' and access local datasets via /local/... in the URL\"",
+    "dev": "node server.js --dev",
+    "start": "echo \"DEPRECATION WARNING: please use npm run dev instead of npm run start\" && npm run --dev",
+    "start:local": "echo \"Please run 'npm run --dev' and access local datasets via /local/... in the URL\"",
     "lint": "eslint src",
     "heroku-postbuild": "npm run build",
     "get-data": "./scripts/get-data.sh",
@@ -32,6 +32,7 @@
     "create-data-dir": "./scripts/create-data-dir.sh"
   },
   "dependencies": {
+    "argparse": "^1.0.10",
     "awesomplete": "^1.1.2",
     "babel-polyfill": "^6.26.0",
     "binomial": "^0.2.0",

--- a/releaseNewVersion.sh
+++ b/releaseNewVersion.sh
@@ -49,7 +49,7 @@ git diff-index --quiet HEAD -- # $? = 1 if uncommited changes
 # step 2: increment version number (req user input)
 step="2"
 packagesVersion=$(grep "\"version\":" package.json | sed -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/")
-srcVersion=$(grep "export const version" src/version.js | sed -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/")
+srcVersion=$(grep "const version" src/version.js | sed -E "s/.*([0-9]+.[0-9]+.[0-9]+).*/\1/")
 if [ ${packagesVersion} != ${srcVersion} ]
   then
     echo "packages.json version (${packagesVersion}) doesn't match version.js version (${srcVersion}). Fatal."

--- a/server.js
+++ b/server.js
@@ -7,14 +7,33 @@ const expressStaticGzip = require("express-static-gzip");
 const charon = require("./src/server/charon");
 const globals = require("./src/server/globals");
 const compression = require('compression');
+const argparse = require('argparse');
+const version = require('./src/version').version;
+
+const parser = new argparse.ArgumentParser({
+  version: version,
+  addHelp: true,
+  description: `Auspice version ${version}.`,
+  epilog: `
+  Auspice is an open-source interactive web app for visualising phylogenomic data.
+  This command starts the server, which will make visualisations available in your browser.
+  See nextstrain.org/docs/visualisation/introduction or github.com/nextstrain/auspice
+  for more details.
+  `
+});
+parser.addArgument('--dev', {action: "storeTrue", help: "Run (client) in development mode (hot reloading etc)"});
+parser.addArgument('--data', {help: "Directory where local datasets are sourced"});
+parser.addArgument('--narratives', {help: "Directory where local narratives are sourced"});
+const args = parser.parseArgs();
+console.dir(args);
+
 
 /* documentation in the static site! */
-const devServer = process.argv.indexOf("dev") !== -1;
-globals.setGlobals(process.argv);
+globals.setGlobals(args);
 
 /* if we are in dev-mode, we need to import specific libraries & set flags */
 let webpack, config, webpackDevMiddleware, webpackHotMiddleware;
-if (devServer) {
+if (args.dev) {
   webpack = require("webpack"); // eslint-disable-line
   config = require("./webpack.config.dev"); // eslint-disable-line
   webpackDevMiddleware = require("webpack-dev-middleware"); // eslint-disable-line
@@ -25,7 +44,7 @@ const app = express();
 app.set('port', process.env.PORT || 4000);
 app.use(compression());
 
-if (devServer) {
+if (args.dev) {
   const compiler = webpack(config);
   app.use(webpackDevMiddleware(compiler, {
     noInfo: true,
@@ -53,7 +72,7 @@ app.get("*", (req, res) => {
 const server = app.listen(app.get('port'), () => {
   console.log("-----------------------------------");
   console.log("Auspice server now running at http://localhost:" + server.address().port);
-  if (devServer) console.log(`*** DEVELOPMENT MODE ***`);
+  if (args.dev) console.log(`*** DEVELOPMENT MODE ***`);
   console.log(`Local datasets at http://localhost:${server.address().port}/local are sourced from ${global.LOCAL_DATA_PATH}`);
   console.log(`Local narratives at http://localhost:${server.address().port}/local/narratives are sourced from ${global.LOCAL_NARRATIVES_PATH}`);
   console.log("-----------------------------------\n\n");

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /* eslint no-console: off */
 const path = require("path");
 const express = require("express");

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ if (devServer) {
   }));
   app.use(webpackHotMiddleware(compiler));
 } else {
-  app.use("/dist", expressStaticGzip("dist"));
+  app.use("/dist", expressStaticGzip(path.resolve(__dirname, "dist")));
   app.use(express.static(path.resolve(__dirname, "dist")));
 }
 

--- a/server.js
+++ b/server.js
@@ -53,9 +53,8 @@ app.get("*", (req, res) => {
 const server = app.listen(app.get('port'), () => {
   console.log("-----------------------------------");
   console.log("Auspice server now running at http://localhost:" + server.address().port);
-  console.log("-----------------------------------");
-  console.log(devServer ? "Serving dev bundle with hot-reloading enabled" : "Serving compiled bundle from /dist");
-  console.log(`Local datasets sourced from ${global.LOCAL_DATA_PATH} can be accessed via "/local/..." URLs`);
-  console.log(`Local narratives sourced from ${global.LOCAL_NARRATIVES_PATH} can be accessed via "/local/narratives/..." URLs`);
+  if (devServer) console.log(`*** DEVELOPMENT MODE ***`);
+  console.log(`Local datasets at http://localhost:${server.address().port}/local are sourced from ${global.LOCAL_DATA_PATH}`);
+  console.log(`Local narratives at http://localhost:${server.address().port}/local/narratives are sourced from ${global.LOCAL_NARRATIVES_PATH}`);
   console.log("-----------------------------------\n\n");
 });

--- a/server.js
+++ b/server.js
@@ -52,7 +52,8 @@ app.get("*", (req, res) => {
 
 const server = app.listen(app.get('port'), () => {
   console.log("-----------------------------------");
-  console.log("Auspice server started on port " + server.address().port);
+  console.log("Auspice server now running at http://localhost:" + server.address().port);
+  console.log("-----------------------------------");
   console.log(devServer ? "Serving dev bundle with hot-reloading enabled" : "Serving compiled bundle from /dist");
   console.log(`Local datasets sourced from ${global.LOCAL_DATA_PATH} can be accessed via "/local/..." URLs`);
   console.log(`Local narratives sourced from ${global.LOCAL_NARRATIVES_PATH} can be accessed via "/local/narratives/..." URLs`);

--- a/src/server/globals.js
+++ b/src/server/globals.js
@@ -3,34 +3,66 @@ const path = require("path");
 const fs = require('fs');
 const manifestHelpers = require("./manifestHelpers");
 
-const setGlobals = (argv) => {
-  /* do we have a custom local data(sets) directory? */
-  global.LOCAL_DATA_PATH = path.resolve(__dirname, "..", "..", "data/"); /* default */
-  const customLocalDir = argv.filter((x) => x.startsWith("local"));
-  if (customLocalDir.length === 1 && customLocalDir[0].indexOf(":") !== -1) {
-    let ldp = customLocalDir[0].split(":")[1];
-    if (!ldp.endsWith("/")) ldp += "/";
-    ldp = path.resolve(ldp);
-    if (!fs.existsSync(ldp)) {
-      console.log(`ERROR -- local directory ${ldp} wasn't found. Falling back to default.`);
-    } else {
-      global.LOCAL_DATA_PATH = ldp;
-    }
-  }
-  /* do we have a custom local narratives directory? */
-  global.LOCAL_NARRATIVES_PATH = path.resolve(__dirname, "..", "..", "local_narratives/"); /* default */
-  const customLocalNarrativesDir = argv.filter((x) => x.startsWith("narratives"));
-  if (customLocalNarrativesDir.length === 1 && customLocalNarrativesDir[0].indexOf(":") !== -1) {
-    let ldp = customLocalNarrativesDir[0].split(":")[1];
-    if (!ldp.endsWith("/")) ldp += "/";
-    ldp = path.resolve(ldp);
-    if (!fs.existsSync(ldp)) {
-      console.log(`ERROR -- local narratives directory ${ldp} wasn't found. Falling back to default.`);
-    } else {
-      global.LOCAL_NARRATIVES_PATH = ldp;
-    }
-  }
+const isNpmGlobalInstall = () => {
+  return __dirname.indexOf("lib/node_modules/auspice") !== -1;
+};
 
+const processCmdLineArgs = (argv) => {
+  const args = {};
+  argv.filter((x) => x.indexOf(":") !== -1).forEach((argStr) => {
+    const argPair = argStr.split(":");
+    args[argPair[0]] = argPair[1];
+  });
+  return args;
+};
+
+const cleanUpPathname = (pathIn) => {
+  let pathOut = pathIn;
+  if (!pathOut.endsWith("/")) pathOut += "/";
+  if (pathOut.startsWith("~")) {
+    pathOut = path.join(process.env.HOME, pathOut.slice(1));
+  }
+  pathOut = path.resolve(pathOut);
+  if (!fs.existsSync(pathOut)) {
+    return undefined;
+  }
+  return pathOut;
+};
+
+const getCurrentDirectoriesFor = (type) => {
+  const cwd = process.cwd();
+  const folderName = type === "data" ? "auspice" : "narratives";
+  if (fs.existsSync(path.join(cwd, folderName))) {
+    return cleanUpPathname(path.join(cwd, folderName));
+  }
+  return cleanUpPathname(cwd);
+};
+
+
+const getLocalDataPath = (niceArgs) => {
+  let localPath;
+  if ("data" in niceArgs) {
+    localPath = cleanUpPathname(niceArgs.data);
+  } else if (isNpmGlobalInstall()) {
+    localPath = getCurrentDirectoriesFor("data");
+  }
+  return localPath;
+};
+
+const getLocalNarrativesPath = (niceArgs) => {
+  let localPath;
+  if ("narratives" in niceArgs) {
+    localPath = cleanUpPathname(niceArgs.narratives);
+  } else if (isNpmGlobalInstall()) {
+    localPath = getCurrentDirectoriesFor("narratives");
+  }
+  return localPath;
+};
+
+const setGlobals = (argv) => {
+  const niceArgs = processCmdLineArgs(argv);
+  global.LOCAL_DATA_PATH = getLocalDataPath(niceArgs) || path.resolve(__dirname, "..", "..", "data/");
+  global.LOCAL_NARRATIVES_PATH = getLocalNarrativesPath(niceArgs) || path.resolve(__dirname, "..", "..", "local_narratives/");
   global.REMOTE_DATA_LIVE_BASEURL = "http://data.nextstrain.org";
   global.REMOTE_DATA_STAGING_BASEURL = "http://staging.nextstrain.org";
   global.REMOTE_NARRATIVES_BASEURL = "http://cdn.rawgit.com/nextstrain/narratives/master";

--- a/src/server/globals.js
+++ b/src/server/globals.js
@@ -7,15 +7,6 @@ const isNpmGlobalInstall = () => {
   return __dirname.indexOf("lib/node_modules/auspice") !== -1;
 };
 
-const processCmdLineArgs = (argv) => {
-  const args = {};
-  argv.filter((x) => x.indexOf(":") !== -1).forEach((argStr) => {
-    const argPair = argStr.split(":");
-    args[argPair[0]] = argPair[1];
-  });
-  return args;
-};
-
 const cleanUpPathname = (pathIn) => {
   let pathOut = pathIn;
   if (!pathOut.endsWith("/")) pathOut += "/";
@@ -39,30 +30,29 @@ const getCurrentDirectoriesFor = (type) => {
 };
 
 
-const getLocalDataPath = (niceArgs) => {
+const getLocalDataPath = (args) => {
   let localPath;
-  if ("data" in niceArgs) {
-    localPath = cleanUpPathname(niceArgs.data);
+  if (args.data) {
+    localPath = cleanUpPathname(args.data);
   } else if (isNpmGlobalInstall()) {
     localPath = getCurrentDirectoriesFor("data");
   }
   return localPath;
 };
 
-const getLocalNarrativesPath = (niceArgs) => {
+const getLocalNarrativesPath = (args) => {
   let localPath;
-  if ("narratives" in niceArgs) {
-    localPath = cleanUpPathname(niceArgs.narratives);
+  if (args.narratives) {
+    localPath = cleanUpPathname(args.narratives);
   } else if (isNpmGlobalInstall()) {
     localPath = getCurrentDirectoriesFor("narratives");
   }
   return localPath;
 };
 
-const setGlobals = (argv) => {
-  const niceArgs = processCmdLineArgs(argv);
-  global.LOCAL_DATA_PATH = getLocalDataPath(niceArgs) || path.resolve(__dirname, "..", "..", "data/");
-  global.LOCAL_NARRATIVES_PATH = getLocalNarrativesPath(niceArgs) || path.resolve(__dirname, "..", "..", "local_narratives/");
+const setGlobals = (args) => {
+  global.LOCAL_DATA_PATH = getLocalDataPath(args) || path.resolve(__dirname, "..", "..", "data/");
+  global.LOCAL_NARRATIVES_PATH = getLocalNarrativesPath(args) || path.resolve(__dirname, "..", "..", "local_narratives/");
   global.REMOTE_DATA_LIVE_BASEURL = "http://data.nextstrain.org";
   global.REMOTE_DATA_STAGING_BASEURL = "http://staging.nextstrain.org";
   global.REMOTE_NARRATIVES_BASEURL = "http://cdn.rawgit.com/nextstrain/narratives/master";

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,5 @@
-export const version = "1.29.0";
+const version = "1.29.0";
+
+module.exports = {
+  version
+};


### PR DESCRIPTION
Closes #652

This allows auspice to be globally installed via npm (currently working via `npm install -g auspice`).

Default local datasets directory for a globally installed auspice is `<cwd>/auspice` (or `<cwd>` if that doesn't exist). As before, the command line argument `data:<path>` overwrites this. Narratives operate similarly.
