### PR TITLE
Implement server redirects in nextstrain.org to handle incomplete request urls

### DIFF
--- a/cli/server/getDataset.js
+++ b/cli/server/getDataset.js
@@ -120,7 +120,6 @@ const setUpGetDatasetHandler = ({datasetsPath}) => {
         unifiedJson._treeTwoName = datasetInfo.secondTreeName;
       }
       unifiedJson._treeName = datasetInfo.treeName;
-      unifiedJson._url = datasetInfo.auspiceDisplayUrl;
     } catch (err) {
       return handleError(res, `Couldn't fetch JSONs`, err.message);
     }

--- a/docs-src/docs/customisations/server/charonAPI.md
+++ b/docs-src/docs/customisations/server/charonAPI.md
@@ -92,7 +92,6 @@ The current main dataset response shape is:
   "meta": "the schema 1.0 metadata json object",
   "tree": "the schema 1.0 tree json object",
   "_source": "the source (e.g. live, staging, github). Only used by the sidebar dataset selector",
-  "_url": "the URL to which auspice should update. Allows flu to redirect silently to flu/seasonal/..."
 }
 ```
 

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -84,15 +84,17 @@ const fetchDataAndDispatch = (dispatch, url, query, narrativeBlocks) => {
     fetchExtras += `&deprecatedSecondTree=${query.tt}`;
   }
 
-
   // fetchJSON(`${charonAPIAddress}request=mainJSON&url=${url}${fetchExtras}`)
+  let pathnameShouldBe;
   getDataset(`${url}${fetchExtras}`)
     .then((res) => {
+      pathnameShouldBe = queryString.parse(res.url.split("?")[1]).prefix;
       return res.json();
     })
     .then((json) => {
       dispatch({
         type: types.CLEAN_START,
+        pathnameShouldBe,
         ...createStateFromQueryOrJSONs({json, query, narrativeBlocks})
       });
       return {

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -56,7 +56,7 @@ const getDatasetFromCharon = (prefix, {type, narrative=false}={}) => {
  */
 const getHardcodedData = (prefix, {type="mainJSON", narrative=false}={}) => {
   const datapaths = getExtension("hardcodedDataPaths");
-  console.log("FETCHING", datapaths[type]);
+
   const p = fetch(datapaths[type])
     .then((res) => {
       if (res.status !== 200) {
@@ -67,7 +67,6 @@ const getHardcodedData = (prefix, {type="mainJSON", narrative=false}={}) => {
   return p;
 };
 
-// const fetchData = hasExtension("hardcodedDataPaths") ? getHardcodedData : getDatasetFromCharon;
 const getDataset = hasExtension("hardcodedDataPaths") ? getHardcodedData : getDatasetFromCharon;
 
 
@@ -119,6 +118,7 @@ const fetchDataAndDispatch = (dispatch, url, query, narrativeBlocks) => {
       console.warn(err, err.message);
       dispatch(goTo404(`Couldn't load JSONs for ${url}`));
     });
+
   if (warning) {
     dispatch(warningNotification(warning));
   }
@@ -132,7 +132,9 @@ export const loadJSONs = ({url = window.location.pathname, search = window.locat
     }
     const query = queryString.parse(search);
 
-    if (url.indexOf("narratives") !== -1) {
+    if (url.indexOf("narratives") === -1) {
+      fetchDataAndDispatch(dispatch, url, query);
+    } else {
       /* we want to have an additional fetch to get the narrative JSON, which in turn
       tells us which data JSON to fetch... */
       getDatasetFromCharon(url, {narrative: true})
@@ -147,9 +149,7 @@ export const loadJSONs = ({url = window.location.pathname, search = window.locat
           console.error("Error obtaining narratives", err.message);
           dispatch(goTo404(`Couldn't load narrative for ${url}`));
         });
-    } else {
-      fetchDataAndDispatch(dispatch, url, query);
-    }
+    };
   };
 };
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -585,8 +585,8 @@ export const createStateFromQueryOrJSONs = ({
   if (json["_treeName"]) {
     tree.name = json["_treeName"];
   }
-  const url = json["_url"]; // injected by the server. Will be picked up by middleware.
-  return {tree, treeToo, metadata, entropy, controls, narrative, frequencies, query, url};
+
+  return {tree, treeToo, metadata, entropy, controls, narrative, frequencies, query};
 };
 
 export const createTreeTooState = ({

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -119,8 +119,8 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
   /* second switch: path change */
   switch (action.type) {
     case types.CLEAN_START:
-      if (action.url && !action.narrative) {
-        pathname = action.url;
+      if (action.pathnameShouldBe && !action.narrative) {
+        pathname = action.pathnameShouldBe;
       }
       break;
     case types.CHANGE_URL_QUERY_BUT_NOT_REDUX_STATE: {


### PR DESCRIPTION
The part of issue #753 pertaining to Auspice v1 magic `_url`s is addressed via this PR.
See nextstrain/nextstrain.org/pull/25 for the nextstrain.org side of things.

Auspice `v2` doesn't quite work with Nextstrain.org yet, so I branched off of `master` instead for this work.

Note that it doesn't appear that changing the browser window path has to go through Redux at all. This is deeply suspicious to me, but so far all my testing suggests this works just fine. I would love some additional eyes on it.