### PR TITLE
Fix frequency panel bug

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -122,7 +122,7 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
   }
 
   /* do we have frequencies to display? */
-  if (mainJson.panels && mainJson.panels.indexOf("frequencies") !== -1) {
+  if (mainJson.meta.panels && mainJson.meta.panels.indexOf("frequencies") !== -1) {
     try {
       const frequencyData = await getDataset(url, {type: "tip-frequencies"});
       dispatch(loadFrequencies(frequencyData));


### PR DESCRIPTION
This is a simple fix for a bug caused by moving metadata 
into a top-level `meta` layer, 
the frequencies panel was missed in updates to the 
React code.