### PR TITLE
Update frequencies tooltips and include projection pivot

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -74,6 +74,10 @@ const removeYAxis = (svg) => {
   svg.selectAll(".y.axis").remove();
 };
 
+const removeProjectionPivot = (svg) => {
+  svg.selectAll(".projection-pivot").remove();
+};
+
 export const drawXAxis = (svg, chartGeom, scales) => {
   removeXAxis(svg);
   svg.append("g")
@@ -83,6 +87,7 @@ export const drawXAxis = (svg, chartGeom, scales) => {
     .style("font-size", "12px")
     .call(axisBottom(scales.x).ticks(scales.numTicksX, ".1f"));
 };
+
 export const drawYAxis = (svg, chartGeom, scales) => {
   removeYAxis(svg);
   svg.append("g")
@@ -91,6 +96,22 @@ export const drawYAxis = (svg, chartGeom, scales) => {
     .style("font-family", dataFont)
     .style("font-size", "12px")
     .call(axisLeft(scales.y).ticks(scales.numTicksY));
+};
+
+export const drawProjectionPivot = (svg, scales, projection_pivot) => {
+  if (projection_pivot) {
+    removeProjectionPivot(svg);
+    svg.append("g")
+      .attr("class", "projection-pivot")
+      .append("line")
+      .attr("x1", scales.x(parseFloat(projection_pivot)))
+      .attr("x2", scales.x(parseFloat(projection_pivot)))
+      .attr("y1", scales.y(1))
+      .attr("y2", scales.y(0))
+      .style("visibility", "visible")
+      .style("stroke", "#555")
+      .style("stroke-width", "2");
+  }
 };
 
 const turnMatrixIntoSeries = (categories, nPivots, matrix) => {

--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -109,8 +109,9 @@ export const drawProjectionPivot = (svg, scales, projection_pivot) => {
       .attr("y1", scales.y(1))
       .attr("y2", scales.y(0))
       .style("visibility", "visible")
-      .style("stroke", "#555")
-      .style("stroke-width", "2");
+      .style("stroke", "rgba(55,55,55,0.9)")
+      .style("stroke-width", "2")
+      .style("stroke-dasharray", "4 4");
   }
 };
 
@@ -237,20 +238,35 @@ export const drawStream = (
     const date = scales.x.invert(mousex);
     const pivotIdx = pivots.reduce((closestIdx, val, idx, arr) => Math.abs(val - date) < Math.abs(arr[closestIdx] - date) ? idx : closestIdx, 0);
     const freqVal = Math.round((d[pivotIdx][1] - d[pivotIdx][0]) * 100) + "%";
-    const xvalueOfPivot = scales.x(pivots[pivotIdx]);
+    const xValueOfPivot = scales.x(pivots[pivotIdx]);
+    const y1ValueOfPivot = scales.y(d[pivotIdx][1]);
+    const y2ValueOfPivot = scales.y(d[pivotIdx][0]);
 
     select("#vline")
       .style("visibility", "visible")
-      .attr("x1", xvalueOfPivot)
-      .attr("x2", xvalueOfPivot);
+      .attr("x1", xValueOfPivot)
+      .attr("x2", xValueOfPivot)
+      .attr("y1", y1ValueOfPivot)
+      .attr("y2", y2ValueOfPivot);
 
-    const left = mousex > 0.5 * scales.x.range()[1] ? "" : `${mousex + 4}px`;
-    const right = mousex > 0.5 * scales.x.range()[1] ? `${scales.x.range()[1] - mousex - 4}px` : "";
+    const left = xValueOfPivot > 0.5 * scales.x.range()[1] ? "" : `${xValueOfPivot + 25}px`;
+    const right = xValueOfPivot > 0.5 * scales.x.range()[1] ? `${scales.x.range()[1] - xValueOfPivot + 25}px` : "";
+    const top = y1ValueOfPivot > 0.5 * scales.y(0) ? `${scales.y(0) - 50}px` : `${y1ValueOfPivot + 25}px`;
     select("#freqinfo")
       .style("left", left)
       .style("right", right)
-      .style("top", `${70}px`)
+      .style("top", top)
+      .style("padding-left", "10px")
+      .style("padding-right", "10px")
+      .style("padding-top", "0px")
+      .style("padding-bottom", "0px")
       .style("visibility", "visible")
+      .style("background-color", "rgba(55,55,55,0.9)")
+      .style("color", "white")
+      .style("font-family", "Lato, Helvetica Neue, Helvetica, sans-serif")
+      .style("font-size", 18)
+      .style("line-height", 1)
+      .style("font-weight", 300)
       .html(`<p>${parseColorBy(colorBy, colorOptions)}: ${prettyString(labels[i])}</p>
         <p>Time point: ${pivots[pivotIdx]}</p>
         <p>Frequency: ${freqVal}</p>`);
@@ -269,15 +285,13 @@ export const drawStream = (
     .on("mouseout", handleMouseOut)
     .on("mousemove", handleMouseMove);
 
-  /* the vertical line to indicate the pivot point */
+  /* the vertical line to indicate the highlighted frequency interval */
   svgStreamGroup.append("line")
     .attr("id", "vline")
-    .attr("y1", scales.y(1))
-    .attr("y2", scales.y(0))
     .style("visibility", "hidden")
     .style("pointer-events", "none")
-    .style("stroke", "hsla(0,0%,100%,.9)")
-    .style("stroke-width", "5");
+    .style("stroke", "rgba(55,55,55,0.9)")
+    .style("stroke-width", 4);
 
   drawLabelsOverStream(svgStreamGroup, series, pivots, labels, scales);
 };

--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -74,8 +74,9 @@ const removeYAxis = (svg) => {
   svg.selectAll(".y.axis").remove();
 };
 
-const removeProjectionPivot = (svg) => {
+const removeProjectionInfo = (svg) => {
   svg.selectAll(".projection-pivot").remove();
+  svg.selectAll(".projection-text").remove();
 };
 
 export const drawXAxis = (svg, chartGeom, scales) => {
@@ -98,9 +99,11 @@ export const drawYAxis = (svg, chartGeom, scales) => {
     .call(axisLeft(scales.y).ticks(scales.numTicksY));
 };
 
-export const drawProjectionPivot = (svg, scales, projection_pivot) => {
+export const drawProjectionInfo = (svg, scales, projection_pivot) => {
   if (projection_pivot) {
-    removeProjectionPivot(svg);
+
+    removeProjectionInfo(svg);
+
     svg.append("g")
       .attr("class", "projection-pivot")
       .append("line")
@@ -112,6 +115,21 @@ export const drawProjectionPivot = (svg, scales, projection_pivot) => {
       .style("stroke", "rgba(55,55,55,0.9)")
       .style("stroke-width", "2")
       .style("stroke-dasharray", "4 4");
+
+    const midPoint = 0.5 * (scales.x(parseFloat(projection_pivot)) + scales.x.range()[1]);
+    svg.append("g")
+      .attr("class", "projection-text")
+      .append("text")
+      .attr("x", midPoint)
+      .attr("y", scales.y(1) - 3)
+      .style("pointer-events", "none")
+      .style("fill", "#555")
+      .style("font-family", dataFont)
+      .style("font-size", 12)
+      .style("alignment-baseline", "bottom")
+      .style("text-anchor", "middle")
+      .text("Projection");
+
   }
 };
 
@@ -219,7 +237,7 @@ export const processMatrix = ({matrix, pivots, colorScale}) => {
 };
 
 export const drawStream = (
-  svgStreamGroup, scales, {categories, series}, {colorBy, colorScale, colorOptions, pivots}
+  svgStreamGroup, scales, {categories, series}, {colorBy, colorScale, colorOptions, pivots, projection_pivot}
 ) => {
   removeStream(svgStreamGroup);
   const colourer = generateColorScaleD3(categories, colorScale);
@@ -252,6 +270,14 @@ export const drawStream = (
     const left = xValueOfPivot > 0.5 * scales.x.range()[1] ? "" : `${xValueOfPivot + 25}px`;
     const right = xValueOfPivot > 0.5 * scales.x.range()[1] ? `${scales.x.range()[1] - xValueOfPivot + 25}px` : "";
     const top = y1ValueOfPivot > 0.5 * scales.y(0) ? `${scales.y(0) - 50}px` : `${y1ValueOfPivot + 25}px`;
+
+    let frequencyText = "Frequency";
+    if (projection_pivot) {
+      if (pivots[pivotIdx] > projection_pivot) {
+        frequencyText = "Projected frequency";
+      }
+    }
+
     select("#freqinfo")
       .style("left", left)
       .style("right", right)
@@ -263,13 +289,13 @@ export const drawStream = (
       .style("visibility", "visible")
       .style("background-color", "rgba(55,55,55,0.9)")
       .style("color", "white")
-      .style("font-family", "Lato, Helvetica Neue, Helvetica, sans-serif")
+      .style("font-family", dataFont)
       .style("font-size", 18)
       .style("line-height", 1)
       .style("font-weight", 300)
       .html(`<p>${parseColorBy(colorBy, colorOptions)}: ${prettyString(labels[i])}</p>
         <p>Time point: ${pivots[pivotIdx]}</p>
-        <p>Frequency: ${freqVal}</p>`);
+        <p>${frequencyText}: ${freqVal}</p>`);
   }
 
 

--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -4,6 +4,7 @@ import { scaleLinear } from "d3-scale";
 import { axisBottom, axisLeft } from "d3-axis";
 import { rgb } from "d3-color";
 import { area } from "d3-shape";
+import { format } from "d3-format";
 import { dataFont } from "../../globalStyles";
 import { prettyString } from "../../util/stringHelpers";
 import { unassigned_label } from "../../util/processFrequencies";
@@ -91,12 +92,13 @@ export const drawXAxis = (svg, chartGeom, scales) => {
 
 export const drawYAxis = (svg, chartGeom, scales) => {
   removeYAxis(svg);
+  const formatPercent = format(".0%");
   svg.append("g")
     .attr("class", "y axis")
     .attr("transform", `translate(${chartGeom.spaceLeft},0)`)
     .style("font-family", dataFont)
     .style("font-size", "12px")
-    .call(axisLeft(scales.y).ticks(scales.numTicksY));
+    .call(axisLeft(scales.y).ticks(scales.numTicksY).tickFormat(formatPercent));
 };
 
 export const drawProjectionInfo = (svg, scales, projection_pivot) => {

--- a/src/components/frequencies/index.js
+++ b/src/components/frequencies/index.js
@@ -3,8 +3,8 @@ import { select } from "d3-selection";
 import 'd3-transition'
 import { connect } from "react-redux";
 import Card from "../framework/card";
-import { calcXScale, calcYScale, drawXAxis, drawYAxis, areListsEqual,
-  drawStream, processMatrix, parseColorBy } from "./functions";
+import { calcXScale, calcYScale, drawXAxis, drawYAxis, drawProjectionPivot,
+  areListsEqual, drawStream, processMatrix, parseColorBy } from "./functions";
 import "../../css/entropy.css";
 
 @connect((state) => {
@@ -13,6 +13,7 @@ import "../../css/entropy.css";
     pivots: state.frequencies.pivots,
     ticks: state.frequencies.ticks,
     matrix: state.frequencies.matrix,
+    projection_pivot: state.frequencies.projection_pivot,
     version: state.frequencies.version,
     browserDimensions: state.browserDimensions.browserDimensions,
     colorBy: state.controls.colorBy,
@@ -40,6 +41,7 @@ class Frequencies extends React.Component {
     drawXAxis(newState.svg, chartGeom, scalesX);
     drawYAxis(newState.svg, chartGeom, scalesY);
     drawStream(newState.svgStreamGroup, newState.scales, data, {...props});
+    drawProjectionPivot(newState.svg, newState.scales, props.projection_pivot);
   }
   recomputeRedrawPartial(oldState, oldProps, newProps) {
     /* we don't have to check width / height changes here - that's done in componentDidUpdate */
@@ -59,6 +61,9 @@ class Frequencies extends React.Component {
     }
     /* if !catChange we could transition the streams instead of redrawing them... */
     drawStream(oldState.svgStreamGroup, newScales, data, {...newProps});
+    if (maxYChange) {
+      drawProjectionPivot(oldState.svg, newScales, newProps.projection_pivot);  
+    }
     return {...oldState, scales: newScales, maxY: data.maxY, categories: data.categories};
   }
   componentDidMount() {

--- a/src/components/frequencies/index.js
+++ b/src/components/frequencies/index.js
@@ -3,7 +3,7 @@ import { select } from "d3-selection";
 import 'd3-transition'
 import { connect } from "react-redux";
 import Card from "../framework/card";
-import { calcXScale, calcYScale, drawXAxis, drawYAxis, drawProjectionPivot,
+import { calcXScale, calcYScale, drawXAxis, drawYAxis, drawProjectionInfo,
   areListsEqual, drawStream, processMatrix, parseColorBy } from "./functions";
 import "../../css/entropy.css";
 
@@ -41,7 +41,7 @@ class Frequencies extends React.Component {
     drawXAxis(newState.svg, chartGeom, scalesX);
     drawYAxis(newState.svg, chartGeom, scalesY);
     drawStream(newState.svgStreamGroup, newState.scales, data, {...props});
-    drawProjectionPivot(newState.svg, newState.scales, props.projection_pivot);
+    drawProjectionInfo(newState.svg, newState.scales, props.projection_pivot);
   }
   recomputeRedrawPartial(oldState, oldProps, newProps) {
     /* we don't have to check width / height changes here - that's done in componentDidUpdate */
@@ -62,7 +62,7 @@ class Frequencies extends React.Component {
     /* if !catChange we could transition the streams instead of redrawing them... */
     drawStream(oldState.svgStreamGroup, newScales, data, {...newProps});
     if (maxYChange) {
-      drawProjectionPivot(oldState.svg, newScales, newProps.projection_pivot);  
+      drawProjectionInfo(oldState.svg, newScales, newProps.projection_pivot);
     }
     return {...oldState, scales: newScales, maxY: data.maxY, categories: data.categories};
   }
@@ -113,7 +113,15 @@ class Frequencies extends React.Component {
             fontSize: "14px"
           }}
         />
-        <svg style={{pointerEvents: "auto"}} width={this.props.width} height={this.props.height} id="d3frequenciesSVG">
+        <svg
+          id="d3frequenciesSVG"
+          width={this.props.width}
+          height={this.props.height}
+          style={{
+            pointerEvents: "auto",
+            overflow: "visible"
+          }}
+        >
           <g ref={(c) => { this.domRef = c; }} id="d3frequencies"/>
         </svg>
       </Card>

--- a/src/reducers/frequencies.js
+++ b/src/reducers/frequencies.js
@@ -7,6 +7,7 @@ const frequencies = (state = {
   pivots: undefined,
   ticks: undefined,
   matrix: undefined,
+  projection_pivot: undefined,
   version: 0
 }, action) => {
   switch (action.type) {
@@ -17,7 +18,7 @@ const frequencies = (state = {
       return Object.assign({}, state, {loaded: true, matrix: action.matrix, version: state.version + 1});
     }
     case types.DATA_INVALID: {
-      return {loaded: false, data: undefined, pivots: undefined, ticks: undefined, matrix: undefined, version: 0};
+      return {loaded: false, data: undefined, pivots: undefined, ticks: undefined, matrix: undefined, projection_pivot: undefined, version: 0};
     }
     default:
       return state;

--- a/src/util/processFrequencies.js
+++ b/src/util/processFrequencies.js
@@ -74,6 +74,10 @@ export const processFrequenciesJSON = (rawJSON, tree, controls) => {
   while (ticks[ticks.length - 1] < pivots[pivots.length - 1]) {
     ticks.push((ticks[ticks.length - 1] + tick_step) * 10 / 10);
   }
+  let projection_pivot = null;
+  if ("projection_pivot" in rawJSON) {
+    projection_pivot = Math.round(parseFloat(rawJSON.projection_pivot) * 100) / 100;
+  }
   if (!tree.loaded) {
     throw new Error("tree not loaded");
   }
@@ -101,6 +105,7 @@ export const processFrequenciesJSON = (rawJSON, tree, controls) => {
     data,
     pivots,
     ticks,
-    matrix
+    matrix,
+    projection_pivot
   };
 };


### PR DESCRIPTION
@jameshadfield, @rneher  ---

This PR is motivated by @huddlej's recent flu forecasting work. We thought it best to not mess with the underlying data structure of `tip-frequencies.json`. We've kept this JSON structure exactly as before but just included an additional attribute of `projection_pivot`:
```
{
 "A/Aberystwyth/5949/2018": {
  "frequencies": [
   0.0,
   0.0,
   0.0,
...
  ]
 },
...
 "pivots": [
  2017.67,
  2017.75,
  2017.83,
...
 ],
 "projection_pivot": 2019.67
}
```

This way the frequency streamplot can be drawn as before, but we just mark down with a dashed line what derives from empirical `augur frequencies` and what derives from a forecast.

<img width="941" alt="Screen Shot 2019-08-26 at 9 41 25 AM" src="https://user-images.githubusercontent.com/1176109/63659752-c0f17a80-c7e5-11e9-863e-6343e5d3d3f6.png">

I've added `state.frequencies.projection_pivot` to redux to accomplish this. If you want a dataset to demo this with use: https://nextstrain.org/staging/flu/seasonal/h3n2/ha/2y

Importantly, this is backward compatible with previous versions of auspice. The forecast will still show correctly, but we just won't get the dashed projection pivot.

------------------------------------

Additionally, this improves frequencies tooltips to be specific to the frequency bin rather than show a full vertical line, as so:

<img width="942" alt="Screen Shot 2019-08-26 at 9 44 51 AM" src="https://user-images.githubusercontent.com/1176109/63659825-38bfa500-c7e6-11e9-99c9-13d3c5d38a93.png">

And makes a few aesthetic improvements (white text on black background and tooltip placement).
