### PR TITLE
Remove .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ after_success:
     npm run gzip-and-upload;
     npm run redeploy-site;
     npm run rebuild-docker-image;
+    npm config set //registry.npmjs.org/:_authToken="$NPM_TOKEN";
     npm publish;
   fi


### PR DESCRIPTION
It broke local use of npm if NPM_TOKEN was missing from the environment.
Since the file was only meant for Travis CI, define the config
dynamically in .travis.yml instead.

Resolves #661.