### PR TITLE
Prettify and Sort Filters

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -416,9 +416,10 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
   /* are filters valid? */
   const activeFilters = Object.keys(state.filters).filter((f) => f.length);
   const stateCounts = countTraitsAcrossTree(tree.nodes, activeFilters, false, true);
+  // Also allow filter "unk" for unknown values!
   for (const filterType of activeFilters) {
     const validValues = state.filters[filterType]
-      .filter((filterValue) => filterValue in stateCounts[filterType]);
+      .filter((filterValue) => filterValue in stateCounts[filterType] || filterValue === "unk");
     state.filters[filterType] = validValues;
     if (!validValues.length) {
       delete query[`f_${filterType}`];

--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -241,17 +241,20 @@ export const updateTipRadii = (
  * @param {Array of strings} values the values (see above)
  */
 export const applyFilter = (mode, trait, values) => {
+  // If filtering by unknown values "", replace with "unk" for filter/url
+  // This makes it prettier and easier to handle (url can't have "")
+  const correctValues = values.map((x) => x === "" ? "unk" : x );
   return (dispatch, getState) => {
     const { controls } = getState();
     const currentlyFilteredTraits = Object.keys(controls.filters);
     let newValues;
     if (mode === "set") {
-      newValues = values;
+      newValues = correctValues;
     } else if (mode === "add") {
       if (currentlyFilteredTraits.indexOf(trait) === -1) {
-        newValues = values;
+        newValues = correctValues;
       } else {
-        newValues = controls.filters[trait].concat(values);
+        newValues = controls.filters[trait].concat(correctValues);
       }
     } else if (mode === "remove") {
       if (currentlyFilteredTraits.indexOf(trait) === -1) {
@@ -259,7 +262,7 @@ export const applyFilter = (mode, trait, values) => {
         return;
       }
       newValues = controls.filters[trait].slice();
-      for (const item of values) {
+      for (const item of correctValues) {
         const idx = newValues.indexOf(item);
         if (idx !== -1) {
           newValues.splice(idx, 1);

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -173,11 +173,14 @@ class Info extends React.Component {
     );
   }
   addNonAuthorFilterButton(buttons, filterName) {
+    // Get filterTitle so we can show what unknown is being filtered by
+    // We'll display particular things if unknown. And need to get counts for "" trait, not "unk"!
+    const filterTitle = this.props.metadata.colorings[filterName] ? this.props.metadata.colorings[filterName].title : filterName;
     this.props.filters[filterName].sort().forEach((itemName) => {
       const display = (
         <span>
-          {itemName}
-          {" (" + this.props.totalStateCounts[filterName][itemName] + ")"}
+          {itemName !== "unk" ? itemName : "Unknown " + filterTitle}
+          {" (" + this.props.totalStateCounts[filterName][itemName !== "unk" ? itemName : ""] + ")"}
         </span>
       );
       buttons.push(displayFilterValueAsButton(this.props.dispatch, this.props.filters, filterName, itemName, display, true));

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -179,7 +179,7 @@ class Info extends React.Component {
     this.props.filters[filterName].sort().forEach((itemName) => {
       const display = (
         <span>
-          {itemName !== "unk" ? itemName : "Unknown " + filterTitle}
+          {itemName !== "unk" && itemName !== "undefined" ? itemName : "Unknown " + filterTitle}
           {" (" + this.props.totalStateCounts[filterName][itemName !== "unk" ? itemName : ""] + ")"}
         </span>
       );

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -135,7 +135,9 @@ const calcVisibility = (tree, controls, dates) => {
     const filters = [];
     Object.keys(controls.filters).forEach((trait) => {
       if (controls.filters[trait].length) {
-        filters.push({trait, values: controls.filters[trait]});
+        // If filtering by unknown trait, check "" against node values, not "unk"!
+        const rawTraits = controls.filters[trait].map(function(x) {return x === "unk" ? "" : x; });
+        filters.push({trait, values: rawTraits});
       }
     });
     if (filters.length) {


### PR DESCRIPTION
Should address issue #787 and also fixes sorting of filters to match legend (only applies if colour values have been supplied, thus legend is in that order).

I addressed this by *allowing* filtering by unknown values - I thought, maybe that's actually useful if you'd like to filter by those you don't have a value for and colour by another value. 

But, this required making the whole thing more official....

**This is tested with `v1` and `v2` export JSONS for values where in the metadata file they were recoreded as `""` (blank) or `NA`. Other values (`null`, `undefined`, etc) in metadata - especially in `v1` untested!**
More testing & thoughts would be GOOD

First, addresses original two issues: Unknown values are now 'official' and sit at back of list, and other values which are sorted in the legend (because of provided colours) are sorted in same order:
For legend:
![image](https://user-images.githubusercontent.com/14290674/65256165-6525c300-daff-11e9-9701-2b0ee877e5dc.png)
(note the grey box is fixed in my other PR today)

Old way:
![image](https://user-images.githubusercontent.com/14290674/65256198-71aa1b80-daff-11e9-9653-7a7dbcc88c4a.png)
New way:
![image](https://user-images.githubusercontent.com/14290674/65256278-90101700-daff-11e9-86a2-38aba740f4f5.png)

If colours/order are assigned but there are values that don't have a colour, they're added to the end:
Kenya just came in, I haven't yet added it to colors.txt:
![image](https://user-images.githubusercontent.com/14290674/65256505-ec733680-daff-11e9-8618-1fe390a4aee5.png)
So it also sits at the end in filter:
![image](https://user-images.githubusercontent.com/14290674/65256547-fd23ac80-daff-11e9-8df4-d9c10a0d7325.png)

**The below applies to `v1` JSONS**
I needed a way to process this through the URL - this is tricky because the value for these nodes is "", and this doesn't work in the URL processing (URL filters with values of "" are seen as empty and thus deleted). I also needed a better way to store the active filter keys - if you store them as "" or "unk" then you get a same-key warning.

So this is handled a little complexly - I refer you to the code for details. In short, values on the tree/nodes remain "". Value in the filters and URL is "unk" (`trait` (ex country) is also stored/specified in these places, so this is unambiguous). When comparing to the tree, values of "unk" are converted to "". In the `key` of active filters, which are *not* unambiguous across `trait`s, they are stored as "unk_[trait]" (ex: "unk_country", "unk_samptype"). 

I added some prettifying so that the summary at the top looks nice. Some screenshots:

![image](https://user-images.githubusercontent.com/14290674/65256999-c8fcbb80-db00-11e9-8412-69b259a00295.png)

![image](https://user-images.githubusercontent.com/14290674/65257021-d2862380-db00-11e9-8da8-c007e76af4be.png)

-------

![image](https://user-images.githubusercontent.com/14290674/65257078-eb8ed480-db00-11e9-8c13-1ebe7795e270.png)

![image](https://user-images.githubusercontent.com/14290674/65257106-fb0e1d80-db00-11e9-9901-4a753a3fb6dc.png)

