### PR TITLE
Handle trees without date information

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -20,7 +20,7 @@ export const checkColorByConfidence = (attrs, colorBy) => {
 };
 
 export const getMinCalDateViaTree = (nodes, state) => {
-  // const minNumDate = nodes[0].attr.num_date - 0.01; /* slider should be earlier than actual day */
+  /* slider should be earlier than actual day */
   /* if no date, use some default dates - slider will not be visible */
   const minNumDate = nodes[0].attr.num_date ? nodes[0].attr.num_date - 0.01 : state.dateMaxNumeric - defaultDateRange;
   return numericToCalendar(minNumDate);
@@ -266,10 +266,10 @@ const modifyStateViaTree = (state, tree, treeToo) => {
   }
 
   /* does the tree have date information? if not, disable controls, modify view */
-  state.displayDates = Object.keys(tree.nodes[0].attr).indexOf("num_date") > -1;
+  state.branchLengthsToDisplay = Object.keys(tree.nodes[0].attr).indexOf("num_date") > -1 ? "divAndDate" : "divOnly";
 
-  /* if no displayDates is false, force to display by divergence */
-  if (state.displayDates === false) {
+  /* if branchLengthsToDisplay is divOnly, force to display by divergence */
+  if (state.branchLengthsToDisplay === "divOnly") {
     state.distanceMeasure = "div";
   }
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -237,7 +237,7 @@ const modifyStateViaTree = (state, tree, treeToo) => {
   state.dateMaxNumeric = calendarToNumeric(state.dateMax);
 
   if (treeToo) {
-    const min = getMinCalDateViaTree(treeToo.nodes);
+    const min = getMinCalDateViaTree(treeToo.nodes, state);
     const max = getMaxCalDateViaTree(treeToo.nodes);
     const minNumeric = calendarToNumeric(min);
     const maxNumeric = calendarToNumeric(max);

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -53,7 +53,7 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.gmax) {
     state["zoomMax"] = parseInt(query.gmax, 10);
   }
-  if (query.m) {
+  if (query.m && state.branchLengthsToDisplay === "divAndDate") {
     state["distanceMeasure"] = query.m;
   }
   if (query.c) {
@@ -404,6 +404,12 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
       query[`f_${filterType}`] = validValues.join(",");
     }
   }
+
+  /* can we display branch length by div or num_date? */
+  if (query.m && state.branchLengthsToDisplay !== "divAndDate") {
+    delete query.m;
+  }
+
   return state;
 };
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -266,12 +266,13 @@ const modifyStateViaTree = (state, tree, treeToo) => {
   }
 
   /* does the tree have date information? if not, disable controls, modify view */
-  state.branchLengthsToDisplay = Object.keys(tree.nodes[0].attr).indexOf("num_date") > -1 ? "divAndDate" : "divOnly";
+  state.branchLengthsToDisplay = Object.keys(tree.nodes[0].attr).indexOf("num_date") === -1 ? "divOnly" :
+    Object.keys(tree.nodes[0].attr).indexOf("div") === -1 ? "dateOnly" : "divAndDate";
 
-  /* if branchLengthsToDisplay is divOnly, force to display by divergence */
-  if (state.branchLengthsToDisplay === "divOnly") {
-    state.distanceMeasure = "div";
-  }
+  /* if branchLengthsToDisplay is divOnly, force to display by divergence
+    if branchLengthsToDisplay is dateONly, force to display by date */
+  state.distanceMeasure = state.branchLengthsToDisplay === "divOnly" ? "div" :
+    state.branchLengthsToDisplay === "dateOnly" ? "num_date" : state.distanceMeasure;
 
   state.selectedBranchLabel = tree.availableBranchLabels.indexOf("clade") !== -1 ? "clade" : "none";
   state.temporalConfidence = Object.keys(tree.nodes[0].attr).indexOf("num_date_confidence") > -1 ?

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -11,7 +11,7 @@ import { SelectLabel } from "../framework/select-label";
   return {
     layout: state.controls.layout,
     showTreeToo: state.controls.showTreeToo,
-    displayDates: state.controls.displayDates
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay
   };
 })
 class ChooseLayout extends React.Component {
@@ -37,7 +37,7 @@ class ChooseLayout extends React.Component {
     const styles = this.getStyles();
     const selected = this.props.layout;
 
-    if (this.props.displayDates) {
+    if (this.props.branchLengthsToDisplay === "divAndDate") {
       return (
         <div style={styles.container}>
           <SelectLabel text="Layout" extraStyles={{marginTop: "0px"}}/>
@@ -108,7 +108,7 @@ class ChooseLayout extends React.Component {
         </div>
       );
     }
-    /* else */
+    /* else - if divOnly */
     return (
       <div style={styles.container}>
         <SelectLabel text="Layout" extraStyles={{marginTop: "0px"}}/>

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -10,7 +10,8 @@ import { SelectLabel } from "../framework/select-label";
 @connect((state) => {
   return {
     layout: state.controls.layout,
-    showTreeToo: state.controls.showTreeToo
+    showTreeToo: state.controls.showTreeToo,
+    displayDates: state.controls.displayDates
   };
 })
 class ChooseLayout extends React.Component {
@@ -35,6 +36,79 @@ class ChooseLayout extends React.Component {
     if (this.props.showTreeToo) return null;
     const styles = this.getStyles();
     const selected = this.props.layout;
+
+    if (this.props.displayDates) {
+      return (
+        <div style={styles.container}>
+          <SelectLabel text="Layout" extraStyles={{marginTop: "0px"}}/>
+          <div style={{margin: 5}}>
+            <icons.RectangularTree width={25} stroke={selected === "rect" ? brandColor : darkGrey}/>
+            <button
+              key={1}
+              style={selected === "rect" ? materialButtonSelected : materialButton}
+              onClick={() => {
+                const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
+                if (!loopRunning) {
+                  analyticsControlsEvent("change-layout-rectangular");
+                  this.props.dispatch({ type: CHANGE_LAYOUT, data: "rect" });
+                }
+              }}
+            >
+              <span style={styles.title}> {"rectangular"} </span>
+            </button>
+          </div>
+          <div style={{margin: 5}}>
+            <icons.RadialTree width={25} stroke={selected === "radial" ? brandColor : darkGrey}/>
+            <button
+              key={2}
+              style={selected === "radial" ? materialButtonSelected : materialButton}
+              onClick={() => {
+                const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
+                if (!loopRunning) {
+                  analyticsControlsEvent("change-layout-radial");
+                  this.props.dispatch({ type: CHANGE_LAYOUT, data: "radial" });
+                }
+              }}
+            >
+              <span style={styles.title}> {"radial"} </span>
+            </button>
+          </div>
+          <div style={{margin: 5}}>
+            <icons.UnrootedTree width={25} stroke={selected === "unrooted" ? brandColor : darkGrey}/>
+            <button
+              key={3}
+              style={selected === "unrooted" ? materialButtonSelected : materialButton}
+              onClick={() => {
+                const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
+                if (!loopRunning) {
+                  analyticsControlsEvent("change-layout-unrooted");
+                  this.props.dispatch({ type: CHANGE_LAYOUT, data: "unrooted" });
+                }
+              }}
+            >
+              <span style={styles.title}> {"unrooted"} </span>
+            </button>
+          </div>
+          <div style={{margin: 5}}>
+            <icons.Clock width={25} stroke={selected === "clock" ? brandColor : darkGrey}/>
+            <button
+              key={4}
+              style={selected === "clock" ? materialButtonSelected : materialButton}
+              onClick={() => {
+                const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
+                if (!loopRunning) {
+                  analyticsControlsEvent("change-layout-clock");
+                  this.props.dispatch({ type: CHANGE_LAYOUT, data: "clock" });
+                }
+              }}
+            >
+              <span style={styles.title}> {"clock"} </span>
+            </button>
+          </div>
+        </div>
+      );
+    }
+    /* else */
     return (
       <div style={styles.container}>
         <SelectLabel text="Layout" extraStyles={{marginTop: "0px"}}/>
@@ -84,22 +158,6 @@ class ChooseLayout extends React.Component {
             }}
           >
             <span style={styles.title}> {"unrooted"} </span>
-          </button>
-        </div>
-        <div style={{margin: 5}}>
-          <icons.Clock width={25} stroke={selected === "clock" ? brandColor : darkGrey}/>
-          <button
-            key={4}
-            style={selected === "clock" ? materialButtonSelected : materialButton}
-            onClick={() => {
-              const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
-              if (!loopRunning) {
-                analyticsControlsEvent("change-layout-clock");
-                this.props.dispatch({ type: CHANGE_LAYOUT, data: "clock" });
-              }
-            }}
-          >
-            <span style={styles.title}> {"clock"} </span>
           </button>
         </div>
       </div>

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -82,63 +82,9 @@ class ChooseMetric extends React.Component {
           }
         </div>
       );
-    } else if (this.props.branchLengthsToDisplay === "divOnly") {
-      return (
-        <div style={styles.container}>
-          <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
-          <button
-            key={1}
-            style={selected === "div" ? materialButtonSelected : materialButton}
-            onClick={() => {
-              analyticsControlsEvent("tree-metric-divergence");
-              this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "div" });
-            }}
-          >
-            <span style={styles.title}> {"divergence"} </span>
-          </button>
-          {this.props.showTreeToo ?
-            null : (
-              <div style={styles.toggle}>
-                <Toggle
-                  display={this.props.temporalConfidence.display}
-                  on={this.props.temporalConfidence.on}
-                  callback={() => this.props.dispatch(toggleTemporalConfidence())}
-                  label="Show confidence intervals"
-                />
-              </div>
-            )
-          }
-        </div>
-      );
     }
-    /* else - if dateOnly */
-    return (
-      <div style={styles.container}>
-        <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
-        <button
-          key={1}
-          style={selected === "num_date" ? materialButtonSelected : materialButton}
-          onClick={() => {
-            analyticsControlsEvent("tree-metric-temporal");
-            this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "num_date" });
-          }}
-        >
-          <span style={styles.title}> {"time"} </span>
-        </button>
-        {this.props.showTreeToo ?
-          null : (
-            <div style={styles.toggle}>
-              <Toggle
-                display={this.props.temporalConfidence.display}
-                on={this.props.temporalConfidence.on}
-                callback={() => this.props.dispatch(toggleTemporalConfidence())}
-                label="Show confidence intervals"
-              />
-            </div>
-          )
-        }
-      </div>
-    );
+    /* else - if dateOnly or divOnly - don't show anything */
+    return (<div></div>);
   }
 }
 

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -15,7 +15,7 @@ import { SelectLabel } from "../framework/select-label";
   return {
     distanceMeasure: state.controls.distanceMeasure,
     showTreeToo: state.controls.showTreeToo,
-    displayDates: state.controls.displayDates,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
     temporalConfidence: state.controls.temporalConfidence
   };
 })
@@ -44,7 +44,7 @@ class ChooseMetric extends React.Component {
     const styles = this.getStyles();
     const selected = this.props.distanceMeasure;
     const potentialOffset = this.props.showTreeToo ? {marginTop: "0px"} : {};
-    if (this.props.displayDates) {
+    if (this.props.branchLengthsToDisplay === "divAndDate") {
       return (
         <div style={styles.container}>
           <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
@@ -83,7 +83,7 @@ class ChooseMetric extends React.Component {
         </div>
       );
     }
-    /* else */
+    /* else - if divOnly */
     return (
       <div style={styles.container}>
         <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -15,6 +15,7 @@ import { SelectLabel } from "../framework/select-label";
   return {
     distanceMeasure: state.controls.distanceMeasure,
     showTreeToo: state.controls.showTreeToo,
+    displayDates: state.controls.displayDates,
     temporalConfidence: state.controls.temporalConfidence
   };
 })
@@ -43,21 +44,51 @@ class ChooseMetric extends React.Component {
     const styles = this.getStyles();
     const selected = this.props.distanceMeasure;
     const potentialOffset = this.props.showTreeToo ? {marginTop: "0px"} : {};
+    if (this.props.displayDates) {
+      return (
+        <div style={styles.container}>
+          <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
+          <button
+            key={1}
+            style={selected === "num_date" ? materialButtonSelected : materialButton}
+            onClick={() => {
+              analyticsControlsEvent("tree-metric-temporal");
+              this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "num_date" });
+            }}
+          >
+            <span style={styles.title}> {"time"} </span>
+          </button>
+          <button
+            key={2}
+            style={selected === "div" ? materialButtonSelected : materialButton}
+            onClick={() => {
+              analyticsControlsEvent("tree-metric-divergence");
+              this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "div" });
+            }}
+          >
+            <span style={styles.title}> {"divergence"} </span>
+          </button>
+          {this.props.showTreeToo ?
+            null : (
+              <div style={styles.toggle}>
+                <Toggle
+                  display={this.props.temporalConfidence.display}
+                  on={this.props.temporalConfidence.on}
+                  callback={() => this.props.dispatch(toggleTemporalConfidence())}
+                  label="Show confidence intervals"
+                />
+              </div>
+            )
+          }
+        </div>
+      );
+    }
+    /* else */
     return (
       <div style={styles.container}>
         <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
         <button
           key={1}
-          style={selected === "num_date" ? materialButtonSelected : materialButton}
-          onClick={() => {
-            analyticsControlsEvent("tree-metric-temporal");
-            this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "num_date" });
-          }}
-        >
-          <span style={styles.title}> {"time"} </span>
-        </button>
-        <button
-          key={2}
           style={selected === "div" ? materialButtonSelected : materialButton}
           onClick={() => {
             analyticsControlsEvent("tree-metric-divergence");

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -82,20 +82,48 @@ class ChooseMetric extends React.Component {
           }
         </div>
       );
+    } else if (this.props.branchLengthsToDisplay === "divOnly") {
+      return (
+        <div style={styles.container}>
+          <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
+          <button
+            key={1}
+            style={selected === "div" ? materialButtonSelected : materialButton}
+            onClick={() => {
+              analyticsControlsEvent("tree-metric-divergence");
+              this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "div" });
+            }}
+          >
+            <span style={styles.title}> {"divergence"} </span>
+          </button>
+          {this.props.showTreeToo ?
+            null : (
+              <div style={styles.toggle}>
+                <Toggle
+                  display={this.props.temporalConfidence.display}
+                  on={this.props.temporalConfidence.on}
+                  callback={() => this.props.dispatch(toggleTemporalConfidence())}
+                  label="Show confidence intervals"
+                />
+              </div>
+            )
+          }
+        </div>
+      );
     }
-    /* else - if divOnly */
+    /* else - if dateOnly */
     return (
       <div style={styles.container}>
         <SelectLabel text="Branch Length" extraStyles={potentialOffset}/>
         <button
           key={1}
-          style={selected === "div" ? materialButtonSelected : materialButton}
+          style={selected === "num_date" ? materialButtonSelected : materialButton}
           onClick={() => {
-            analyticsControlsEvent("tree-metric-divergence");
-            this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "div" });
+            analyticsControlsEvent("tree-metric-temporal");
+            this.props.dispatch({ type: CHANGE_DISTANCE_MEASURE, data: "num_date" });
           }}
         >
-          <span style={styles.title}> {"divergence"} </span>
+          <span style={styles.title}> {"time"} </span>
         </button>
         {this.props.showTreeToo ?
           null : (

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -35,7 +35,6 @@ const Controls = ({mapOn}) => (
     <Header text="Dataset"/>
     <ChooseDataset/>
 
-    <Header text="Date Range"/>
     <DateRangeInputs/>
 
 

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -142,7 +142,7 @@ class DateRangeInputs extends React.Component {
 
     const styles = this.getStyles();
 
-    if (branchLengthsToDisplay === "divAndDate") {
+    if (branchLengthsToDisplay !== "divOnly") {
       return (
         <span style={{marginTop: "15px"}}>
           <Header text="Date Range"/>

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -6,10 +6,12 @@ import { controlsWidth, minDistanceDateSlider } from "../../util/globals";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { changeDateFilter } from "../../actions/tree";
 import { MAP_ANIMATION_PLAY_PAUSE_BUTTON } from "../../actions/types";
+import { Header } from "../framework/select-label";
 import { headerFont, darkGrey } from "../../globalStyles";
 
 @connect((state) => {
   return {
+    displayDates: state.controls.displayDates,
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     dateMinNumeric: state.controls.dateMinNumeric,
@@ -134,39 +136,46 @@ class DateRangeInputs extends React.Component {
     const absoluteMaxNumDate = this.props.absoluteDateMaxNumeric;
     const selectedMinNumDate = this.props.dateMinNumeric;
     const selectedMaxNumDate = this.props.dateMaxNumeric;
+    const displayDates = this.props.displayDates;
 
     const minDistance = minDistanceDateSlider * (absoluteMaxNumDate - absoluteMinNumDate);
 
     const styles = this.getStyles();
 
-    return (
-      <div>
-        <div style={{height: 5}}/>
-        <div style={{width: controlsWidth}}>
-          <Slider // numDates are handed to Slider
-            min={absoluteMinNumDate}
-            max={absoluteMaxNumDate}
-            defaultValue={[absoluteMinNumDate, absoluteMaxNumDate]}
-            value={[selectedMinNumDate, selectedMaxNumDate]}
-            /* debounce the onChange event, but ensure the final one goes through */
-            onChange={this.updateFromSlider.bind(this, true)}
-            onAfterChange={this.updateFromSlider.bind(this, false)}
-            minDistance={minDistance}
-            pearling
-            withBars
-          />
-        </div>
-        <div style={{height: 5}}/>
-        <div style={{width: controlsWidth}}>
-          <div style={{ ...styles.base, float: "left" }}>
-            {selectedMin}
+    if (displayDates) {
+      return (
+        <span style={{marginTop: "15px"}}>
+          <Header text="Date Range"/>
+          <div>
+            <div style={{height: 5}}/>
+            <div style={{width: controlsWidth}}>
+              <Slider // numDates are handed to Slider
+                min={absoluteMinNumDate}
+                max={absoluteMaxNumDate}
+                defaultValue={[absoluteMinNumDate, absoluteMaxNumDate]}
+                value={[selectedMinNumDate, selectedMaxNumDate]}
+                /* debounce the onChange event, but ensure the final one goes through */
+                onChange={this.updateFromSlider.bind(this, true)}
+                onAfterChange={this.updateFromSlider.bind(this, false)}
+                minDistance={minDistance}
+                pearling
+                withBars
+              />
+            </div>
+            <div style={{height: 5}}/>
+            <div style={{width: controlsWidth}}>
+              <div style={{ ...styles.base, float: "left" }}>
+                {selectedMin}
+              </div>
+              <div style={{ ...styles.base, float: "right" }}>
+                {selectedMax}
+              </div>
+            </div>
           </div>
-          <div style={{ ...styles.base, float: "right" }}>
-            {selectedMax}
-          </div>
-        </div>
-      </div>
-    );
+        </span>
+      );
+    }
+    return (<div></div>);
   }
 }
 

--- a/src/components/controls/date-range-inputs.js
+++ b/src/components/controls/date-range-inputs.js
@@ -11,7 +11,7 @@ import { headerFont, darkGrey } from "../../globalStyles";
 
 @connect((state) => {
   return {
-    displayDates: state.controls.displayDates,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     dateMinNumeric: state.controls.dateMinNumeric,
@@ -136,13 +136,13 @@ class DateRangeInputs extends React.Component {
     const absoluteMaxNumDate = this.props.absoluteDateMaxNumeric;
     const selectedMinNumDate = this.props.dateMinNumeric;
     const selectedMaxNumDate = this.props.dateMaxNumeric;
-    const displayDates = this.props.displayDates;
+    const branchLengthsToDisplay = this.props.branchLengthsToDisplay;
 
     const minDistance = minDistanceDateSlider * (absoluteMaxNumDate - absoluteMinNumDate);
 
     const styles = this.getStyles();
 
-    if (displayDates) {
+    if (branchLengthsToDisplay === "divAndDate") {
       return (
         <span style={{marginTop: "15px"}}>
           <Header text="Date Range"/>
@@ -175,6 +175,7 @@ class DateRangeInputs extends React.Component {
         </span>
       );
     }
+    /* else - if divOnly */
     return (<div></div>);
   }
 }

--- a/src/components/controls/map-animation.js
+++ b/src/components/controls/map-animation.js
@@ -9,6 +9,7 @@ import { materialButton, materialButtonSelected } from "../../globalStyles";
 @connect((state) => {
   return {
     // metadata: state.metadata,
+    displayDates: state.controls.displayDates,
     mapAnimationStartDate: state.controls.mapAnimationStartDate,
     mapAnimationDurationInMilliseconds: state.controls.mapAnimationDurationInMilliseconds,
     mapAnimationCumulative: state.controls.mapAnimationCumulative,
@@ -62,52 +63,56 @@ class MapAnimationControls extends React.Component {
 
   render() {
 
-    return (
-      <div id="mapAnimationControls">
+    if (this.props.displayDates) {
+      return (
+        <div id="mapAnimationControls">
 
-        <div style={{marginTop: 5, marginBottom: 5}}>
-          <SelectLabel text="Animation speed"/>
-          <button
-            style={this.props.mapAnimationDurationInMilliseconds === 60000 ? materialButtonSelected : materialButton}
-            onClick={this.handleChangeAnimationTimeClicked("slow")}
-          >
-            Slow
-          </button>
-          <button
-            style={this.props.mapAnimationDurationInMilliseconds === 30000 ? materialButtonSelected : materialButton}
-            onClick={this.handleChangeAnimationTimeClicked("medium")}
-          >
-            Medium
-          </button>
-          <button
-            style={this.props.mapAnimationDurationInMilliseconds === 15000 ? materialButtonSelected : materialButton}
-            onClick={this.handleChangeAnimationTimeClicked("fast")}
-          >
-            Fast
-          </button>
+          <div style={{marginTop: 5, marginBottom: 5}}>
+            <SelectLabel text="Animation speed"/>
+            <button
+              style={this.props.mapAnimationDurationInMilliseconds === 60000 ? materialButtonSelected : materialButton}
+              onClick={this.handleChangeAnimationTimeClicked("slow")}
+            >
+              Slow
+            </button>
+            <button
+              style={this.props.mapAnimationDurationInMilliseconds === 30000 ? materialButtonSelected : materialButton}
+              onClick={this.handleChangeAnimationTimeClicked("medium")}
+            >
+              Medium
+            </button>
+            <button
+              style={this.props.mapAnimationDurationInMilliseconds === 15000 ? materialButtonSelected : materialButton}
+              onClick={this.handleChangeAnimationTimeClicked("fast")}
+            >
+              Fast
+            </button>
+          </div>
+          <Toggle
+            display
+            on={this.props.mapAnimationShouldLoop}
+            callback={() => {
+              this.props.dispatch({ type: CHANGE_ANIMATION_LOOP, data: !this.props.mapAnimationShouldLoop });
+            }}
+            label="Loop animation"
+          />
+          <br/>
+
+          <Toggle
+            display
+            on={this.props.mapAnimationCumulative}
+            callback={() => {
+              analyticsControlsEvent("change-animation-cumulative");
+              this.props.dispatch({ type: CHANGE_ANIMATION_CUMULATIVE, data: !this.props.mapAnimationCumulative });
+            }}
+            label="Animate cumulative history"
+          />
+
         </div>
-        <Toggle
-          display
-          on={this.props.mapAnimationShouldLoop}
-          callback={() => {
-            this.props.dispatch({ type: CHANGE_ANIMATION_LOOP, data: !this.props.mapAnimationShouldLoop });
-          }}
-          label="Loop animation"
-        />
-        <br/>
-
-        <Toggle
-          display
-          on={this.props.mapAnimationCumulative}
-          callback={() => {
-            analyticsControlsEvent("change-animation-cumulative");
-            this.props.dispatch({ type: CHANGE_ANIMATION_CUMULATIVE, data: !this.props.mapAnimationCumulative });
-          }}
-          label="Animate cumulative history"
-        />
-
-      </div>
-    );
+      );
+    }
+    /* else */
+    return (<div></div>);
   }
 }
 

--- a/src/components/controls/map-animation.js
+++ b/src/components/controls/map-animation.js
@@ -63,7 +63,7 @@ class MapAnimationControls extends React.Component {
 
   render() {
 
-    if (this.props.branchLengthsToDisplay === "divAndDate") {
+    if (this.props.branchLengthsToDisplay !== "divOnly") {
       return (
         <div id="mapAnimationControls">
 

--- a/src/components/controls/map-animation.js
+++ b/src/components/controls/map-animation.js
@@ -9,7 +9,7 @@ import { materialButton, materialButtonSelected } from "../../globalStyles";
 @connect((state) => {
   return {
     // metadata: state.metadata,
-    displayDates: state.controls.displayDates,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
     mapAnimationStartDate: state.controls.mapAnimationStartDate,
     mapAnimationDurationInMilliseconds: state.controls.mapAnimationDurationInMilliseconds,
     mapAnimationCumulative: state.controls.mapAnimationCumulative,
@@ -63,7 +63,7 @@ class MapAnimationControls extends React.Component {
 
   render() {
 
-    if (this.props.displayDates) {
+    if (this.props.branchLengthsToDisplay === "divAndDate") {
       return (
         <div id="mapAnimationControls">
 
@@ -111,7 +111,7 @@ class MapAnimationControls extends React.Component {
         </div>
       );
     }
-    /* else */
+    /* else - if divOnly */
     return (<div></div>);
   }
 }

--- a/src/components/controls/slider.js
+++ b/src/components/controls/slider.js
@@ -43,7 +43,7 @@ function undoEnsureArray(x) {
 
 // undoEnsureArray(ensureArray(x)) === x
 
-var Slider = createReactClass({
+const Slider = createReactClass({
 
   propTypes: {
 

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -61,12 +61,12 @@ const arrayToSentence = (arr, {prefix=undefined, suffix=undefined, capatalise=tr
   return ret + " ";
 };
 
-export const createSummary = (virus_count, nodes, filters, visibility, visibleStateCounts, displayDates) => {
+export const createSummary = (virus_count, nodes, filters, visibility, visibleStateCounts, branchLengthsToDisplay) => {
   const nSelectedSamples = getNumSelectedTips(nodes, visibility);
   const sampledDateRange = getVisibleDateRange(nodes, visibility);
   /* Number of genomes & their date range */
   let summary = `Showing ${nSelectedSamples} of ${virus_count} genomes`;
-  if (displayDates) {
+  if (branchLengthsToDisplay !== "divOnly") {
     summary += ` sampled between ${styliseDateRange(sampledDateRange[0])} and ${styliseDateRange(sampledDateRange[1])}`;
   }
   /* parse filters */
@@ -76,7 +76,7 @@ export const createSummary = (virus_count, nodes, filters, visibility, visibleSt
     if (!n) return;
     filterTextArr.push(`${n} ${pluralise(filterName, n)}`);
   });
-  const prefix = displayDates ? "and comprising" : "comprising";
+  const prefix = branchLengthsToDisplay !== "divOnly" ? "and comprising" : "comprising";
   const filterText = arrayToSentence(filterTextArr, {prefix: prefix, capatalise: false});
   if (filterText.length) {
     summary += ` ${filterText}`;
@@ -102,7 +102,7 @@ export const createSummary = (virus_count, nodes, filters, visibility, visibleSt
     dateMax: state.controls.dateMax,
     absoluteDateMin: state.controls.absoluteDateMin,
     absoluteDateMax: state.controls.absoluteDateMax,
-    displayDates: state.controls.displayDates
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay
   };
 })
 class Info extends React.Component {
@@ -292,7 +292,7 @@ class Info extends React.Component {
     (2) The active filters: Filtered to [[Metsky et al Zika Virus Evolution And Spread In The Americas (76)]], [[Colombia (28)]].
     */
 
-    const summary = createSummary(this.props.metadata.virus_count, this.props.nodes, this.props.filters, this.props.visibility, this.props.visibleStateCounts, this.props.displayDates);
+    const summary = createSummary(this.props.metadata.virus_count, this.props.nodes, this.props.filters, this.props.visibility, this.props.visibleStateCounts, this.props.branchLengthsToDisplay);
 
     /* part II - the active filters */
     const filters = [];

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -61,12 +61,14 @@ const arrayToSentence = (arr, {prefix=undefined, suffix=undefined, capatalise=tr
   return ret + " ";
 };
 
-export const createSummary = (virus_count, nodes, filters, visibility, visibleStateCounts) => {
+export const createSummary = (virus_count, nodes, filters, visibility, visibleStateCounts, displayDates) => {
   const nSelectedSamples = getNumSelectedTips(nodes, visibility);
   const sampledDateRange = getVisibleDateRange(nodes, visibility);
   /* Number of genomes & their date range */
   let summary = `Showing ${nSelectedSamples} of ${virus_count} genomes`;
-  summary += ` sampled between ${styliseDateRange(sampledDateRange[0])} and ${styliseDateRange(sampledDateRange[1])}`;
+  if (displayDates) {
+    summary += ` sampled between ${styliseDateRange(sampledDateRange[0])} and ${styliseDateRange(sampledDateRange[1])}`;
+  }
   /* parse filters */
   const filterTextArr = [];
   Object.keys(filters).forEach((filterName) => {
@@ -74,7 +76,8 @@ export const createSummary = (virus_count, nodes, filters, visibility, visibleSt
     if (!n) return;
     filterTextArr.push(`${n} ${pluralise(filterName, n)}`);
   });
-  const filterText = arrayToSentence(filterTextArr, {prefix: "and comprising", capatalise: false});
+  const prefix = displayDates ? "and comprising" : "comprising";
+  const filterText = arrayToSentence(filterTextArr, {prefix: prefix, capatalise: false});
   if (filterText.length) {
     summary += ` ${filterText}`;
   } else {
@@ -98,7 +101,8 @@ export const createSummary = (virus_count, nodes, filters, visibility, visibleSt
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     absoluteDateMin: state.controls.absoluteDateMin,
-    absoluteDateMax: state.controls.absoluteDateMax
+    absoluteDateMax: state.controls.absoluteDateMax,
+    displayDates: state.controls.displayDates
   };
 })
 class Info extends React.Component {
@@ -288,7 +292,7 @@ class Info extends React.Component {
     (2) The active filters: Filtered to [[Metsky et al Zika Virus Evolution And Spread In The Americas (76)]], [[Colombia (28)]].
     */
 
-    const summary = createSummary(this.props.metadata.virus_count, this.props.nodes, this.props.filters, this.props.visibility, this.props.visibleStateCounts);
+    const summary = createSummary(this.props.metadata.virus_count, this.props.nodes, this.props.filters, this.props.visibility, this.props.visibleStateCounts, this.props.displayDates);
 
     /* part II - the active filters */
     const filters = [];

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -25,6 +25,7 @@ import { errorNotification } from "../../actions/notifications";
 @connect((state) => {
   return {
     // datasetGuid: state.tree.datasetGuid,
+    displayDates: state.controls.displayDates,
     absoluteDateMin: state.controls.absoluteDateMin,
     absoluteDateMax: state.controls.absoluteDateMax,
     treeVersion: state.tree.version,
@@ -446,19 +447,23 @@ class Map extends React.Component {
       position: "absolute",
       textTransform: "uppercase"
     };
-    return (
-      <div>
-        <button
-          style={{...buttonBaseStyle, top: 20, left: 20, width: 60, backgroundColor: this.props.animationPlayPauseButton === "Pause" ? pauseColor : goColor}}
-          onClick={this.playPauseButtonClicked}
-        >
-          {this.props.animationPlayPauseButton}
-        </button>
-        <button style={{...buttonBaseStyle, top: 20, left: 88, width: 60, backgroundColor: lightGrey}} onClick={this.resetButtonClicked}>
-          Reset
-        </button>
-      </div>
-    );
+    if (this.props.displayDates) {
+      return (
+        <div>
+          <button
+            style={{...buttonBaseStyle, top: 20, left: 20, width: 60, backgroundColor: this.props.animationPlayPauseButton === "Pause" ? pauseColor : goColor}}
+            onClick={this.playPauseButtonClicked}
+          >
+            {this.props.animationPlayPauseButton}
+          </button>
+          <button style={{...buttonBaseStyle, top: 20, left: 88, width: 60, backgroundColor: lightGrey}} onClick={this.resetButtonClicked}>
+            Reset
+          </button>
+        </div>
+      );
+    }
+    /* else */
+    return (<div></div>);
   }
 
   maybeCreateMapDiv() {

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -447,7 +447,7 @@ class Map extends React.Component {
       position: "absolute",
       textTransform: "uppercase"
     };
-    if (this.props.branchLengthsToDisplay === "divAndDate") {
+    if (this.props.branchLengthsToDisplay !== "divOnly") {
       return (
         <div>
           <button

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -25,7 +25,7 @@ import { errorNotification } from "../../actions/notifications";
 @connect((state) => {
   return {
     // datasetGuid: state.tree.datasetGuid,
-    displayDates: state.controls.displayDates,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
     absoluteDateMin: state.controls.absoluteDateMin,
     absoluteDateMax: state.controls.absoluteDateMax,
     treeVersion: state.tree.version,
@@ -447,7 +447,7 @@ class Map extends React.Component {
       position: "absolute",
       textTransform: "uppercase"
     };
-    if (this.props.displayDates) {
+    if (this.props.branchLengthsToDisplay === "divAndDate") {
       return (
         <div>
           <button
@@ -462,7 +462,7 @@ class Map extends React.Component {
         </div>
       );
     }
-    /* else */
+    /* else - divOnly */
     return (<div></div>);
   }
 

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -70,7 +70,7 @@ export const getDefaultControlsState = () => {
     showTangle: false,
     zoomMin: undefined,
     zoomMax: undefined,
-    displayDates: true
+    branchLengthsToDisplay: "divAndDate"
   };
 };
 
@@ -117,20 +117,20 @@ const Controls = (state = getDefaultControlsState(), action) => {
         if (state.temporalConfidence.display && action.data === "div") {
           return Object.assign({}, state, {
             distanceMeasure: action.data,
-            displayDates: state.displayDates,
+            branchLengthsToDisplay: state.branchLengthsToDisplay,
             temporalConfidence: Object.assign({}, state.temporalConfidence, {display: false, on: false})
           });
         } else if (state.layout === "rect" && action.data === "num_date") {
           return Object.assign({}, state, {
             distanceMeasure: action.data,
-            displayDates: state.displayDates,
+            branchLengthsToDisplay: state.branchLengthsToDisplay,
             temporalConfidence: Object.assign({}, state.temporalConfidence, {display: true})
           });
         }
       }
       return Object.assign({}, state, {
         distanceMeasure: action.data,
-        displayDates: state.displayDates
+        branchLengthsToDisplay: state.branchLengthsToDisplay
       });
     case types.CHANGE_DATES_VISIBILITY_THICKNESS: {
       const newDates = {quickdraw: action.quickdraw};

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -69,7 +69,8 @@ export const getDefaultControlsState = () => {
     showTreeToo: undefined,
     showTangle: false,
     zoomMin: undefined,
-    zoomMax: undefined
+    zoomMax: undefined,
+    displayDates: true
   };
 };
 
@@ -116,17 +117,20 @@ const Controls = (state = getDefaultControlsState(), action) => {
         if (state.temporalConfidence.display && action.data === "div") {
           return Object.assign({}, state, {
             distanceMeasure: action.data,
+            displayDates: state.displayDates,
             temporalConfidence: Object.assign({}, state.temporalConfidence, {display: false, on: false})
           });
         } else if (state.layout === "rect" && action.data === "num_date") {
           return Object.assign({}, state, {
             distanceMeasure: action.data,
+            displayDates: state.displayDates,
             temporalConfidence: Object.assign({}, state.temporalConfidence, {display: true})
           });
         }
       }
       return Object.assign({}, state, {
-        distanceMeasure: action.data
+        distanceMeasure: action.data,
+        displayDates: state.displayDates
       });
     case types.CHANGE_DATES_VISIBILITY_THICKNESS: {
       const newDates = {quickdraw: action.quickdraw};

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -142,8 +142,8 @@ const calcVisibility = (tree, controls, dates) => {
       if (inView[idx] && (filtered ? filtered[idx] : true)) {
         const nodeDate = node.attr.num_date;
         /* if without date, treetime probably not run - or would be inferred
-          so if displayDates false, then ensure node displayed */
-        if (!controls.displayDates && node.attr.num_date === undefined) {
+          so if branchLengthsToDisplay is "divOnly", then ensure node displayed */
+        if (controls.branchLengthsToDisplay === "divOnly" && node.attr.num_date === undefined) {
           return NODE_VISIBLE;
         }
         /* is the actual node date (the "end" of the branch) in the time slice? */

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -137,11 +137,15 @@ const calcVisibility = (tree, controls, dates) => {
         makeParentVisible(filtered, tree.nodes[idxsOfFilteredTips[i]]);
       }
     }
-
     /* intersect the various arrays contributing to visibility */
     const visibility = tree.nodes.map((node, idx) => {
       if (inView[idx] && (filtered ? filtered[idx] : true)) {
         const nodeDate = node.attr.num_date;
+        /* if without date, treetime probably not run - or would be inferred
+          so if displayDates false, then ensure node displayed */
+        if (!controls.displayDates && node.attr.num_date === undefined) {
+          return NODE_VISIBLE;
+        }
         /* is the actual node date (the "end" of the branch) in the time slice? */
         if (nodeDate >= dates.dateMinNumeric && nodeDate <= dates.dateMaxNumeric) {
           return NODE_VISIBLE;


### PR DESCRIPTION
Addresses half of issue [649](https://github.com/nextstrain/auspice/issues/649). 

This PR should allow auspice to handle cases where there is `branch_length` and `div` but no date information (or, date info only at the tips).

It works by looking at the root node to see if it has `num_date,` and if not, setting a new variable, `branchLengthsToDisplay,` to `divOnly` if so (default is `divAndDate`). 

This keeps the default dates behind-the-scenes (seemed the easiest work-around), ensures all nodes will be visible regardless of 'date' (or lack thereof), forces the default view to be `div`, removes the date-slider, 'Time' option (in 'Branch Length'), 'clock' option (in 'Layout'), and animation options from the controls, removes the 'play/reset' buttons from the map, and doesn't show the 'sampled between' in the info text.

This can be expanded to have a `dateOnly` option for trees with dates only.