### PR TITLE
Tangle tree options

### DIFF
--- a/cli/server/convertJsonSchemas.js
+++ b/cli/server/convertJsonSchemas.js
@@ -333,7 +333,7 @@ const setNodeBranchAttrs = (v2) => {
 };
 
 
-const convertFromV1 = ({tree, meta, treeName}) => {
+const convertFromV1 = ({tree, meta}) => {
   const v2 = {version: "2.0", meta: {}};
   // set metadata
   setColorings(v2["meta"], meta);
@@ -344,11 +344,6 @@ const convertFromV1 = ({tree, meta, treeName}) => {
   setLabels(v2);
   setAuthorInfoOnTree(v2, meta);
   setVaccineChoicesOnNodes(v2, meta);
-  if (treeName) {
-    // TODO -- this must be removed before v2 release
-    // see https://github.com/nextstrain/auspice/issues/776
-    v2["meta"].tree_name = treeName;
-  }
   removeNonV2TreeProps(v2);
   return v2;
 };

--- a/cli/server/getAvailable.js
+++ b/cli/server/getAvailable.js
@@ -1,6 +1,7 @@
 const utils = require("../utils");
 const fs = require('fs');
 const { promisify } = require('util');
+const { findAvailableTangleTreeOptions } = require('./getDatasetHelpers');
 
 const readdir = promisify(fs.readdir);
 
@@ -14,7 +15,7 @@ const getAvailableDatasets = async (localDataPath) => {
     const files = await readdir(localDataPath);
     /* v2 files -- match JSONs not ending with `_tree.json`, `_meta.json`,
     `_tip-frequencies.json`, `_seq.json` */
-    files.filter((file) => (
+    const v2Files = files.filter((file) => (
       file.endsWith(".json") &&
       !file.includes("manifest") &&
       !file.endsWith("_tree.json") &&
@@ -26,21 +27,32 @@ const getAvailableDatasets = async (localDataPath) => {
       .replace(".json", "")
       .split("_")
       .join("/")
-    )
-    .forEach((filepath) => {
-      datasets.push({request: filepath, v2: true});
+    );
+
+    v2Files.forEach((filepath) => {
+      datasets.push({
+        request: filepath,
+        v2: true,
+        tangleTreeOptions: findAvailableTangleTreeOptions(filepath, v2Files)
+      });
     });
+
     /* v1 files -- match files ending with `_tree.json` */
-    files
+    const v1Files = files
       .filter((file) => file.endsWith("_tree.json"))
       .map((file) => file
         .replace("_tree.json", "")
         .split("_")
         .join("/")
-      )
-      .forEach((filepath) => {
-        datasets.push({request: filepath, v2: false});
+      );
+
+    v1Files.forEach((filepath) => {
+      datasets.push({
+        request: filepath,
+        v2: false,
+        tangleTreeOptions: findAvailableTangleTreeOptions(filepath, v1Files)
       });
+    });
   } catch (err) {
     utils.warn(`Couldn't collect available dataset files (path searched: ${localDataPath})`);
     utils.verbose(err);

--- a/cli/server/getAvailable.js
+++ b/cli/server/getAvailable.js
@@ -1,7 +1,7 @@
 const utils = require("../utils");
 const fs = require('fs');
 const { promisify } = require('util');
-const { findAvailableTangleTreeOptions } = require('./getDatasetHelpers');
+const { findAvailableSecondTreeOptions } = require('./getDatasetHelpers');
 
 const readdir = promisify(fs.readdir);
 
@@ -33,7 +33,7 @@ const getAvailableDatasets = async (localDataPath) => {
       datasets.push({
         request: filepath,
         v2: true,
-        tangleTreeOptions: findAvailableTangleTreeOptions(filepath, v2Files)
+        secondTreeOptions: findAvailableSecondTreeOptions(filepath, v2Files)
       });
     });
 
@@ -50,7 +50,7 @@ const getAvailableDatasets = async (localDataPath) => {
       datasets.push({
         request: filepath,
         v2: false,
-        tangleTreeOptions: findAvailableTangleTreeOptions(filepath, v1Files)
+        secondTreeOptions: findAvailableSecondTreeOptions(filepath, v1Files)
       });
     });
   } catch (err) {

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -114,10 +114,42 @@ const sendJson = async (res, info) => {
   }
 }
 
+const findAvailableTangleTreeOptions = (currentDatasetUrl, availableDatasetUrls) => {
+  const currentDatasetUrlArr = currentDatasetUrl.split('/');
+
+  const availableTangleTreeOptions = availableDatasetUrls.filter((datasetUrl) => {
+    const datasetUrlArr = datasetUrl.split('/');
+    // Do not return the same dataset
+    if (currentDatasetUrl === datasetUrl) return null;
+
+    // Do not return dataset if the URLs have different number of parameters
+    if (currentDatasetUrlArr.length !== datasetUrlArr.length) return null;
+
+    // Do not return dataset if different pathogens
+    if (currentDatasetUrlArr[0] !== datasetUrlArr[0]) return null;
+
+    // Find differences between the two dataset URLs
+    const urlDifferences = currentDatasetUrlArr.filter((param, index) => {
+      if (datasetUrlArr[index] !== param) {
+        return param;
+      }
+      return null;
+    });
+
+    // Do not return dataset if more than one parameter is different
+    if (urlDifferences.length > 1) return null;
+
+    return datasetUrl;
+  });
+
+  return availableTangleTreeOptions;
+};
+
 module.exports = {
   interpretRequest,
   extendDataPathsToMatchAvailiable,
   makeFetchAddresses,
   handleError,
-  sendJson
+  sendJson,
+  findAvailableTangleTreeOptions
 };

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -108,7 +108,7 @@ const sendJson = async (res, info) => {
     const meta = await utils.readFilePromise(info.address.meta);
     const tree = await utils.readFilePromise(info.address.tree);
     /* v1 JSONs don't define a tree name, so we try to guess it here */
-    const mainTreeName = guessTreeName(info.parts);
+    const mainTreeName = info.parts.join('/');
     const v2Json = convertFromV1({tree, meta, treeName: mainTreeName});
     return res.json(v2Json)
   }

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -10,7 +10,6 @@
 
 const utils = require("../utils");
 const queryString = require("query-string");
-const getAvailable = require("./getAvailable");
 const path = require("path");
 const convertFromV1 = require("./convertJsonSchemas").convertFromV1;
 
@@ -19,15 +18,6 @@ const handleError = (res, clientMsg, serverMsg="") => {
   res.statusMessage = clientMsg;
   utils.warn(`${clientMsg} -- ${serverMsg}`);
   return res.status(500).end();
-};
-
-
-const guessTreeName = (prefixParts) => {
-  const guesses = ["HA", "NA", "PB1", "PB2", "PA", "NP", "NS", "MP", "L", "S", "SEGMENT1", "SEGMENT2", "SEGMENT3", "SEGMENT4", "SEGMENT5", "SEGMENT6", "SEGMENT7", "SEGMENT8", "SEGMENT9", "SEGMENT10"];
-  for (const part of prefixParts) {
-    if (guesses.indexOf(part.toUpperCase()) !== -1) return part;
-  }
-  return undefined;
 };
 
 const splitPrefixIntoParts = (url) => url
@@ -109,7 +99,7 @@ const sendJson = async (res, info) => {
     const tree = await utils.readFilePromise(info.address.tree);
     /* v1 JSONs don't define a tree name, so we try to guess it here */
     const mainTreeName = info.parts.join('/');
-    const v2Json = convertFromV1({tree, meta, treeName: mainTreeName});
+    const v2Json = convertFromV1({tree, meta});
     return res.json(v2Json)
   }
 }

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -104,7 +104,16 @@ const sendJson = async (res, info) => {
   }
 }
 
-const findAvailableTangleTreeOptions = (currentDatasetUrl, availableDatasetUrls) => {
+/**
+ * Return a subset of `availableDatasetUrls` which we deem to be suitable
+ * candidates to make a second tree.
+ * The current logic is to include all datasets which
+ * (a) contain the same first "part" of the URL -- interpreted here to represent the same pathogen
+ * (b) have the same number of "parts" in the URL
+ * (c) differ from the `currentDatasetUrl` by only 1 part
+ * Note: the "parts" of the URL are formed by splitting it on `"/"`
+ */
+const findAvailableSecondTreeOptions = (currentDatasetUrl, availableDatasetUrls) => {
   const currentDatasetUrlArr = currentDatasetUrl.split('/');
 
   const availableTangleTreeOptions = availableDatasetUrls.filter((datasetUrl) => {
@@ -141,5 +150,5 @@ module.exports = {
   makeFetchAddresses,
   handleError,
   sendJson,
-  findAvailableTangleTreeOptions
+  findAvailableSecondTreeOptions
 };

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -122,8 +122,6 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
        * overly complicated. Since we have 2 fetches, could we simplify things
        * and make `recomputeReduxState` for the first tree followed by another
        * state recomputation? */
-      if (!mainJson.tree_name) mainJson.tree_name = secondTree.mainTreeName; // TO DO
-      mainJson._treeTwoName = secondTree.name; // TO DO
     }
 
     const mainUrl = queryString.parse(response.url.split("?")[1]).prefix;
@@ -131,7 +129,13 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
     dispatch({
       type: types.CLEAN_START,
       pathnameShouldBe: secondTree ? mainUrl.concat(":", secondTree.url) : mainUrl,
-      ...createStateFromQueryOrJSONs({json: mainJson, query, narrativeBlocks})
+      ...createStateFromQueryOrJSONs({
+        json: mainJson,
+        query,
+        narrativeBlocks,
+        mainTreeName: secondTree ? secondTree.mainTreeName : null,
+        secondTreeName: secondTree ? secondTree.url : null
+      })
     });
 
   } catch (err) {

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -87,21 +87,13 @@ const processSecondTree = (url, query) => {
   if (url.includes(":")) {
     const parts = url.replace(/^\//, '')
       .replace(/\/$/, '')
-      .split("/");
-    for (let i=0; i<parts.length; i++) {
-      if (parts[i].indexOf(":") !== -1) {
-        const [treeName, secondTreeName] = parts[i].split(":");
-        parts[i] = treeName;
-        url = parts.join("/"); // this is the first tree URL
-        parts[i] = secondTreeName;
-        secondTree = {
-          url: parts.join("/"), // this is the 2nd tree URL
-          name: secondTreeName,
-          mainTreeName: treeName
-        };
-        break;
-      }
-    }
+      .split(":");
+    url = parts[0];
+    secondTree = {
+      url: parts[1],
+      name: parts[1],
+      mainTreeName: parts[0]
+    };
   } else if (query.tt) {
     secondTree = {url: undefined, name: query.tt, mainTreeName: undefined};
   }
@@ -134,9 +126,11 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
       mainJson._treeTwoName = secondTree.name; // TO DO
     }
 
+    const mainUrl = queryString.parse(response.url.split("?")[1]).prefix;
+
     dispatch({
       type: types.CLEAN_START,
-      pathnameShouldBe: queryString.parse(response.url.split("?")[1]).prefix,
+      pathnameShouldBe: secondTree ? mainUrl.concat(":", secondTree.url) : mainUrl,
       ...createStateFromQueryOrJSONs({json: mainJson, query, narrativeBlocks})
     });
 

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -169,10 +169,10 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
 
 };
 
-export const loadSecondTree = (name, fields) => async (dispatch, getState) => {
+export const loadSecondTree = (secondTreeUrl, firstTreeUrl) => async (dispatch, getState) => {
   let secondJson;
   try {
-    secondJson = await getDataset(fields.join("/"))
+    secondJson = await getDataset(secondTreeUrl)
       .then((res) => res.json());
   } catch (err) {
     console.error("Failed to fetch additional tree", err.message);
@@ -180,7 +180,7 @@ export const loadSecondTree = (name, fields) => async (dispatch, getState) => {
     return;
   }
   const oldState = getState();
-  const newState = createTreeTooState({treeTooJSON: secondJson.tree, oldState, segment: name});
+  const newState = createTreeTooState({treeTooJSON: secondJson.tree, oldState, originalTreeUrl: firstTreeUrl, secondTreeUrl: secondTreeUrl});
   dispatch({type: types.TREE_TOO_DATA, segment: name, ...newState});
 };
 

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -127,9 +127,10 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
   This has been deprecated so here we dispatch an error message. */
   if (query.tt) {
     dispatch(errorNotification({
-      message: `Specifing a second tree via '?tt=${query.tt}' has been deprecated.`,
-      details: "The new syntax requires the complete name for both trees.  " +
-        "Example of new syntax: 'flu/seasonal/h3n2/ha/2y:flu/seasonal/h3n2/na/2y' "
+      message: `Specifing a second tree via '?tt=${query.tt}' is no longer supported.`,
+      details: "The new syntax requires the complete name for both trees. " +
+        "For example, instead of 'flu/seasonal/h3n2/ha/2y?tt=na' you must " +
+        "specify 'flu/seasonal/h3n2/ha/2y:flu/seasonal/h3n2/na/2y' "
     }));
   }
 

--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -181,7 +181,7 @@ export const loadSecondTree = (secondTreeUrl, firstTreeUrl) => async (dispatch, 
   }
   const oldState = getState();
   const newState = createTreeTooState({treeTooJSON: secondJson.tree, oldState, originalTreeUrl: firstTreeUrl, secondTreeUrl: secondTreeUrl});
-  dispatch({type: types.TREE_TOO_DATA, segment: name, ...newState});
+  dispatch({type: types.TREE_TOO_DATA, ...newState});
 };
 
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -576,6 +576,7 @@ export const createStateFromQueryOrJSONs = ({
     /* new tree state(s) */
     tree = treeJsonToState(json.tree);
     tree.debug = "LEFT";
+    tree.name = json.tree_name;
     metadata.mainTreeNumTips = calcTotalTipsInTree(tree.nodes);
     if (json.treeTwo) {
       treeToo = treeJsonToState(json.treeTwo);

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -562,6 +562,7 @@ const createMetadataStateFromJSON = (json) => {
 
 export const createStateFromQueryOrJSONs = ({
   json = false, /* raw json data - completely nuke existing redux state */
+  secondTreeDataset = false,
   oldState = false, /* existing redux state (instead of jsons) */
   narrativeBlocks = false,
   mainTreeName = false,
@@ -580,8 +581,8 @@ export const createStateFromQueryOrJSONs = ({
     tree.debug = "LEFT";
     tree.name = mainTreeName;
     metadata.mainTreeNumTips = calcTotalTipsInTree(tree.nodes);
-    if (json.treeTwo) {
-      treeToo = treeJsonToState(json.treeTwo);
+    if (secondTreeDataset) {
+      treeToo = treeJsonToState(secondTreeDataset.tree);
       treeToo.debug = "RIGHT";
       treeToo.name = secondTreeName;
       /* TODO: calc & display num tips in 2nd tree */

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -663,27 +663,25 @@ export const createStateFromQueryOrJSONs = ({
     );
   }
 
-  if (json.tree_name) {
-    /* setting this will enable the sidebar drop down for a 2nd tree */
-    tree.name = json.tree_name;
-  }
-
   return {tree, treeToo, metadata, entropy, controls, narrative, frequencies, query};
 };
 
 export const createTreeTooState = ({
   treeTooJSON, /* raw json data */
   oldState,
-  segment /* name of the treeToo segment */
+  originalTreeUrl,
+  secondTreeUrl /* treeToo URL */
 }) => {
   /* TODO: reconsile choices (filters, colorBys etc) with this new tree */
   /* TODO: reconcile query with visibility etc */
   let controls = oldState.controls;
   const tree = Object.assign({}, oldState.tree);
+  tree.name = originalTreeUrl;
   let treeToo = treeJsonToState(treeTooJSON);
+  treeToo.name = secondTreeUrl;
   treeToo.debug = "RIGHT";
   controls = modifyControlsStateViaTree(controls, tree, treeToo, oldState.metadata.colorings);
-  controls = modifyControlsViaTreeToo(controls, segment);
+  controls = modifyControlsViaTreeToo(controls, secondTreeUrl);
   treeToo = modifyTreeStateVisAndBranchThickness(treeToo, tree.selectedStrain, undefined, controls);
 
   /* calculate colours if loading from JSONs or if the query demands change */

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -564,6 +564,8 @@ export const createStateFromQueryOrJSONs = ({
   json = false, /* raw json data - completely nuke existing redux state */
   oldState = false, /* existing redux state (instead of jsons) */
   narrativeBlocks = false,
+  mainTreeName = false,
+  secondTreeName = false,
   query
 }) => {
   let tree, treeToo, entropy, controls, metadata, narrative, frequencies;
@@ -576,12 +578,12 @@ export const createStateFromQueryOrJSONs = ({
     /* new tree state(s) */
     tree = treeJsonToState(json.tree);
     tree.debug = "LEFT";
-    tree.name = json.tree_name;
+    tree.name = mainTreeName;
     metadata.mainTreeNumTips = calcTotalTipsInTree(tree.nodes);
     if (json.treeTwo) {
       treeToo = treeJsonToState(json.treeTwo);
       treeToo.debug = "RIGHT";
-      treeToo.name = json._treeTwoName;
+      treeToo.name = secondTreeName;
       /* TODO: calc & display num tips in 2nd tree */
       // metadata.secondTreeNumTips = calcTotalTipsInTree(treeToo.nodes);
     }

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -50,12 +50,8 @@ class ChooseDataset extends React.Component {
     const displayedDataset = window.location.pathname
       .replace(/^\//, '')
       .replace(/\/$/, '')
+      .split(":")[0]
       .split("/");
-    displayedDataset.forEach((part, idx) => {
-      if (part.includes(":")) {
-        displayedDataset[idx] = part.split(":")[0];
-      }
-    });
 
     const options = [[]];
 

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -16,37 +16,30 @@ import { SidebarSubtitle } from "./styles";
 })
 class ChooseSecondTree extends React.Component {
   render() {
-    if (!this.props.available || !this.props.available.datasets || !this.props.treeName) {
+    if (!this.props.available || !this.props.available.datasets) {
       return null;
     }
     const displayedDataset = window.location.pathname
       .replace(/^\//, '')
       .replace(/\/$/, '')
       .split("/");
+
     displayedDataset.forEach((part, idx) => {
       if (part.includes(":")) {
         displayedDataset[idx] = part.split(":")[0];
       }
     });
-    const idxOfTree = displayedDataset.indexOf(this.props.treeName);
 
-    const matches = this.props.available.datasets
-      .map((datasetObj) => datasetObj.request.split("/"))
-      .filter((dataset) => {
-        if (dataset.length !== displayedDataset.length) return false;
-        for (let i=0; i<dataset.length; i++) {
-          if (i===idxOfTree) {
-            if (dataset[i] === displayedDataset[i]) {
-              return false; // don't match the same tree name
-            }
-          } else if (dataset[i] !== displayedDataset[i]) {
-            return false; // everything apart from the tree much match
-          }
-        }
-        return true;
-      });
+    const displayedUrl = displayedDataset.join('/');
+    let options = [];
+    this.props.available.datasets
+    .filter((dataset) => {
+      if (dataset.request === displayedUrl) {
+        options = dataset.tangleTreeOptions;
+      }
+      return null;
+    });
 
-    const options = matches.map((m) => m[idxOfTree]);
     if (this.props.showTreeToo) options.unshift("REMOVE");
 
     return (

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -35,7 +35,7 @@ class ChooseSecondTree extends React.Component {
     this.props.available.datasets
     .filter((dataset) => {
       if (dataset.request === displayedUrl) {
-        options = dataset.tangleTreeOptions;
+        options = [...dataset.tangleTreeOptions];
       }
       return null;
     });
@@ -60,9 +60,7 @@ class ChooseSecondTree extends React.Component {
               if (opt.value === "REMOVE") {
                 this.props.dispatch({type: REMOVE_TREE_TOO});
               } else {
-                const dataPath = [...displayedDataset];
-                dataPath.splice(idxOfTree, 1, opt.value);
-                this.props.dispatch(loadSecondTree(opt.value, dataPath));
+                this.props.dispatch(loadSecondTree(opt.value, displayedUrl));
               }
             }}
           />

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -22,19 +22,12 @@ class ChooseSecondTree extends React.Component {
     const displayedDataset = window.location.pathname
       .replace(/^\//, '')
       .replace(/\/$/, '')
-      .split("/");
+      .split(':')[0];
 
-    displayedDataset.forEach((part, idx) => {
-      if (part.includes(":")) {
-        displayedDataset[idx] = part.split(":")[0];
-      }
-    });
-
-    const displayedUrl = displayedDataset.join('/');
     let options = [];
     this.props.available.datasets
     .filter((dataset) => {
-      if (dataset.request === displayedUrl) {
+      if (dataset.request === displayedDataset) {
         options = [...dataset.tangleTreeOptions];
       }
       return null;
@@ -60,7 +53,7 @@ class ChooseSecondTree extends React.Component {
               if (opt.value === "REMOVE") {
                 this.props.dispatch({type: REMOVE_TREE_TOO});
               } else {
-                this.props.dispatch(loadSecondTree(opt.value, displayedUrl));
+                this.props.dispatch(loadSecondTree(opt.value, displayedDataset));
               }
             }}
           />

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -28,7 +28,7 @@ class ChooseSecondTree extends React.Component {
     this.props.available.datasets
     .filter((dataset) => {
       if (dataset.request === displayedDataset) {
-        options = [...dataset.tangleTreeOptions];
+        options = [...dataset.secondTreeOptions];
       }
       return null;
     });

--- a/src/components/tree/tangle/index.js
+++ b/src/components/tree/tangle/index.js
@@ -84,10 +84,10 @@ class Tangle extends React.Component {
     const lefts = [this.props.width/2 - this.props.spaceBetweenTrees/2, this.props.width/2 + this.props.spaceBetweenTrees/2];
     return (
       <div id="TangleContainer">
-        <div id="MainTreeTitle" style={{...textStyles, left: lefts[0]-100, width: 100, textAlign: "right"}}>
+        <div id="MainTreeTitle" style={{...textStyles, left: lefts[0], transform: "translateX(-100%)"}}>
           {this.props.leftTreeName}
         </div>
-        <div id="SecondTreeTitle" style={{...textStyles, left: lefts[1], textAlign: "left"}}>
+        <div id="SecondTreeTitle" style={{...textStyles, left: lefts[1]}}>
           {this.props.rightTreeName}
         </div>
         <div

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -155,8 +155,8 @@ class Tree extends React.Component {
             vVersion={this.props.tree.visibilityVersion}
             metric={this.props.distanceMeasure}
             spaceBetweenTrees={spaceBetweenTrees}
-            leftTreeName={this.props.tree.name.toUpperCase()}
-            rightTreeName={this.props.showTreeToo.toUpperCase()}
+            leftTreeName={this.props.tree.name}
+            rightTreeName={this.props.showTreeToo}
           />
         ) : null }
         {this.renderTreeDiv({width: widthPerTree, height: this.props.height, mainTree: true})}

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -133,7 +133,7 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       if (action.tree.name && action.treeToo && action.treeToo.name) {
         const treeUrlShouldBe = `${action.tree.name}:${action.treeToo.name}`;
         if (!window.location.pathname.includes(treeUrlShouldBe)) {
-          pathname = window.location.pathname.replace(action.tree.name, treeUrlShouldBe);
+          pathname = treeUrlShouldBe;
         }
       }
       break;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -158,23 +158,14 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
         pathname = action.displayComponent;
       }
       break;
-    case types.REMOVE_TREE_TOO: // fallthrough
+    case types.REMOVE_TREE_TOO: {
+      pathname = pathname.split(":")[0];
+      break;
+    }
     case types.TREE_TOO_DATA: {
-      const fields = pathname.split("/");
-      let treeIdx;
-      fields.forEach((f, i) => {
-        if (f === state.tree.name || f.startsWith(state.tree.name+":")) {
-          treeIdx = i;
-        }
-      });
-      if (!treeIdx) {
-        console.warn("Couldn't work out tree name in URL!");
-        break;
-      }
-      fields[treeIdx] = action.type === types.TREE_TOO_DATA ?
-        `${fields[treeIdx].split(":")[0]}:${action.segment}` :
-        fields[treeIdx].split(":")[0];
-      pathname = fields.join("/");
+      const treeUrl = action.tree.name;
+      const secondTreeUrl = action.treeToo.name;
+      pathname = treeUrl.concat(":", secondTreeUrl);
       break;
     }
     default:


### PR DESCRIPTION
This PR addresses issue #776, can be tested with nextstrain.org [branch](https://github.com/nextstrain/nextstrain.org/tree/tangle-tree-options).

In the `getAvailable` request, for each dataset, a list of possible second trees is provided. This list is rendered in the second tree dropdown. 

To allow for rendering of second trees that differ on parameters other than segment, this PR also changes the format of the url:

- Previously: `http://localhost:4000/flu/seasonal/h3n2/ha:na/3y`

- Now: `http://localhost:4000/flu/seasonal/h3n2/ha/3y:flu/seasonal/h3n2/na/3y`)