### PR TITLE
Revise prettyString function to not lowercase further characters

### DIFF
--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -141,9 +141,7 @@ class Legend extends React.Component {
   }
 
   styleLabelText(label) {
-    if (this.props.colorBy === "clade_membership") {
-      return label; /* unchanged */
-    } else if (this.props.colorBy === "num_date") {
+    if (this.props.colorBy === "num_date") {
       const legendValues = this.props.colorScale.legendValues;
       if (
         (legendValues[legendValues.length-1] - legendValues[0] > 10) && /* range spans more than 10 years */

--- a/src/util/stringHelpers.js
+++ b/src/util/stringHelpers.js
@@ -20,7 +20,7 @@ export const prettyString = (x, {multiplier = false, trim = 0, camelCase = true,
     }
     x = x.replace(/_/g, " ");
     if (camelCase) {
-      x = x.replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1).toLowerCase());
+      x = x.replace(/\w\S*/g, (y) => y.charAt(0).toUpperCase() + y.substr(1));
     }
     if (removeComma) {
       x = x.replace(/,/g, "");


### PR DESCRIPTION
@jameshadfield ---

The function prettyString takes snake_case and converts to Title Case. This keeps basic functionality in place, but now doesn't lowercase following characters. This makes it so that the input "3c3.A" remains "3c3.A". This improves display of flu clade names in the frequency plot.

I tested this across other builds and coloring and could not find any regressions.