### PR TITLE
src/components/tree/phyloTree/grid.js:

### DIFF
--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -77,8 +77,12 @@ export const addGrid = function addGrid() {
       const pos = gridMin + step*ii;
       majorGridPoints.push([pos, ((pos<minVis)||(pos>maxVis))?"hidden":"visible", "x"]);
     }
-    const numMinorTicks = this.distanceMeasure === "num_date" ? this.params.minorTicksTimeTree : this.params.minorTicks;
+    let numMinorTicks = this.distanceMeasure === "num_date" ? this.params.minorTicksTimeTree : this.params.minorTicks;
+    if (step===5 || step===10){
+      numMinorTicks=5;
+    }
     const minorStep = step / numMinorTicks;
+    console.log(step, numMinorTicks, minorStep);
     for (let ii = 0; ii <= (xmax - gridMin)/minorStep+30; ii++) {
       const pos = gridMin + minorStep*ii;
       minorGridPoints.push([pos, ((pos<minVis)||(pos>maxVis+minorStep))?"hidden":"visible", "x"]);

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -78,11 +78,10 @@ export const addGrid = function addGrid() {
       majorGridPoints.push([pos, ((pos<minVis)||(pos>maxVis))?"hidden":"visible", "x"]);
     }
     let numMinorTicks = this.distanceMeasure === "num_date" ? this.params.minorTicksTimeTree : this.params.minorTicks;
-    if (step===5 || step===10){
-      numMinorTicks=5;
+    if (step===5 || step===10) {
+      numMinorTicks = 5;
     }
     const minorStep = step / numMinorTicks;
-    console.log(step, numMinorTicks, minorStep);
     for (let ii = 0; ii <= (xmax - gridMin)/minorStep+30; ii++) {
       const pos = gridMin + minorStep*ii;
       minorGridPoints.push([pos, ((pos<minVis)||(pos>maxVis+minorStep))?"hidden":"visible", "x"]);


### PR DESCRIPTION
If the major grid is 5 or 10y use 5 minor ticks instead of 4. This avoids the odd case when our grid lines in the tree are:
2010, 2011.25, 2012.5, 2013.75 and 2015
and replaces this in favor of
2010, 2011, 2012, 2013, 2014 and 2015
(analogously for 10y intervals). 