### PR TITLE
Fix URL query corruption when changing datasets

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -1,3 +1,4 @@
+import queryString from "query-string";
 import { createStateFromQueryOrJSONs } from "./recomputeReduxState";
 import { PAGE_CHANGE, URL_QUERY_CHANGE_WITH_COMPUTED_STATE } from "./types";
 import { loadJSONs } from "./loadData";
@@ -49,7 +50,7 @@ export const changePage = ({
 
   /* set some defaults */
   if (!path) path = window.location.pathname;  // eslint-disable-line
-  if (!query) query = window.location.search;  // eslint-disable-line
+  if (!query) query = queryString.parse(window.location.search);  // eslint-disable-line
   if (!queryToDisplay) queryToDisplay = query; // eslint-disable-line
   /* some booleans */
   const pathHasChanged = oldState.general.pathname !== path;


### PR DESCRIPTION
As described in #691, the query part of the URL was corrupted when
switching between datasets, e.g. coloring an HA tree by antigenic
advance and switching the segment to NA.

I bisected the bug to "Load datasets from a separate component"
(e026df9) and traced the problem to the query part being passed to the
PAGE_CHANGE action action as a string instead of a parsed object.
Notably, the bug existed in the previous version of the code as well,
but was harder to trigger.  Refactoring in the commit above made the bug
much easier to trigger and much more noticeable.

Resolves #691.