### PR TITLE
Dynamically add tip labels

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -263,7 +263,7 @@ export const change = function change({
   const elemsToUpdate = new Set(); /* what needs updating? E.g. ".branch", ".tip" etc */
   const nodePropsToModify = {}; /* which properties (keys) on the nodes should be updated (before the SVG) */
   const svgPropsToUpdate = new Set(); /* which SVG properties shall be changed. E.g. "fill", "stroke" */
-  let useModifySVGInStages = false; /* use modifySVGInStages rather than modifySVG. Not used often. */
+  const useModifySVGInStages = newLayout; /* use modifySVGInStages rather than modifySVG. Not used often. */
 
   /* calculate dt */
   const idealTransitionTime = 500;
@@ -305,9 +305,6 @@ export const change = function change({
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
     elemsToUpdate.add(".grid").add(".regression");
     svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity").add("visibility");
-  }
-  if (newLayout) {
-    useModifySVGInStages = true;
   }
 
   /* change the requested properties on the nodes */

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -204,6 +204,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     if (this.params.showGrid) this.addGrid();
     this.svg.selectAll(".tip").remove();
     this.drawTips();
+    this.updateTipLabels();
     if (this.vaccines) this.drawVaccines();
     this.addTemporalSlice();
     if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -286,7 +286,7 @@ export const change = function change({
   if (changeVisibility) {
     /* check that visibility is not undefined */
     /* in the future we also change the branch visibility (after skeleton merge) */
-    elemsToUpdate.add(".tip");
+    elemsToUpdate.add(".tip").add(".tipLabel");
     svgPropsToUpdate.add("visibility").add("cursor");
     nodePropsToModify.visibility = visibility;
   }

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -1,4 +1,5 @@
 import { timerFlush } from "d3-timer";
+import { NODE_VISIBLE } from "../../../util/globals";
 
 export const updateTipLabels = function updateTipLabels(dt) {
   if ("tipLabels" in this.groups) {
@@ -35,7 +36,7 @@ export const updateTipLabels = function updateTipLabels(dt) {
         .text((d) => tLFunc(d))
         .attr("class", "tipLabel")
         .style("font-size", fontSize.toString()+"px")
-        .style('visibility', 'visible');
+        .style('visibility', (d) => d.visibility === NODE_VISIBLE ? "visible" : "hidden");
     }, dt);
   }
 };


### PR DESCRIPTION
This PR addresses some of the issues stated in Issue #237, namely around tip labels appearing/disappearing dynamically.

The remaining work from that issue is on tip label transitioning and editing the hardcoded # of branches selected.

Because this issue was marked as high priority, I thought I'd open this PR in case the team wanted it merged before everything in the issue was resolved. 