### PR TITLE
Publish release branch to npm via Travis

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,8 @@ script:
 - npm run build
 after_success:
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "release" ]]; then
-  npm run gzip-and-upload; npm run redeploy-site; npm run rebuild-docker-image; fi
-deploy:
-  provider: npm
-  email: jhadfiel@fredhutch.org
-  api_key:
-    secure: q3E48VryY2/SnW0fjuAlVbl6xoib9U6RvbuXF1hiyyuAnFq/YA3lr9sFEfQFVs6GyBZ5baus/yqWi4MNJyR3d7F89Zz2eGSLN8HdBPKk0br1xmdB8apczghzZDvSNijGVvfTneTS1WhoM+0Ta35slZ0nIBqHTfyY4sHDzaib9X6ztIdp3niwOy1/XK0W8caX32QH0q3chsE+5aLG41brLRSqMkGOx/ScNdOCnvEKd1B7NmAshcA3+vy0Ev4S1l3MMLgsXEeYEeV9dDEbGzV7vB5VLPw6oSSwK/tNgdFPtx/ycScUqT2sxmlZB2F3DD0iG1b/DoeCYby8zA801JwDCjhtbCyZDWqHuDK/PScy4VELPCVDZSGxPpuRsH8ijdsunAw3K+s1uehITGl+cJ64f3+8iymdEIcNp1moRA6YoavSYb7iar3fi1gpT3MpdYGszcpVCo7diuHCcDo19uUeevDDdTq8xXBrkqySiA3k2H2QuWyk7bzNDj3Oc+H6JoCyKvI6Jmb35Rfe87qMYCfVMCQGLCSvhLvhG3qt/AwBY4uWvubjoAZok9op1Jj8hFBiQCKzDJ492mumwVdGQ32+9qHUQIh5CMMm4cODk489DCtQ/D6CAuVzIR5ZdPeJLxRT7JGr9Zi7sZRkM+XaLzjPu0VbRTZil+7WHpVkapBnsR8=
-  skip_cleanup: true
-  on:
-    branch: release
-notifications:
-  email:
-    on_success: never
-    on_failure: always
+    npm run gzip-and-upload;
+    npm run redeploy-site;
+    npm run rebuild-docker-image;
+    npm publish;
+  fi


### PR DESCRIPTION
All that NPM needs is a `NPM_TOKEN` that can be obtained via the website (see [here](https://docs.npmjs.com/private-modules/ci-server-config#setting-up-environment-variables)). This was set as an environment variable in Travis. With this in place, publishing is just `npm publish`. I appended this to the end of the set of commands that's run on successful build of the `release` branch.

You can see it working here: https://travis-ci.com/nextstrain/auspice/builds/83951647#L580

@jameshadfield: I struggled with the getting the `deploy` statement of Travis CI to work previously and ended up preferring simple shell commands.

@tsibley: I see that both augur and CLI require you to manually run `twine upload dist/*"`. I thought better to make this as automated as possible here so we won't forget to publish and make sure we remember to run `npm run build` before every publish event. Do you see a problem with this? Otherwise, I'd think to move the `twine` calls to Travis as well.

