### PR TITLE
Don't display custom ebola footer for community builds

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -50,7 +50,7 @@ export const getAcknowledgments = (dispatch, styles) => {
   const preambleContent = "This work is made possible by the open sharing of genetic data by research groups from all over the world. We gratefully acknowledge their contributions.";
   const genericPreamble = (<div style={styles.preamble}>{preambleContent}</div>);
 
-  if (window.location.pathname.includes("ebola")) {
+  if (window.location.pathname.includes("ebola") && !window.location.pathname.includes("community")) {
     return (
       <div>
         {genericPreamble}


### PR DESCRIPTION
As a temporary fix until #707 is addressed, this PR removes the custom ebola footer from all community-sourced ebola builds.