### PR TITLE
Improvements to Codon and Nuc Bars & Mouseovers

### DIFF
--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -107,7 +107,7 @@ EntropyChart.prototype._aaToNtCoord = function _aaToNtCoord(gene, aaPos) {
   if (this.geneMap[gene].strand === "-") {
     return this.geneMap[gene].end - aaPos * 3 + 1;
   }
-  return this.geneMap[gene].start + aaPos * 3;
+  return this.geneMap[gene].start + aaPos * 3 - 2; // Plot from 1st codon position, not last.
 };
 
 EntropyChart.prototype._getZoomCoordinates = function _getZoomCoordinates(parsed, geneMap) {
@@ -278,15 +278,30 @@ EntropyChart.prototype._drawBars = function _drawBars() {
   if (this.aa) {
     posInView /= 3;
   }
-  const barWidth = posInView > 10000 ? 2 : posInView > 1000 ? 2 : posInView > 100 ? 3 : 5;
+  let barWidth;
+  if (this.aa) {
+    if (posInView > 600) {
+      barWidth = 2;
+    } else {
+      barWidth = (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon)+2.4) - this.scales.xMain(this._aaToNtCoord(d.prot, d.codon));
+    }
+  } else {
+    if (posInView > 1000) { // eslint-disable-line no-lonely-if
+      barWidth = 2;
+    } else if (posInView > 250) {
+      barWidth = 3;
+    } else {
+      barWidth = (d) => this.scales.xMain(d.x + 0.3) - this.scales.xMain(d.x - 0.3);
+    }
+  }
   const chart = this.mainGraph.append("g")
     .attr("clip-path", "url(#clip)")
     .selectAll(".bar");
   const idfn = this.aa ? (d) => "prot" + d.prot + d.codon : (d) => "nt" + d.x;
 
   const xscale = this.aa ?
-    (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon)) :
-    (d) => this.scales.xMain(d.x);
+    (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon) + 0.3) : // shift 0.3 in order to
+    (d) => this.scales.xMain(d.x - 0.3);                                 // line up bars & ticks
   const fillfn = this.aa ?
     (d) => this.geneMap[d.prot].idx % 2 ? medGrey : darkGrey :
     (d) => {

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -104,6 +104,9 @@ EntropyChart.prototype.update = function update({
 
 /* convert amino acid X in gene Y to a nucleotide number */
 EntropyChart.prototype._aaToNtCoord = function _aaToNtCoord(gene, aaPos) {
+  if (this.geneMap[gene].strand === "-") {
+    return this.geneMap[gene].end - aaPos * 3 + 1;
+  }
   return this.geneMap[gene].start + aaPos * 3;
 };
 
@@ -280,6 +283,7 @@ EntropyChart.prototype._drawBars = function _drawBars() {
     .attr("clip-path", "url(#clip)")
     .selectAll(".bar");
   const idfn = this.aa ? (d) => "prot" + d.prot + d.codon : (d) => "nt" + d.x;
+
   const xscale = this.aa ?
     (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon)) :
     (d) => this.scales.xMain(d.x);
@@ -310,6 +314,7 @@ EntropyChart.prototype._drawBars = function _drawBars() {
       this.callbacks.onClick(d);
     })
     .style("cursor", "pointer");
+
   this._highlightSelectedBars();
 };
 

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -283,7 +283,7 @@ EntropyChart.prototype._drawBars = function _drawBars() {
     if (posInView > 600) {
       barWidth = 2;
     } else {
-      barWidth = (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon)+2.4) - this.scales.xMain(this._aaToNtCoord(d.prot, d.codon));
+      barWidth = (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon)+2.6) - this.scales.xMain(this._aaToNtCoord(d.prot, d.codon));
     }
   } else {
     if (posInView > 1000) { // eslint-disable-line no-lonely-if
@@ -300,7 +300,7 @@ EntropyChart.prototype._drawBars = function _drawBars() {
   const idfn = this.aa ? (d) => "prot" + d.prot + d.codon : (d) => "nt" + d.x;
 
   const xscale = this.aa ?
-    (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon) + 0.3) : // shift 0.3 in order to
+    (d) => this.scales.xMain(this._aaToNtCoord(d.prot, d.codon) - 0.3) : // shift 0.3 in order to
     (d) => this.scales.xMain(d.x - 0.3);                                 // line up bars & ticks
   const fillfn = this.aa ?
     (d) => this.geneMap[d.prot].idx % 2 ? medGrey : darkGrey :

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -273,6 +273,7 @@ class Entropy extends React.Component {
           height={this.props.height}
           mutType={this.props.mutType}
           showCounts={this.props.showCounts}
+          geneMap={this.props.geneMap}
         />
         <svg
           id="d3entropyParent"

--- a/src/components/entropy/infoPanel.js
+++ b/src/components/entropy/infoPanel.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { infoPanelStyles } from "../../globalStyles";
 
-const InfoPanel = ({hovered, width, height, mutType, showCounts}) => {
+const InfoPanel = ({hovered, width, height, mutType, showCounts, geneMap}) => {
   /* this is a function - we can bail early */
   if (!hovered) {
     return null;
@@ -52,6 +52,10 @@ const InfoPanel = ({hovered, width, height, mutType, showCounts}) => {
           {mutType === "aa" ? `Codon ${hovered.d.codon} in protein ${hovered.d.prot}` :
             hovered.d.prot ? `Nucleotide ${hovered.d.x} (in protein ${hovered.d.prot})` :
               `Nucleotide ${hovered.d.x}`}
+        </div>
+        <p/>
+        <div>
+          {geneMap[hovered.d.prot].strand === "-" ? `Negative strand` : `Positive strand`}
         </div>
         <p/>
         <div>

--- a/src/components/entropy/infoPanel.js
+++ b/src/components/entropy/infoPanel.js
@@ -45,17 +45,33 @@ const InfoPanel = ({hovered, width, height, mutType, showCounts, geneMap}) => {
     styles.container.bottom = height - pos.y;
   }
 
+  const isNegStrand = hovered.d.prot ? geneMap[hovered.d.prot].strand === "-" : null;
+
+  const nucPos = hovered.d.prot ?
+    mutType === "aa" ?
+      isNegStrand ? geneMap[hovered.d.prot].end - hovered.d.codon * 3 + 3 :
+        geneMap[hovered.d.prot].start + hovered.d.codon * 3
+      : isNegStrand ? geneMap[hovered.d.prot].end - hovered.d.x :
+        hovered.d.x - geneMap[hovered.d.prot].start-1
+    : null;
+
+  const codonFromNuc = hovered.d.prot && mutType !== "aa" ? Math.floor((nucPos)/3) + 1 : null;
+
   return (
     <div style={styles.container}>
       <div className={"tooltip"} style={infoPanelStyles.tooltip}>
         <div>
           {mutType === "aa" ? `Codon ${hovered.d.codon} in protein ${hovered.d.prot}` :
-            hovered.d.prot ? `Nucleotide ${hovered.d.x} (in protein ${hovered.d.prot})` :
+            hovered.d.prot ? `Nucleotide ${hovered.d.x} (codon ${codonFromNuc} in protein ${hovered.d.prot})` :
               `Nucleotide ${hovered.d.x}`}
         </div>
         <p/>
         <div>
-          {geneMap[hovered.d.prot].strand === "-" ? `Negative strand` : `Positive strand`}
+          {mutType === "aa" ? `Nuc positions ${nucPos-2} to ${nucPos}` : ``}
+        </div>
+        <p/>
+        <div>
+          {isNegStrand === null ? `` : isNegStrand ? `Negative strand` : `Positive strand`}
         </div>
         <p/>
         <div>


### PR DESCRIPTION
I got this started just to fix item 1 below, which James noticed was wrong, but then I got rolling and did some stuff that I've been wishing for for a while.

1. Negative strand genes now plot codons in the right position (10 codons from the end/right rather than 10 codons from the start/left).
Compare 10 AA (orange) and 30AA (grey) mutation in this gene which is on the negative strand before:
![image](https://user-images.githubusercontent.com/14290674/63120903-90b70a00-bfa3-11e9-8f40-9c3e8f5c941b.png)

    And after:
  ![image](https://user-images.githubusercontent.com/14290674/63120941-a75d6100-bfa3-11e9-8815-b0d24a1435f3.png)
(Sorry, the 10AA is no longer orange, but it's the one to the far right.)

2. While doing this I got annoyed about how codon and nucleotide boxes are drawn. Here, the orange box is a codon for positions 5326-5328. It's just kind of floating randomly between 5325 and 5330.
The one to the left is worse - it's for positions 5323-5325, but it's plotted starting at 5325 and going to the right!
   ![image](https://user-images.githubusercontent.com/14290674/63120999-cb20a700-bfa3-11e9-8d5a-fc790c341ff1.png)

   This now plots like this. The orange actually covers 5326-5328. The one to the left now looks like it sits nicely on 5323-5325:
   ![image](https://user-images.githubusercontent.com/14290674/63121196-2a7eb700-bfa4-11e9-8aeb-5a2b89fff4a4.png)

   I did the same thing for nucs - currently they sit to the right of what they are. Here the orange one is nuc 5325:
   ![image](https://user-images.githubusercontent.com/14290674/63121339-77628d80-bfa4-11e9-9182-9170ac7c207d.png)

    Now it sits actually on the number!:
   ![image](https://user-images.githubusercontent.com/14290674/63121402-a547d200-bfa4-11e9-9334-bbc789ce07b3.png)

3. Finally, I wanted to make it easier to connect between the codons and the nucleotides. This is something I've dreamed of for a long while - knowing an interesting codon is number 103 in a gene in the middle of your genome can be not-so-helpful for more closely examining the associated nucleotides...

   So now, on a nucleotide in a gene, you can see what codon it is:
   ![image](https://user-images.githubusercontent.com/14290674/63121525-f2c43f00-bfa4-11e9-9e3c-d7bbfd64692a.png)

   And for a codon, you can see what nucleotides they are!:
   ![image](https://user-images.githubusercontent.com/14290674/63121576-138c9480-bfa5-11e9-8faa-57ab4212cbdd.png)

    (Also shows the strand) This works on negative strand too, and is possibly even more useful, since this is super not-intuitive:
  
   ![image](https://user-images.githubusercontent.com/14290674/63121656-446cc980-bfa5-11e9-8e3e-21d49ac5fd15.png)
  
   ![image](https://user-images.githubusercontent.com/14290674/63121670-4fbff500-bfa5-11e9-936a-2efcb42f3990.png)


I wanted to write all this up before I forget (also because I'm very excited by it, this would be so useful for me), but welcome comments! Will have to be modified when the GFF changes are merged to look for `+` and `-` instead of `-1` and `+1` for strand. 

And to preempt maybe a comment on how the 'fat' codon view above looks - if you aren't really zoomed in the codons look very similar to what we have now. Only when you really zoom in do they look 'fat'. But this means their actual position is shown *so much more clearly*! 😄 