### PR TITLE
Don't Count X for AA Diversity Chart

### DIFF
--- a/src/util/entropy.js
+++ b/src/util/entropy.js
@@ -21,7 +21,11 @@ const calcMutationCounts = (nodes, visibility, geneMap, isAA) => {
         for (const prot in n.aa_muts) { // eslint-disable-line
           n.aa_muts[prot].forEach((m) => {
             const pos = parseInt(m.slice(1, m.length - 1), 10);
-            sparse[prot][pos] ? sparse[prot][pos]++ : sparse[prot][pos] = 1;
+            const A = m.slice(0, 1);
+            const B = m.slice(-1);
+            if (A !== 'X' && B !== 'X') {
+              sparse[prot][pos] ? sparse[prot][pos]++ : sparse[prot][pos] = 1;
+            }
           });
         }
       }
@@ -92,9 +96,9 @@ const calcEntropy = (nodes, visibility, geneMap, isAA) => {
     const A = m.slice(0, 1);
     const B = m.slice(m.length - 1, m.length);
     // console.log("mut @ ", pos, ":", A, " -> ", B)
-    if (isAA){
-      if (A === "X" || A === "-" || B === "X" || B === "-") return;
-    }else{
+    if (isAA) {
+      if (A === "X" || B === "X") return;
+    } else {
       if (A === "N" || A === "-" || B === "N" || B === "-") return;
     }
     if (!anc_state[prot][pos]) {


### PR DESCRIPTION
With the update to allow recovery of ambiguous sites for Fasta-input in `augur`, there's now the possibility for many AA sites be 'X' at the tips. At the moment, these are counted as 'mutations' for the diversity chart:

Before the change:
![counts-before](https://user-images.githubusercontent.com/14290674/57612801-c815b500-7575-11e9-9f30-e29a5ad85abc.PNG)

But these should probably be disregarded from 'entropy' and 'count', as 'N' is in nucleotide data. I introduced a similar check as is already present for nucleotides in 'counts'. However, I decided that we may be interested in gaps ('-') in AA alignments (as this is a little more stringent than gaps in nucleotides, since they must be in-frame), so I allowed this to be counted both in 'entropy' and 'counts'. We can change this in future if it doesn't seem to actually be informative. 

After the change:
![counts-after](https://user-images.githubusercontent.com/14290674/57612999-28a4f200-7576-11e9-8306-135e678573a7.PNG)
