### PR TITLE
Update author lookups (now stored on each node)

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -153,12 +153,6 @@ const modifyStateViaMetadata = (state, metadata) => {
   if (metadata.analysisSlider) {
     state["analysisSlider"] = {key: metadata.analysisSlider, valid: false};
   }
-  if (metadata.authorInfo) {
-    // need authors in metadata.filters to include as filter
-    // but metadata.authorInfo is generally required for app functioning
-  } else {
-    console.warn("JSON did not include author_info");
-  }
   if (metadata.filters) {
     metadata.filters.forEach((v) => {
       state.filters[v] = [];
@@ -514,9 +508,6 @@ export const createStateFromQueryOrJSONs = ({
       metadata.version = json.version;
     }
     metadata.maintainers = json.maintainers;
-    if (json.author_info) {
-      metadata.authorInfo = json.author_info;
-    }
     if (json.genome_annotations) {
       metadata.genomeAnnotations = json.genome_annotations;
     }

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -57,8 +57,7 @@ export const publications = {
   filters: state.controls.filters,
   visibility: state.tree.visibility,
   panelsToDisplay: state.controls.panelsToDisplay,
-  panelLayout: state.controls.panelLayout,
-  authorInfo: state.metadata.authorInfo
+  panelLayout: state.controls.panelLayout
 }))
 class DownloadModal extends React.Component {
   constructor(props) {
@@ -183,7 +182,7 @@ class DownloadModal extends React.Component {
     const buttons = [
       ["Tree (newick)", (<RectangularTreeIcon width={iconWidth} selected />), () => helpers.newick(this.props.dispatch, filePrefix, this.props.nodes[0], false)],
       ["TimeTree (newick)", (<RectangularTreeIcon width={iconWidth} selected />), () => helpers.newick(this.props.dispatch, filePrefix, this.props.nodes[0], true)],
-      ["Strain Metadata (TSV)", (<MetaIcon width={iconWidth} selected />), () => helpers.strainTSV(this.props.dispatch, filePrefix, this.props.nodes, this.props.authorInfo)],
+      ["Strain Metadata (TSV)", (<MetaIcon width={iconWidth} selected />), () => helpers.strainTSV(this.props.dispatch, filePrefix, this.props.nodes)],
       ["Author Metadata (TSV)", (<MetaIcon width={iconWidth} selected />), () => helpers.authorTSV(this.props.dispatch, filePrefix, this.props.metadata, this.props.tree)],
       ["Screenshot (SVG)", (<PanelsGridIcon width={iconWidth} selected />), () => helpers.SVG(this.props.dispatch, filePrefix, this.props.panelsToDisplay, this.props.panelLayout, this.makeTextStringsForSVGExport())]
     ];

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -154,14 +154,6 @@ class Info extends React.Component {
     };
   }
 
-  getNumSelectedAuthors() {
-    if (this.props.metadata.authorInfo) {
-      if (!Object.prototype.hasOwnProperty.call(this.props.filters, "authors") || this.props.filters.authors.length === 0) {
-        return Object.keys(this.props.metadata.authorInfo).length;
-      }
-    }
-    return this.props.filters.authors.length;
-  }
   addFilteredDatesButton(buttons) {
     buttons.push(
       <div key={"timefilter"} style={{display: "inline-block"}}>
@@ -230,54 +222,9 @@ class Info extends React.Component {
     );
   }
 
-  addFilteredAuthorsButton(buttons) {
-    if (!this.props.metadata.authorInfo) {return;}
-    const nTotalAuthors = Object.keys(this.props.metadata.authorInfo).length;
-    const nSelectedAuthors = this.getNumSelectedAuthors(); // will be equal to nTotalAuthors if none selected
-    /* case 1 (no selected authors) - return now. */
-    if (nTotalAuthors === nSelectedAuthors) {return;}
-    const authorInfo = this.props.filters.authors.map((v) => {
-      const n = this.props.totalStateCounts.authors[v];
-      return {
-        name: v,
-        label: (
-          <span>
-            {prettyString(v, {stripEtAl: true})}
-            <i>{" et al, "}</i>
-            {`(n=${n})`}
-          </span>
-        ),
-        longlabel: (
-          <span>
-            {prettyString(v, {stripEtAl: true})}
-            <i>{" et al, "}</i>
-            {prettyString(this.props.metadata.authorInfo[v].title)}
-            {` (n=${n})`}
-          </span>
-        )
-      };
-    });
-    /* case 2: 1 or 2 authors selected */
-    if (nSelectedAuthors > 0 && nSelectedAuthors < 3) {
-      authorInfo.forEach((d) => (
-        buttons.push(
-          displayFilterValueAsButton(this.props.dispatch, this.props.filters, "authors", d.name, d.longlabel, true)
-        )
-      ));
-      return;
-    }
-    /* case 3: more than 2 authors selected. */
-    authorInfo.forEach((d) => (
-      buttons.push(
-        displayFilterValueAsButton(this.props.dispatch, this.props.filters, "authors", d.name, d.label, true)
-      )
-    ));
-  }
-
   render() {
     if (!this.props.metadata || !this.props.nodes || !this.props.visibility) return null;
     const styles = this.getStyles(this.props.width);
-    // const nSelectedAuthors = this.getNumSelectedAuthors();
     // const filtersWithValues = Object.keys(this.props.filters).filter((n) => this.props.filters[n].length > 0);
     const animating = this.props.animationPlayPauseButton === "Pause";
     const showExtended = !animating && !this.props.selectedStrain;
@@ -296,9 +243,7 @@ class Info extends React.Component {
 
     /* part II - the active filters */
     const filters = [];
-    this.addFilteredAuthorsButton(filters);
     Object.keys(this.props.filters)
-      .filter((n) => n !== "authors")
       .filter((n) => this.props.filters[n].length > 0)
       .forEach((n) => this.addNonAuthorFilterButton(filters, n));
     if (!datesMaxed) {this.addFilteredDatesButton(filters);}

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -19,8 +19,7 @@ const Tree = connect((state) => ({
   showTangle: state.controls.showTangle,
   panelsToDisplay: state.controls.panelsToDisplay,
   selectedBranchLabel: state.controls.selectedBranchLabel,
-  narrativeMode: state.narrative.display,
-  authorInfo: state.metadata.authorInfo
+  narrativeMode: state.narrative.display
 }))(UnconnectedTree);
 
 export default Tree;

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -32,10 +32,14 @@ export const stopProp = (e) => {
 };
 
 /* min width to get "collection date" on 1 line: 120 */
-const item = (key, value) => (
+const item = (key, value, href) => (
   <tr key={key}>
     <th style={infoPanelStyles.item}>{key}</th>
-    <td style={infoPanelStyles.item}>{value}</td>
+    <td style={infoPanelStyles.item}>{href ? (
+      <a href={href} target="_blank" rel="noopener noreferrer">{value}</a>
+    ) :
+      value
+    }</td>
   </tr>
 );
 
@@ -123,25 +127,26 @@ const displayVaccineInfo = (d) => {
   return null;
 };
 
-const displayPublicationInfo = (authorKey, authorInfo) => {
-  if (!authorKey || !authorInfo[authorKey]) {
+const displayPublicationInfo = (info) => {
+  if (!info) {
     return null;
   }
-  const info = authorInfo[authorKey];
   const itemsToRender = [];
-  itemsToRender.push(item("Authors", info.authors));
-  if (info.title && info.title !== "?") itemsToRender.push(item("Title", info.title));
-  if (info.journal && info.journal !== "?") itemsToRender.push(item("Journal", info.journal));
-  if (info.url && info.url !== "?") itemsToRender.push(item("URL", info.url));
-  if (itemsToRender.length === 1) {
-    return itemsToRender[0];
+  itemsToRender.push(item("Authors", info.author));
+  if (info.title && info.title !== "?") {
+    if (info.paper_url && info.paper_url !== "?") {
+      itemsToRender.push(item("Title", info.title, info.paper_url));
+    } else {
+      itemsToRender.push(item("Title", info.title));
+    }
   }
-  return (
-    itemsToRender
-  );
+  if (info.journal && info.journal !== "?") {
+    itemsToRender.push(item("Journal", info.journal));
+  }
+  return (itemsToRender.length === 1 ? itemsToRender[0] : itemsToRender);
 };
 
-const TipClickedPanel = ({tip, goAwayCallback, authorInfo}) => {
+const TipClickedPanel = ({tip, goAwayCallback}) => {
   if (!tip) {return null;}
   const showUncertainty = tip.n.num_date && tip.n.num_date.confidence && tip.n.num_date.confidence[0] !== tip.n.num_date.confidence[1];
 
@@ -166,7 +171,7 @@ const TipClickedPanel = ({tip, goAwayCallback, authorInfo}) => {
             )}
             {showUncertainty ? dateConfidence(tip.n.num_date.confidence) : null}
             {/* Author / Paper information */}
-            {displayPublicationInfo(tip.n.authors, authorInfo)}
+            {displayPublicationInfo(tip.n.author)}
             {/* try to join URL with accession, else display the one that's available */}
             {accessionAndUrl(tip.n)}
           </tbody>

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -241,15 +241,22 @@ const getPanelStyling = (d, panelDims) => {
   return styles;
 };
 
-const tipDisplayColorByInfo = (d, colorBy, distanceMeasure, temporalConfidence, mutType, colorScale, authorInfo) => {
+const tipDisplayColorByInfo = (d, colorBy, distanceMeasure, temporalConfidence, mutType, colorScale) => {
   if (colorBy === "num_date") {
     if (distanceMeasure === "num_date") return null;
     return renderBranchTime(d.n, temporalConfidence);
-  } else if (colorBy === "authors") {
-    if (authorInfo[d.n.authors]) {
-      return renderInfoLine("Authors:", authorInfo[d.n.authors].authors);
+  } else if (colorBy === "author") {
+    if (!d.n.author) return null;
+    const ret = [
+      renderInfoLine("Author:", d.n.author.author || d.n.author.value)
+    ];
+    if (d.n.author.title) {
+      ret.push(renderInfoLine("Title:", d.n.author.title));
     }
-    return null;
+    if (d.n.author.journal) {
+      ret.push(renderInfoLine("Journal:", d.n.author.journal));
+    }
+    return ret;
   } else if (isColorByGenotype(colorBy)) {
     const genotype = decodeColorByGenotype(colorBy);
     const key = genotype.aa
@@ -283,7 +290,7 @@ const displayVaccineInfo = (d) => {
 
 /* the actual component - a pure function, so we can return early if needed */
 const HoverInfoPanel = ({mutType, temporalConfidence, distanceMeasure,
-  hovered, colorBy, colorByConfidence, colorScale, panelDims, authorInfo}) => {
+  hovered, colorBy, colorByConfidence, colorScale, panelDims}) => {
 
   if (!hovered) return null;
 
@@ -295,7 +302,7 @@ const HoverInfoPanel = ({mutType, temporalConfidence, distanceMeasure,
     inner = (
       <span>
         {displayVaccineInfo(d)}
-        {tipDisplayColorByInfo(d, colorBy, distanceMeasure, temporalConfidence, mutType, colorScale, authorInfo)}
+        {tipDisplayColorByInfo(d, colorBy, distanceMeasure, temporalConfidence, mutType, colorScale)}
         {distanceMeasure === "div" ? renderBranchDivergence(d.n) : renderBranchTime(d.n, temporalConfidence)}
       </span>
     );

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -13,8 +13,7 @@ import { isColorByGenotype, decodeColorByGenotype } from "../../../util/getGenot
   return {
     colorBy: state.controls.colorBy,
     colorings: state.metadata.colorings,
-    colorScale: state.controls.colorScale,
-    authorInfo: state.metadata.authorInfo
+    colorScale: state.controls.colorScale
   };
 })
 class Legend extends React.Component {
@@ -152,8 +151,6 @@ class Legend extends React.Component {
       }
       const [yyyy, mm, dd] = numericToCalendar(label).split('-'); // eslint-disable-line
       return `${months[mm]} ${yyyy}`;
-    } else if (this.props.colorBy === "authors") {
-      return this.props.authorInfo[label].authors;
     } else if (this.props.colorScale.continuous) {
       return label;
     }

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -137,12 +137,10 @@ class Tree extends React.Component {
           colorByConfidence={this.props.colorByConfidence}
           colorScale={this.props.colorScale}
           panelDims={{width: this.props.width, height: this.props.height, spaceBetweenTrees}}
-          authorInfo={this.props.authorInfo}
         />
         <TipClickedPanel
           goAwayCallback={this.clearSelectedTip}
           tip={this.state.selectedTip}
-          authorInfo={this.props.authorInfo}
         />
         {this.props.showTangle && this.state.tree && this.state.treeToo ? (
           <Tangle

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -7,12 +7,13 @@
  */
 export const getTraitFromNode = (node, trait, {entropy=false, confidence=false}={}) => {
   if (!entropy && !confidence) {
+    if (trait === "author") return node.author ? node.author.value : undefined;
     if (trait === "num_date") return node.num_date.value;
     if (node[trait]) return node[trait];
     if (node.traits && node.traits[trait]) return node.traits[trait].value;
-  } if (entropy) {
+  } else if (entropy) {
     if (node.traits && node.traits[trait]) return node.traits[trait].entropy;
-  } if (confidence) {
+  } else if (confidence) {
     if (node.traits && node.traits[trait]) return node.traits[trait].confidence;
     if (trait === "num_date" && node.num_date) return node.num_date.confidence;
   }


### PR DESCRIPTION
The v2 JSON changes how authorship is assigned, including the information on each node as opposed to an "author_info" lookup. This necessitated modifications to:
* the `convert` functionality (v1 - v2 JSONs)
* info displayed when hovering over a tip (much improved)
* info displayed when clicking on a tip (much improved)
* export TSVs
* How author traits are collected during tree traversals