### PR TITLE
Swap rawgit CDN to githubusercontent CDN

### DIFF
--- a/src/server/globals.js
+++ b/src/server/globals.js
@@ -55,7 +55,7 @@ const setGlobals = (args) => {
   global.LOCAL_NARRATIVES_PATH = getLocalNarrativesPath(args) || path.resolve(__dirname, "..", "..", "local_narratives/");
   global.REMOTE_DATA_LIVE_BASEURL = "http://data.nextstrain.org";
   global.REMOTE_DATA_STAGING_BASEURL = "http://staging.nextstrain.org";
-  global.REMOTE_NARRATIVES_BASEURL = "http://cdn.rawgit.com/nextstrain/narratives/master";
+  global.REMOTE_NARRATIVES_BASEURL = "https://raw.githubusercontent.com/nextstrain/narratives/master";
   global.LIVE_MANIFEST = undefined;
   global.LOCAL_MANIFEST = undefined;
   global.STAGING_MANIFEST = undefined;

--- a/src/server/narratives.js
+++ b/src/server/narratives.js
@@ -135,7 +135,7 @@ const serveCommunityNarrative = (res, url, errorHandler) => {
   const orgName = urlParts[2];
   const repoName = urlParts[3];
   const filename = [repoName].concat(urlParts.slice(4)).join("_")+".md";
-  const fetchURL = `https://rawgit.com/${orgName}/${repoName}/master/narratives/${filename}`;
+  const fetchURL = `https://raw.githubusercontent.com/${orgName}/${repoName}/master/narratives/${filename}`;
   fetch(fetchURL)
     .then((result) => result.text())
     .then((fileContents) => {

--- a/src/server/sourceSelect.js
+++ b/src/server/sourceSelect.js
@@ -134,7 +134,7 @@ const constructPathToGet = (source, providedUrl, otherQueries) => {
     if (parts.length < 3) {
       throw new Error("Community URLs must be of format community/githubOrgName/repoName/...");
     }
-    fetchURL = `https://rawgit.com/${parts[1]}/${parts[2]}/master/auspice`;
+    fetchURL = `https://raw.githubusercontent.com/${parts[1]}/${parts[2]}/master/auspice`;
     auspiceURL = `community/${parts[1]}/`;
     datasetFields = parts.slice(2);
   } else if (source === "staging") {


### PR DESCRIPTION
Currently, "community" builds from nextstrain.org/community are being sourced from rawgit. However, rawgit is shutting down.

This moves the CDN source to githubusercontent, which is the official source for "raw" files from GitHub.

This PR would resolve #672.