### PR TITLE
Fix nucleotide colorby bug

### DIFF
--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -8,9 +8,7 @@ export const setGenotype = (nodes, prot, positions) => {
   const recurse = (node, state) => {
     const newState = state; /* reference. cheap */
     let data; // any potential mutations that would result in a state change
-    if (prot === nucleotide_gene && node.mutations && node.mutations.nuc && node.mutations.nuc.length) {
-      data = node.mutations;
-    } else if (node.mutations && node.mutations[prot]) {
+    if (node.mutations && node.mutations[prot]) {
       data = node.mutations[prot];
     }
     if (data && data.length) {


### PR DESCRIPTION
This should close issue #749 

When prot = "nuc", data was getting passed the entire
`node.mutations` object instead of the `node.mutations.nuc`
 array. 

Since both protein and nucleotide mutations are contained 
within the `node.mutations` object, there is no need to 
differentiate between them and just pass to data
`node.mutations[prot]`