### PR TITLE
Fix Undefined Value Colouring Bug

### DIFF
--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -76,6 +76,7 @@ const getVisibleNodesPerLocation = (nodes, visibility, geoResolution) => {
  */
 const createOrUpdateArcs = (allValues, visibleNodes, legendValues, colorBy, nodeColors, currentArcs=undefined) => {
   const colorByIsGenotype = isColorByGenotype(colorBy);
+  const useValues = colorByIsGenotype ? legendValues: allValues;
   const legendValueToArcIdx = {};
   // Don't rely on legendValues as these don't include 'unknown'/'undefined' values!
   // Instead, pull directily from tree, so have all info - passed in as 'allValues'
@@ -83,13 +84,13 @@ const createOrUpdateArcs = (allValues, visibleNodes, legendValues, colorBy, node
   if (currentArcs) {
     /* updating arcs -- reset `_count` */
     arcs = currentArcs;
-    allValues.forEach((v, i) => {
+    useValues.forEach((v, i) => {
       legendValueToArcIdx[v] = i;
       arcs[i]._count = 0;
     });
   } else {
     /* creating arcs */
-    arcs = allValues.map((v, i) => {
+    arcs = useValues.map((v, i) => {
       legendValueToArcIdx[v] = i;
       return {innerRadius: 0, _count: 0};
     });

--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -78,6 +78,7 @@ const createOrUpdateArcs = (allValues, visibleNodes, legendValues, colorBy, node
   const colorByIsGenotype = isColorByGenotype(colorBy);
   const useValues = colorByIsGenotype ? legendValues: allValues;
   const legendValueToArcIdx = {};
+
   // Don't rely on legendValues as these don't include 'unknown'/'undefined' values!
   // Instead, pull directily from tree, so have all info - passed in as 'allValues'
   let arcs;
@@ -130,6 +131,10 @@ const setupDemeData = (nodes, visibility, geoResolution, nodeColors, triplicate,
   const demeToLatLongs = metadata.geoResolutions.filter((x) => x.key === geoResolution)[0].demes;
   // get all possible values from tree rather than relying on legend (doesn't include 'undefined', or "", etc)
   const allValues = Object.keys(countTraitsAcrossTree(nodes, [colorBy], false, false)[colorBy]);
+  // Sort values by legend order, add empty values to end (prettier)
+  allValues.sort((a, b) => {return legendValues.indexOf(a) - legendValues.indexOf(b);});
+  const emptyVal = allValues.indexOf("") !== -1 ? allValues.indexOf("") : allValues.indexOf("undefined");
+  if (emptyVal !== -1) { allValues.push(allValues.splice(emptyVal, 1)[0]); }
 
   let index = 0;
   offsets.forEach((OFFSET) => {
@@ -460,6 +465,10 @@ const updateDemeDataColAndVis = (demeData, demeIndices, nodes, visibility, geoRe
   const demeDataCopy = demeData.slice();
   // get all possible values from tree rather than relying on legend (doesn't include 'undefined', or "", etc)
   const allValues = Object.keys(countTraitsAcrossTree(nodes, [colorBy], false, false)[colorBy]);
+  // Sort values by legend order, add empty values to end (prettier)
+  allValues.sort((a, b) => {return legendValues.indexOf(a) - legendValues.indexOf(b);});
+  const emptyVal = allValues.indexOf("") !== -1 ? allValues.indexOf("") : allValues.indexOf("undefined");
+  if (emptyVal !== -1) { allValues.push(allValues.splice(emptyVal, 1)[0]); }
 
   const locationToVisibleNodes = getVisibleNodesPerLocation(nodes, visibility, geoResolution);
 

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -14,7 +14,7 @@ const unknownColor = "#AAAAAA";
 const getMinMaxFromTree = (nodes, nodesToo, attr) => {
   const arr = nodesToo ? nodes.concat(nodesToo) : nodes.slice();
   const vals = arr.map((n) => getTraitFromNode(n, attr))
-    .filter((n) => n !== undefined && n !== "") // if coerce "" to numeric, becomes 0!
+    .filter((n) => n !== undefined && n !== "undefined" && n !== "") // if coerce "" to numeric, becomes 0!
     .filter((item, i, ar) => ar.indexOf(item) === i)
     .map((v) => +v); // coerce to numeric
   return [min(vals), max(vals)];
@@ -208,7 +208,7 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
           domain = genericDomain.map((d) => minMax[0] + d * (minMax[1] - minMax[0]));
       }
       const scale = scaleLinear().domain(domain).range(range);
-      colorScale = (val) => (val === undefined || val === false || val === "") ? unknownColor : scale(val);
+      colorScale = (val) => (val === "undefined" || val === undefined || val === false || val === "") ? unknownColor : scale(val);
 
       /* construct the legend values & their respective bounds */
       switch (colorBy) {


### PR DESCRIPTION
Should resolve bug #785 , where a) branches without a value get a colour and b) undefined values show up in the legend.

You can see the before examples on [Heroku](https://nextstrain-dev.herokuapp.com/enterovirus/d68/vp1).
I've tested this with a bunch of EV-D68 stuff but it would benefit from someone having a good play with it on something else, esp ensuring filters etc work.

Compare before and after (before always above, after always below):

For categorical without specified colours:
![image](https://user-images.githubusercontent.com/14290674/65235551-1ebc6e00-dad7-11e9-845e-0fa56f44f425.png)
![image](https://user-images.githubusercontent.com/14290674/65235560-267c1280-dad7-11e9-8ea9-4e5f2b065ffc.png)

![image](https://user-images.githubusercontent.com/14290674/65235714-765ad980-dad7-11e9-8ced-e509258ebc50.png)
![image](https://user-images.githubusercontent.com/14290674/65235740-807cd800-dad7-11e9-8957-e2bc0bc270e5.png)


For continuous:
![image](https://user-images.githubusercontent.com/14290674/65235654-562b1a80-dad7-11e9-8bed-dc7d7d95ff0c.png)
![image](https://user-images.githubusercontent.com/14290674/65235664-5d522880-dad7-11e9-90be-819d7e825cbf.png)

For categorical with specified colors:
![image](https://user-images.githubusercontent.com/14290674/65235777-95f20200-dad7-11e9-9897-2c2db859993f.png)
![image](https://user-images.githubusercontent.com/14290674/65235796-9b4f4c80-dad7-11e9-80ee-0f683d1ed6c8.png)
(Tree looks the same)

For clades ('Unassigned' wasn't being detected properly):
![image](https://user-images.githubusercontent.com/14290674/65235876-bc17a200-dad7-11e9-85bd-629145f19e7d.png)
![image](https://user-images.githubusercontent.com/14290674/65235894-c639a080-dad7-11e9-84c8-6d101469b966.png)

------

As a bonus, managed to get of annoying pie chart lines when filtering so demes go to one colour only:

Before
![image](https://user-images.githubusercontent.com/14290674/65236103-2af4fb00-dad8-11e9-9288-de5463f1a25a.png)

After
![image](https://user-images.githubusercontent.com/14290674/65236126-35af9000-dad8-11e9-999c-bc405335cfd6.png)

