### PR TITLE
Ordinal vs categorical

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -329,11 +329,11 @@ class Footer extends React.Component {
         {`Filter by ${filterTitle}`}
         {this.props.activeFilters[filterName].length ? removeFiltersButton(this.props.dispatch, [filterName], "inlineRight", `Clear ${filterName} filter`) : null}
         <Flex wrap="wrap" justifyContent="flex-start" alignItems="center" style={styles.citationList}>
-          {Object.keys(totalStateCount).sort().map((itemName) => {
+          {Array.from(totalStateCount.keys()).sort().map((itemName) => {
             const display = (
               <span>
                 {itemName}
-                {" (" + totalStateCount[itemName] + ")"}
+                {` (${totalStateCount.get(itemName)})`}
               </span>
             );
             return displayFilterValueAsButton(this.props.dispatch, this.props.activeFilters, filterName, itemName, display, false);

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -177,7 +177,7 @@ class Info extends React.Component {
       const display = (
         <span>
           {itemName}
-          {" (" + this.props.totalStateCounts[filterName][itemName] + ")"}
+          {` (${this.props.totalStateCounts[filterName].get(itemName)})`}
         </span>
       );
       buttons.push(displayFilterValueAsButton(this.props.dispatch, this.props.filters, filterName, itemName, display, true));

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -33,16 +33,14 @@ const createListOfColors = (n, range) => {
 const getDiscreteValuesFromTree = (nodes, nodesToo, attr) => {
   const stateCount = countTraitsAcrossTree(nodes, [attr], false, false)[attr];
   if (nodesToo) {
-    const sc = countTraitsAcrossTree(nodesToo, [attr], false, false)[attr];
-    for (let state in sc) { // eslint-disable-line
-      if (stateCount[state]) {
-        stateCount[state] += sc[state];
-      } else {
-        stateCount[state] = sc[state];
-      }
+    const stateCountSecondTree = countTraitsAcrossTree(nodesToo, [attr], false, false)[attr];
+    for (const state of stateCountSecondTree.keys()) {
+      const currentCount = stateCount.get(state) || 0;
+      stateCount.set(state, currentCount+1);
     }
   }
-  const domain = Object.keys(stateCount);
+  console.log("stateCount", stateCount);
+  const domain = Array.from(stateCount.keys());
   /* sorting technique depends on the colorBy */
   if (attr === "clade_membership") {
     domain.sort();

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -52,15 +52,16 @@ const getDiscreteValuesFromTree = (nodes, nodesToo, attr) => {
   return domain;
 };
 
-const createDiscreteScale = (domain, type='discrete') => {
+const createDiscreteScale = (domain, type='categorical') => {
   // note: colors[n] has n colors
+  let colorList;
   if (type==="ordinal"){
-    const colorList = domain.length <= colors.length ?
+    colorList = domain.length <= colors.length ?
       colors[domain.length].slice() :
       colors[colors.length - 1].slice();
   }else{
-      const colorList = genotypeColors.slice();
-   }
+    colorList = genotypeColors.slice();
+  }
   /* set unknowns which appear in the domain to the unknownColor */
   const unknowns = ["unknown", "undefined", "unassigned", "NA", "NaN", "?"];
   for (const key of unknowns) {
@@ -68,7 +69,6 @@ const createDiscreteScale = (domain, type='discrete') => {
       colorList[domain.indexOf(key)] = unknownColor;
     }
   }
-  console.log(colorList);
   const scale = scaleOrdinal().domain(domain).range(colorList);
   return (val) => ((val === undefined || domain.indexOf(val) === -1)) ? unknownColor : scale(val);
 };
@@ -156,7 +156,7 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
           .range(range);
         legendValues = domain;
       }
-    } else if (colorings && (colorings[colorBy].type === "categorical")  || (colorings[colorBy].type === "ordinal")) {
+    } else if (colorings && (colorings[colorBy].type === "categorical")) {
       continuous = false;
       legendValues = getDiscreteValuesFromTree(tree.nodes, treeTooNodes, colorBy);
       colorScale = createDiscreteScale(legendValues, "categorical");

--- a/src/util/treeCountingHelpers.js
+++ b/src/util/treeCountingHelpers.js
@@ -11,7 +11,7 @@ import { getTraitFromNode } from "./treeMiscHelpers";
 */
 export const countTraitsAcrossTree = (nodes, traits, visibility, terminalOnly) => {
   const counts = {};
-  traits.forEach((trait) => {counts[trait] = {};});
+  traits.forEach((trait) => {counts[trait] = new Map();});
 
   nodes.forEach((node) => {
     traits.forEach((trait) => {                         // traits are "country" or "author" etc
@@ -25,7 +25,8 @@ export const countTraitsAcrossTree = (nodes, traits, visibility, terminalOnly) =
         return;
       }
 
-      counts[trait][value] ? counts[trait][value] += 1 : counts[trait][value] = 1;
+      const currentValue = counts[trait].get(value) || 0;
+      counts[trait].set(value, currentValue+1);
     });
   });
   return counts;


### PR DESCRIPTION
This implements ordinal scales (integer) for quantities like RBS or epitope mutations and falls back on continuous scales when the number of values exceeds the longest defined sequential colorscale. Addresses issue #726.

It leaves categorical scales untouched, but they should probably use a categorical rather than a sequential scale (as currently the case for clades). 