### PR TITLE
Allow tree nodes to be hidden

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -3,6 +3,7 @@ import { calcConfidenceWidth } from "./confidence";
 import { applyToChildren } from "./helpers";
 import { timerStart, timerEnd } from "../../../util/perf";
 import { NODE_VISIBLE } from "../../../util/globals";
+import { getBranchVisibility } from "./renderers";
 
 /* loop through the nodes and update each provided prop with the new value
  * additionally, set d.update -> whether or not the node props changed
@@ -58,7 +59,8 @@ const svgSetters = {
     ".branch": {
       stroke: (d) => d.branchStroke,
       "stroke-width": (d) => d["stroke-width"] + "px", // style - as per drawBranches()
-      cursor: (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default"
+      cursor: (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default",
+      visibility: getBranchVisibility
     }
   }
 };
@@ -298,11 +300,11 @@ export const change = function change({
     nodePropsToModify["stroke-width"] = branchThickness;
   }
   if (newDistance || newLayout || zoomIntoClade || svgHasChangedDimensions) {
-    elemsToUpdate.add(".tip").add(".branch.S").add(".branch.T");
+    elemsToUpdate.add(".tip").add(".branch.S").add(".branch.T").add(".branch");
     elemsToUpdate.add(".vaccineCross").add(".vaccineDottedLine").add(".conf");
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
     elemsToUpdate.add(".grid").add(".regression");
-    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity");
+    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity").add("visibility");
   }
   if (newLayout) {
     useModifySVGInStages = true;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -120,6 +120,24 @@ export const drawTips = function drawTips() {
   timerEnd("drawTips");
 };
 
+/**
+ * given a tree node, decide whether the branch should be rendered
+ * This enforces the "hidden" property set in the dataset JSON
+ * @return {string}
+ */
+export const getBranchVisibility = (d) => {
+  const hiddenSetting = d.n.hidden;
+  if (hiddenSetting &&
+    (
+      hiddenSetting === 1 ||
+      (hiddenSetting === 2 && d.that.distance === "num_date") ||
+      (hiddenSetting === 3 && d.that.distance === "div")
+    )
+  ) {
+    return "hidden";
+  }
+  return "visible";
+};
 
 /**
  * adds all branches to the svg, these are paths with class branch, which comprise two groups
@@ -167,6 +185,7 @@ export const drawBranches = function drawBranches() {
         .style("stroke-linecap", "round")
         .style("stroke-width", (d) => d['stroke-width']+"px" || params.branchStrokeWidth)
         .style("fill", "none")
+        .style("visibility", getBranchVisibility)
         .style("cursor", (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default")
         .style("pointer-events", "auto")
         .on("mouseover", this.callbacks.onBranchHover)

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -129,9 +129,9 @@ export const getBranchVisibility = (d) => {
   const hiddenSetting = d.n.hidden;
   if (hiddenSetting &&
     (
-      hiddenSetting === 1 ||
-      (hiddenSetting === 2 && d.that.distance === "num_date") ||
-      (hiddenSetting === 3 && d.that.distance === "div")
+      hiddenSetting === "always" ||
+      (hiddenSetting === "timetree" && d.that.distance === "num_date") ||
+      (hiddenSetting === "divtree" && d.that.distance === "div")
     )
   ) {
     return "hidden";


### PR DESCRIPTION
This allows `node.hidden` to decide whether the node is rendered or not.
Try `localhost:4000/ZEBOV` for an example of what this can do.

Allowed values: (Will be added to docs when they exist)
not set or `0` -- always shown
`1` -- always hidden
`2` -- hidden for time trees only
`3` -- hidden for div trees only
