### PR TITLE
Improve V2 author display

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -321,6 +321,13 @@ class Footer extends React.Component {
                   {" et al (" + totalStateCount[itemName] + ")"}
                 </span>
               );
+            } else if (filterName === "author") {
+              display = (
+                <span>
+                  {itemName}
+                  {" (" + totalStateCount[itemName] + ")"}
+                </span>
+              );
             } else {
               display = (
                 <span>

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -127,7 +127,7 @@ const displayPublicationInfo = (info) => {
     return null;
   }
   const itemsToRender = [];
-  itemsToRender.push(item("Authors", info.author));
+  itemsToRender.push(item("Author", info.author));
   if (info.title && info.title !== "?") {
     if (info.paper_url && info.paper_url !== "?") {
       itemsToRender.push(item("Title", info.title, info.paper_url));
@@ -172,7 +172,7 @@ const TipClickedPanel = ({tip, goAwayCallback}) => {
               item("Collection date confidence", `(${numericToCalendar(dateUncertainty[0])}, ${numericToCalendar(dateUncertainty[1])})`)
             ) : null}
             {/* Author / Paper information */}
-            {displayPublicationInfo(getTraitFromNode(tip.n, "author"))}
+            {displayPublicationInfo(tip.n.author)}
             {/* try to join URL with accession, else display the one that's available */}
             {accessionAndUrl(tip.n)}
           </tbody>

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -153,6 +153,8 @@ class Legend extends React.Component {
       return `${months[mm]} ${yyyy}`;
     } else if (this.props.colorScale.continuous) {
       return label;
+    } else if (this.props.colorBy === "author") {
+      return label;
     }
     return prettyString(label);
   }


### PR DESCRIPTION
This is tested to improve simultaneous display of author fields in V1 JSONs and in V2 JSONs

This resolves:
* Don't CamelCase to "Et Al"
* Properly display author, title and journal in clicked info panel

This can be tested on http://staging.nextstrain.org/zika-v2.json.