### PR TITLE
Recalculate radial and unrooted tree layout on clade zoom

### DIFF
--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -4,7 +4,7 @@ import _minBy from "lodash/minBy";
 import { interpolateNumber } from "d3-interpolate";
 import { averageColors } from "../../util/colorHelpers";
 import { bezier } from "./transmissionBezier";
-import { NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "../../util/globals";
+import { NODE_NOT_VISIBLE } from "../../util/globals";
 import { errorNotification } from "../../actions/notifications";
 
 /* global L */
@@ -64,8 +64,7 @@ const setupDemeData = (nodes, visibility, geoResolution, nodeColors, triplicate,
   // second pass to fill vectors
   nodes.forEach((n, i) => {
     /* demes only count terminal nodes */
-    if (!n.children && visibility[i] === NODE_VISIBLE_TO_MAP_ONLY
-      || !n.children && visibility[i] === NODE_VISIBLE) {
+    if (!n.children && visibility[i] !== NODE_NOT_VISIBLE) {
       // if tip and visible, push
       if (n.attr[geoResolution]) { // check for undefined
         demeMap[n.attr[geoResolution]].push(nodeColors[i]);
@@ -201,7 +200,7 @@ const maybeConstructTransmissionEvent = (
       originNumDate: node.attr["num_date"],
       destinationNumDate: child.attr["num_date"],
       color: nodeColors[node.arrayIdx],
-      visible: visibility[child.arrayIdx] === NODE_VISIBLE_TO_MAP_ONLY || visibility[child.arrayIdx] === NODE_VISIBLE ? "visible" : "hidden", // transmission visible if child is visible
+      visible: visibility[child.arrayIdx] !== NODE_NOT_VISIBLE ? "visible" : "hidden", // transmission visible if child is visible
       extend: extend
     };
   }
@@ -392,8 +391,7 @@ const updateDemeDataColAndVis = (demeData, demeIndices, nodes, visibility, geoRe
   // second pass to fill vectors
   nodes.forEach((n, i) => {
     /* demes only count terminal nodes */
-    if (!n.children && visibility[i] === NODE_VISIBLE_TO_MAP_ONLY
-      || !n.children && visibility[i] === NODE_VISIBLE) {
+    if (!n.children && visibility[i] !== NODE_NOT_VISIBLE) {
       // if tip and visible, push
       if (n.attr[geoResolution]) { // check for undefined
         if (n.attr[geoResolution] in demeMap) {
@@ -428,7 +426,7 @@ const updateTransmissionDataColAndVis = (transmissionData, transmissionIndices, 
       // this is a transmission event from n to child
       const id = node.arrayIdx.toString() + "-" + child.arrayIdx.toString();
       const col = nodeColors[node.arrayIdx];
-      const vis = visibility[child.arrayIdx] === NODE_VISIBLE_TO_MAP_ONLY || visibility[child.arrayIdx] === NODE_VISIBLE ? "visible" : "hidden"; // transmission visible if child is visible
+      const vis = visibility[child.arrayIdx] !== NODE_NOT_VISIBLE ? "visible" : "hidden"; // transmission visible if child is visible
 
       // update transmissionData via index lookup
       try {

--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -4,7 +4,7 @@ import _minBy from "lodash/minBy";
 import { interpolateNumber } from "d3-interpolate";
 import { averageColors } from "../../util/colorHelpers";
 import { bezier } from "./transmissionBezier";
-import { NODE_NOT_VISIBLE } from "../../util/globals";
+import { NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "../../util/globals";
 import { errorNotification } from "../../actions/notifications";
 
 /* global L */
@@ -64,7 +64,8 @@ const setupDemeData = (nodes, visibility, geoResolution, nodeColors, triplicate,
   // second pass to fill vectors
   nodes.forEach((n, i) => {
     /* demes only count terminal nodes */
-    if (!n.children && visibility[i] !== NODE_NOT_VISIBLE) {
+    if (!n.children && visibility[i] === NODE_VISIBLE_TO_MAP_ONLY
+      || !n.children && visibility[i] === NODE_VISIBLE) {
       // if tip and visible, push
       if (n.attr[geoResolution]) { // check for undefined
         demeMap[n.attr[geoResolution]].push(nodeColors[i]);
@@ -200,7 +201,7 @@ const maybeConstructTransmissionEvent = (
       originNumDate: node.attr["num_date"],
       destinationNumDate: child.attr["num_date"],
       color: nodeColors[node.arrayIdx],
-      visible: visibility[child.arrayIdx] !== NODE_NOT_VISIBLE ? "visible" : "hidden", // transmission visible if child is visible
+      visible: visibility[child.arrayIdx] === NODE_VISIBLE_TO_MAP_ONLY || visibility[child.arrayIdx] === NODE_VISIBLE ? "visible" : "hidden", // transmission visible if child is visible
       extend: extend
     };
   }
@@ -391,7 +392,8 @@ const updateDemeDataColAndVis = (demeData, demeIndices, nodes, visibility, geoRe
   // second pass to fill vectors
   nodes.forEach((n, i) => {
     /* demes only count terminal nodes */
-    if (!n.children && visibility[i] !== NODE_NOT_VISIBLE) {
+    if (!n.children && visibility[i] === NODE_VISIBLE_TO_MAP_ONLY
+      || !n.children && visibility[i] === NODE_VISIBLE) {
       // if tip and visible, push
       if (n.attr[geoResolution]) { // check for undefined
         if (n.attr[geoResolution] in demeMap) {
@@ -426,7 +428,7 @@ const updateTransmissionDataColAndVis = (transmissionData, transmissionIndices, 
       // this is a transmission event from n to child
       const id = node.arrayIdx.toString() + "-" + child.arrayIdx.toString();
       const col = nodeColors[node.arrayIdx];
-      const vis = visibility[child.arrayIdx] !== NODE_NOT_VISIBLE ? "visible" : "hidden"; // transmission visible if child is visible
+      const vis = visibility[child.arrayIdx] === NODE_VISIBLE_TO_MAP_ONLY || visibility[child.arrayIdx] === NODE_VISIBLE ? "visible" : "hidden"; // transmission visible if child is visible
 
       // update transmissionData via index lookup
       try {

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -187,6 +187,9 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
       this.drawBranchLabels(extras.newBranchLabellingKey);
     }
   }
+
+  if (this.vaccines) this.drawVaccines();
+
 };
 
 /* instead of modifying the SVG the "normal" way, this is sometimes too janky (e.g. when we need to move everything)
@@ -250,6 +253,7 @@ export const change = function change({
   /* change these things to provided value */
   newDistance = undefined,
   newLayout = undefined,
+  updateLayout = undefined,
   newBranchLabellingKey = undefined,
   /* arrays of data (the same length as nodes) */
   branchStroke = undefined,
@@ -300,7 +304,7 @@ export const change = function change({
     svgPropsToUpdate.add("stroke-width");
     nodePropsToModify["stroke-width"] = branchThickness;
   }
-  if (newDistance || newLayout || zoomIntoClade || svgHasChangedDimensions) {
+  if (newDistance || newLayout || updateLayout || zoomIntoClade || svgHasChangedDimensions) {
     elemsToUpdate.add(".tip").add(".branch.S").add(".branch.T").add(".branch");
     elemsToUpdate.add(".vaccineCross").add(".vaccineDottedLine").add(".conf");
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
@@ -330,12 +334,13 @@ export const change = function change({
   /* distance */
   if (newDistance) this.setDistance(newDistance);
   /* layout (must run after distance) */
-  if (newDistance || newLayout) this.setLayout(newLayout || this.layout);
+  if (newDistance || newLayout || updateLayout) this.setLayout(newLayout || this.layout);
   /* mapToScreen */
   if (
     svgPropsToUpdate.has(["stroke-width"]) ||
     newDistance ||
     newLayout ||
+    updateLayout ||
     zoomIntoClade ||
     svgHasChangedDimensions
   ) {
@@ -346,7 +351,7 @@ export const change = function change({
   const extras = {removeConfidences, showConfidences, newBranchLabellingKey};
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   if (useModifySVGInStages) {
-    this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 1000);
+    this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 750);
   } else {
     this.modifySVG(elemsToUpdate, svgPropsToUpdate, transitionTime, extras);
   }

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-param-reassign */
+import { NODE_VISIBLE } from "../../../util/globals";
+
 
 /*
  * adds the total number of descendant leaves to each node in the tree
@@ -7,8 +9,10 @@
  *   node -- root node of the tree.
  */
 export const addLeafCount = (node) => {
-  if (node.terminal) {
+  if (node.terminal && node.visibility === NODE_VISIBLE) {
     node.leafCount = 1;
+  } else if (node.terminal && node.visibility !== NODE_VISIBLE) {
+    node.leafCount = 0.25;
   } else {
     node.leafCount = 0;
     for (let i = 0; i < node.children.length; i++) {

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-param-reassign */
-import { NODE_VISIBLE } from "../../../util/globals";
-
 
 /*
  * adds the total number of descendant leaves to each node in the tree
@@ -9,10 +7,10 @@ import { NODE_VISIBLE } from "../../../util/globals";
  *   node -- root node of the tree.
  */
 export const addLeafCount = (node) => {
-  if (node.terminal && node.visibility === NODE_VISIBLE) {
+  if (node.terminal && node.inView) {
     node.leafCount = 1;
-  } else if (node.terminal && node.visibility !== NODE_VISIBLE) {
-    node.leafCount = 0.25;
+  } else if (node.terminal && !node.inView) {
+    node.leafCount = 0.15;
   } else {
     node.leafCount = 0;
     for (let i = 0; i < node.children.length; i++) {

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -66,16 +66,14 @@ const branchLabelFontWeight = (key) => {
  * @return {func||str}
  */
 const createBranchLabelVisibility = (key, layout, totalTipsInView) => {
-  if (key === "clade") return "visible";
-  const magicTipFractionToShowBranchLabel = 0.05;
+  const magicTipCountToShowBranchLabel = 0.05 * totalTipsInView;
   return (d) => {
     /* if the number of _visible_ tips descending from this node are over the
-    magicTipFractionToShowBranchLabel (c/w the total numer of _visible_ and
+    magicTipCountToShowBranchLabel (c/w the total numer of _visible_ and
     _inView_ tips then display the label */
     if (
-      d.n.tipCount > magicTipFractionToShowBranchLabel * totalTipsInView &&
-      layout === "rect"
-    ) {
+      (d.n.tipCount > magicTipCountToShowBranchLabel || key === "clade") &&
+      layout === "rect" && d.visibility === NODE_VISIBLE) {
       return "visible";
     }
     return "hidden";

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -25,12 +25,8 @@ export const render = function render(svg, layout, distance, parameters, callbac
   this.vaccines = vaccines ? vaccines.map((d) => d.shell) : undefined;
   this.dateRange = dateRange;
 
-  /* set x, y values & scale them to the screen */
-  this.setDistance(distance);
-  this.setLayout(layout);
-  this.mapToScreen();
-
   /* set nodes stroke / fill */
+  /* visibility is used when calculating setLayout */
   this.nodes.forEach((d, i) => {
     d.branchStroke = branchStroke[i];
     d.tipStroke = tipStroke[i];
@@ -39,6 +35,11 @@ export const render = function render(svg, layout, distance, parameters, callbac
     d["stroke-width"] = branchThickness[i];
     d.r = tipRadii ? tipRadii[i] : this.params.tipRadius;
   });
+
+  /* set x, y values & scale them to the screen */
+  this.setDistance(distance);
+  this.setLayout(layout);
+  this.mapToScreen();
 
   /* draw functions */
   if (this.params.showGrid) {
@@ -72,17 +73,18 @@ export const drawVaccines = function drawVaccines() {
     .selectAll(".vaccineCross")
     .data(this.vaccines)
     .enter()
-      .append("path")
-        .attr("class", "vaccineCross")
-        .attr("d", (d) => d.vaccineCross)
-        .style("stroke", "#333")
-        .style("stroke-width", 2 * this.params.branchStrokeWidth)
-        .style("fill", "none")
-        .style("cursor", "pointer")
-        .style("pointer-events", "auto")
-        .on("mouseover", this.callbacks.onTipHover)
-        .on("mouseout", this.callbacks.onTipLeave)
-        .on("click", this.callbacks.onTipClick);
+    .append("path")
+    .attr("class", "vaccineCross")
+    .attr("d", (d) => d.vaccineCross)
+    .style("stroke", "#333")
+    .style("stroke-width", 2 * this.params.branchStrokeWidth)
+    .style("fill", "none")
+    .style("cursor", "pointer")
+    .style("pointer-events", "auto")
+    .style("visibility", (d) => d.visibility === NODE_VISIBLE ? "visible" : "hidden")
+    .on("mouseover", this.callbacks.onTipHover)
+    .on("mouseout", this.callbacks.onTipLeave)
+    .on("click", this.callbacks.onTipClick);
 };
 
 

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -77,6 +77,7 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
     newState.selectedBranch = newTreeRedux.idxOfInViewRootNode === 0 ? null : rootNode;
     newState.selectedTip = null;
     newState.hovered = null;
+    args.updateLayout = true;
   }
 
   if (oldProps.width !== newProps.width || oldProps.height !== newProps.height) {

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -178,6 +178,8 @@ export const months = {
 export const normalNavBarHeight = 50;
 export const narrativeNavBarHeight = 55;
 
-export const NODE_NOT_VISIBLE = 0;
-export const NODE_VISIBLE_TO_MAP_ONLY = 1;
-export const NODE_VISIBLE = 2;
+// increasing levels of "visibility"
+export const NODE_NOT_VISIBLE_BASAL = 0;    // branch thickness 0 and excluded from map
+export const NODE_NOT_VISIBLE_FILTERED = 1; // branch thickness 0.5 and excluded from map
+export const NODE_VISIBLE_TO_MAP_ONLY = 2;  // branch thickness 0.5 and included in map
+export const NODE_VISIBLE = 3;              // included on tree and map

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -179,7 +179,6 @@ export const normalNavBarHeight = 50;
 export const narrativeNavBarHeight = 55;
 
 // increasing levels of "visibility"
-export const NODE_NOT_VISIBLE_BASAL = 0;    // branch thickness 0 and excluded from map
-export const NODE_NOT_VISIBLE_FILTERED = 1; // branch thickness 0.5 and excluded from map
-export const NODE_VISIBLE_TO_MAP_ONLY = 2;  // branch thickness 0.5 and included in map
-export const NODE_VISIBLE = 3;              // included on tree and map
+export const NODE_NOT_VISIBLE = 0;          // branch thickness 0 and excluded from map
+export const NODE_VISIBLE_TO_MAP_ONLY = 1;  // branch thickness 0.5 and included in map
+export const NODE_VISIBLE = 2;              // included on tree and map

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -1,4 +1,4 @@
-import { freqScale, NODE_NOT_VISIBLE_BASAL, NODE_NOT_VISIBLE_FILTERED, NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "./globals";
+import { freqScale, NODE_NOT_VISIBLE, NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "./globals";
 import { calcTipCounts } from "./treeCountingHelpers";
 
 export const getVisibleDateRange = (nodes, visibility) => nodes
@@ -49,10 +49,8 @@ const calcBranchThickness = (nodes, visibility, rootIdx) => {
   return nodes.map((d, idx) => {
     if (visibility[idx] === NODE_VISIBLE) {
       return freqScale((d.tipCount + 5) / (maxTipCount + 5));
-    } else if (visibility[idx] === NODE_NOT_VISIBLE_FILTERED || visibility[idx] === NODE_VISIBLE_TO_MAP_ONLY) {
-      return 0.5;
     }
-    return 0.0;
+    return 0.5;
   });
 };
 
@@ -160,10 +158,7 @@ const calcVisibility = (tree, controls, dates) => {
           return NODE_VISIBLE_TO_MAP_ONLY;
         }
       }
-      if (!inView[idx]) {
-        return NODE_NOT_VISIBLE_BASAL;
-      }
-      return NODE_NOT_VISIBLE_FILTERED;
+      return NODE_NOT_VISIBLE;
     });
     return visibility;
   }

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -1,4 +1,4 @@
-import { freqScale, NODE_NOT_VISIBLE, NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "./globals";
+import { freqScale, NODE_NOT_VISIBLE_BASAL, NODE_NOT_VISIBLE_FILTERED, NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "./globals";
 import { calcTipCounts } from "./treeCountingHelpers";
 
 export const getVisibleDateRange = (nodes, visibility) => nodes
@@ -46,9 +46,14 @@ const calcBranchThickness = (nodes, visibility, rootIdx) => {
   if (!maxTipCount) {
     maxTipCount = 1;
   }
-  return nodes.map((d, idx) => (
-    visibility[idx] === 2 ? freqScale((d.tipCount + 5) / (maxTipCount + 5)) : 0.5
-  ));
+  return nodes.map((d, idx) => {
+    if (visibility[idx] === NODE_VISIBLE) {
+      return freqScale((d.tipCount + 5) / (maxTipCount + 5));
+    } else if (visibility[idx] === NODE_NOT_VISIBLE_FILTERED || visibility[idx] === NODE_VISIBLE_TO_MAP_ONLY) {
+      return 0.5;
+    }
+    return 0.0;
+  });
 };
 
 /* recursively mark the parents of a given node active
@@ -155,7 +160,10 @@ const calcVisibility = (tree, controls, dates) => {
           return NODE_VISIBLE_TO_MAP_ONLY;
         }
       }
-      return NODE_NOT_VISIBLE;
+      if (!inView[idx]) {
+        return NODE_NOT_VISIBLE_BASAL;
+      }
+      return NODE_NOT_VISIBLE_FILTERED;
     });
     return visibility;
   }


### PR DESCRIPTION
This PR started with the direct goal of recalculating radial and unrooted tree layout on clade zoom. This was basically making `radialLayou`t and `unrootedLayout` depend on node visibility to set bounds. These changes required some additional modifications however. These were:
* Inclusion of a new node visibility flag to distinguish nodes that are filtered from nodes that outside of the "shell". Zooming into a radial or unrooted clade and applying layout to other branches resulted in strange layouts of out of view nodes. This had the added benefit of cleaning up the thin branches that interfered with the x-axes when zooming to clade in rectangular layout.
* A new change arg called `updateLayout` is passed through reactD3Interface when zooming to clades that causes layout recalculation in a modifySVG action.

I believe this is a slight improvement over existing behavior (but definitely not as much as I was hoping for when I started on it), but please @jameshadfield, @rneher, @emmahodcroft , etc... let me know if you think existing zoom behavior is preferable. Or if you have other directions you think to take this. There are a few things (like dynamically updating radial grid lines) that need cleaning up in this PR.

Zika radial zoom before and after:

<img width="919" alt="zika-before" src="https://user-images.githubusercontent.com/1176109/62015939-0fb6e080-b164-11e9-86dc-68b008d38f87.png">

<img width="919" alt="zika-after" src="https://user-images.githubusercontent.com/1176109/62015942-13e2fe00-b164-11e9-8e7c-95f03a10fd8a.png">

Zika unrooted zoom before and after:

<img width="919" alt="unrooted-before" src="https://user-images.githubusercontent.com/1176109/62015945-17768500-b164-11e9-93f1-2dd9a16295b0.png">

<img width="919" alt="unrooted-after" src="https://user-images.githubusercontent.com/1176109/62015951-1a717580-b164-11e9-9e48-049b615b4a1c.png">

The zoom animation does come out looking rather fun for these.

_And I see now that this is mostly a reimplementation of @jameshadfield's `js-v-vals` branch. I think I prefer the current behavior of clade zoom for rectangular trees, but keeping more context around for unrooted and radial trees seems helpful._