### PR TITLE
`node.num_date.value` Undefined Fix

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -148,7 +148,8 @@ const displayPublicationInfo = (info) => {
 
 const TipClickedPanel = ({tip, goAwayCallback}) => {
   if (!tip) {return null;}
-  const showUncertainty = tip.n.num_date && tip.n.num_date.confidence && tip.n.num_date.confidence[0] !== tip.n.num_date.confidence[1];
+  const showDates = "num_date" in tip.n;
+  const showUncertainty = showDates && tip.n.num_date.confidence && tip.n.num_date.confidence[0] !== tip.n.num_date.confidence[1];
 
   return (
     <div style={infoPanelStyles.modalContainer} onClick={() => goAwayCallback(tip)}>
@@ -165,10 +166,10 @@ const TipClickedPanel = ({tip, goAwayCallback}) => {
               return isValueValid(value) ? item(prettyString(x), prettyString(value)) : null;
             })}
             {/* Dates */}
-            {item(
+            {showDates ? item(
               showUncertainty ? "Inferred collection date" : "Collection date",
               prettyString(numericToCalendar(tip.n.num_date.value))
-            )}
+            ) : null}
             {showUncertainty ? dateConfidence(tip.n.num_date.confidence) : null}
             {/* Author / Paper information */}
             {displayPublicationInfo(tip.n.author)}

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -52,13 +52,9 @@ const formatURL = (url) => {
   return url;
 };
 
-const dateConfidence = (x) => (
-  item("Collection date confidence", `(${numericToCalendar(x[0])}, ${numericToCalendar(x[1])})`)
-);
-
 const accessionAndUrl = (node) => {
-  const accession = node.accession;
-  const url = node.url;
+  const accession = getTraitFromNode(node, "accession");
+  const url = getTraitFromNode(node, "url");
 
   if (isValueValid(accession) && isValueValid(url)) {
     return (
@@ -148,31 +144,36 @@ const displayPublicationInfo = (info) => {
 
 const TipClickedPanel = ({tip, goAwayCallback}) => {
   if (!tip) {return null;}
-  const showDates = "num_date" in tip.n;
-  const showUncertainty = showDates && tip.n.num_date.confidence && tip.n.num_date.confidence[0] !== tip.n.num_date.confidence[1];
+
+  const date = getTraitFromNode(tip.n, "num_date");
+  const dateUncertainty = getTraitFromNode(tip.n, "num_date", {confidence: true});
+  const showDateUncertainty = date && dateUncertainty && dateUncertainty[0] !== dateUncertainty[1];
 
   return (
     <div style={infoPanelStyles.modalContainer} onClick={() => goAwayCallback(tip)}>
       <div className={"panel"} style={infoPanelStyles.panel} onClick={(e) => stopProp(e)}>
         <p style={infoPanelStyles.modalHeading}>
-          {`${tip.n.strain}`}
+          {`${getTraitFromNode(tip.n, "strain")}`}
         </p>
         <table>
           <tbody>
             {displayVaccineInfo(tip) /* vaccine information (if applicable) */}
             {/* the "basic" attributes (which may not exist in certain datasets) */}
+            {/* TODO - we should scan all colorings here */}
             {["country", "region", "division"].map((x) => {
               const value = getTraitFromNode(tip.n, x);
               return isValueValid(value) ? item(prettyString(x), prettyString(value)) : null;
             })}
             {/* Dates */}
-            {showDates ? item(
-              showUncertainty ? "Inferred collection date" : "Collection date",
-              prettyString(numericToCalendar(tip.n.num_date.value))
+            {date ? item(
+              showDateUncertainty ? "Inferred collection date" : "Collection date",
+              prettyString(numericToCalendar(date))
             ) : null}
-            {showUncertainty ? dateConfidence(tip.n.num_date.confidence) : null}
+            {showDateUncertainty ? (
+              item("Collection date confidence", `(${numericToCalendar(dateUncertainty[0])}, ${numericToCalendar(dateUncertainty[1])})`)
+            ) : null}
             {/* Author / Paper information */}
-            {displayPublicationInfo(tip.n.author)}
+            {displayPublicationInfo(getTraitFromNode(tip.n, "author"))}
             {/* try to join URL with accession, else display the one that's available */}
             {accessionAndUrl(tip.n)}
           </tbody>

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -8,7 +8,7 @@
 export const getTraitFromNode = (node, trait, {entropy=false, confidence=false}={}) => {
   if (!entropy && !confidence) {
     if (trait === "author") return node.author ? node.author.value : undefined;
-    if (trait === "num_date") return node.num_date.value;
+    if (trait === "num_date" && node.num_date) return node.num_date.value;
     if (node[trait]) return node[trait];
     if (node.traits && node.traits[trait]) return node.traits[trait].value;
   } else if (entropy) {

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -5,8 +5,8 @@ import { getTraitFromNode } from "./treeMiscHelpers";
 export const getVisibleDateRange = (nodes, visibility) => nodes
   .filter((node, idx) => (visibility[idx] === NODE_VISIBLE && !node.hasChildren))
   .reduce((acc, node) => {
-    if (node.num_date.value < acc[0]) return [node.num_date.value, acc[1]];
-    if (node.num_date.value > acc[1]) return [acc[0], node.num_date.value];
+    if (node.numdate && node.num_date.value < acc[0]) return [node.num_date.value, acc[1]];
+    if (node.numdate && node.num_date.value > acc[1]) return [acc[0], node.num_date.value];
     return acc;
   }, [100000, -100000]);
 
@@ -147,18 +147,18 @@ const calcVisibility = (tree, controls, dates) => {
     /* intersect the various arrays contributing to visibility */
     const visibility = tree.nodes.map((node, idx) => {
       if (inView[idx] && (filtered ? filtered[idx] : true)) {
-        const nodeDate = node.num_date.value;
+        const nodeDate = node.num_date;
         /* if without date, treetime probably not run - or would be inferred
           so if branchLengthsToDisplay is "divOnly", then ensure node displayed */
         if (controls.branchLengthsToDisplay === "divOnly" && !node.num_date) {
           return NODE_VISIBLE;
         }
         /* is the actual node date (the "end" of the branch) in the time slice? */
-        if (nodeDate >= dates.dateMinNumeric && nodeDate <= dates.dateMaxNumeric) {
+        if (nodeDate.value >= dates.dateMinNumeric && nodeDate.value <= dates.dateMaxNumeric) {
           return NODE_VISIBLE;
         }
         /* is any part of the (parent date -> node date) in the time slice? */
-        if (!(nodeDate < dates.dateMinNumeric || node.parent.num_date.value > dates.dateMaxNumeric)) {
+        if (!(nodeDate.value < dates.dateMinNumeric || node.parent.num_date.value > dates.dateMaxNumeric)) {
           return NODE_VISIBLE_TO_MAP_ONLY;
         }
       }

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -5,8 +5,9 @@ import { getTraitFromNode } from "./treeMiscHelpers";
 export const getVisibleDateRange = (nodes, visibility) => nodes
   .filter((node, idx) => (visibility[idx] === NODE_VISIBLE && !node.hasChildren))
   .reduce((acc, node) => {
-    if (node.numdate && node.num_date.value < acc[0]) return [node.num_date.value, acc[1]];
-    if (node.numdate && node.num_date.value > acc[1]) return [acc[0], node.num_date.value];
+    const nodeDate = getTraitFromNode(node, "num_date");
+    if (nodeDate && nodeDate < acc[0]) return [nodeDate, acc[1]];
+    if (nodeDate && nodeDate > acc[1]) return [acc[0], nodeDate];
     return acc;
   }, [100000, -100000]);
 
@@ -147,18 +148,21 @@ const calcVisibility = (tree, controls, dates) => {
     /* intersect the various arrays contributing to visibility */
     const visibility = tree.nodes.map((node, idx) => {
       if (inView[idx] && (filtered ? filtered[idx] : true)) {
-        const nodeDate = node.num_date;
-        /* if without date, treetime probably not run - or would be inferred
-          so if branchLengthsToDisplay is "divOnly", then ensure node displayed */
-        if (controls.branchLengthsToDisplay === "divOnly" && !node.num_date) {
+        const nodeDate = getTraitFromNode(node, "num_date");
+        const parentNodeDate = getTraitFromNode(node.parent, "num_date");
+        if (!nodeDate || !parentNodeDate) {
+          return NODE_VISIBLE;
+        }
+        /* if branchLengthsToDisplay is "divOnly", then ensure node displayed */
+        if (controls.branchLengthsToDisplay === "divOnly") {
           return NODE_VISIBLE;
         }
         /* is the actual node date (the "end" of the branch) in the time slice? */
-        if (nodeDate.value >= dates.dateMinNumeric && nodeDate.value <= dates.dateMaxNumeric) {
+        if (nodeDate >= dates.dateMinNumeric && nodeDate <= dates.dateMaxNumeric) {
           return NODE_VISIBLE;
         }
         /* is any part of the (parent date -> node date) in the time slice? */
-        if (!(nodeDate.value < dates.dateMinNumeric || node.parent.num_date.value > dates.dateMaxNumeric)) {
+        if (!(nodeDate < dates.dateMinNumeric || parentNodeDate > dates.dateMaxNumeric)) {
           return NODE_VISIBLE_TO_MAP_ONLY;
         }
       }


### PR DESCRIPTION
Should address **bug 2** of #745. 

Where changes to how we store `num_date` meant that we need to more explicitly check if it's undefined before trying to access it's value. See the bug comments for more information. 

@jameshadfield  May be worth checking if there are more instances where this may occur? I had a look and didn't see more, but this would be worth investigating slightly more in-depth I think...