### PR TITLE
Sort Filters and Prettify Some Filter Buttons

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -324,12 +324,21 @@ class Footer extends React.Component {
   displayFilter(styles, filterName) {
     const totalStateCount = this.props.totalStateCounts[filterName];
     const filterTitle = this.props.metadata.colorings[filterName] ? this.props.metadata.colorings[filterName].title : filterName;
+    let stateKeysOrdered;
+    // If has ordered colorings, use this to sort
+    if (this.props.metadata.colorings[filterName] && this.props.metadata.colorings[filterName].scale) {
+      const colorValues = this.props.metadata.colorings[filterName].scale.map(function(x) { return x[0];});
+      // Add any extra values without a set color to the end
+      stateKeysOrdered = _.union(colorValues, Array.from(totalStateCount.keys()));
+    } else { // Otherwise, sort by value
+      stateKeysOrdered = Array.from(totalStateCount.keys()).sort();
+    }
     return (
       <div>
         {`Filter by ${filterTitle}`}
-        {this.props.activeFilters[filterName].length ? removeFiltersButton(this.props.dispatch, [filterName], "inlineRight", `Clear ${filterName} filter`) : null}
+        {this.props.activeFilters[filterName].length ? removeFiltersButton(this.props.dispatch, [filterName], "inlineRight", `Clear ${filterTitle} filter`) : null}
         <Flex wrap="wrap" justifyContent="flex-start" alignItems="center" style={styles.citationList}>
-          {Array.from(totalStateCount.keys()).sort().map((itemName) => {
+          {stateKeysOrdered.map((itemName) => {
             const display = (
               <span>
                 {itemName}

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -173,10 +173,12 @@ class Info extends React.Component {
     );
   }
   addNonAuthorFilterButton(buttons, filterName) {
+    // Get filterTitle so we can show which unknown is being filtered by
+    const filterTitle = this.props.metadata.colorings[filterName] ? this.props.metadata.colorings[filterName].title : filterName;
     this.props.filters[filterName].sort().forEach((itemName) => {
       const display = (
         <span>
-          {itemName}
+          {itemName !== "undefined" ? itemName : "Unknown "+filterTitle}
           {` (${this.props.totalStateCounts[filterName].get(itemName)})`}
         </span>
       );


### PR DESCRIPTION
This takes just the parts of PR #794 which were not fixed via other changes.

First, prettifies the 'clear filter' button by using `filterTitle` instead of `filterName`.
Before:
![image](https://user-images.githubusercontent.com/14290674/65778142-aba1a000-e145-11e9-9e9f-70b3b8a6b9ca.png)

After:
![image](https://user-images.githubusercontent.com/14290674/65778156-b2c8ae00-e145-11e9-8e84-933d04884169.png)

Second, sorts filters by the order specified in a `color.txt` file (order of the legend), if that trait has such an ordering.
Before:
![image](https://user-images.githubusercontent.com/14290674/65778241-dd1a6b80-e145-11e9-9bc2-2c3856660519.png)

After:
![image](https://user-images.githubusercontent.com/14290674/65778265-e9062d80-e145-11e9-89a5-ffcffbea52e3.png)

Finally, prettifies the filter buttons at the top when filtering by 'undefined' values, to show *which* undefined values are being filtered to.
Before:
![image](https://user-images.githubusercontent.com/14290674/65778383-1c48bc80-e146-11e9-81cb-5553de32be2e.png)

After:
![image](https://user-images.githubusercontent.com/14290674/65778407-24086100-e146-11e9-9f97-2dea1382403a.png)

We could change this to 'Undefined' if we wanted to strictly match what shows up in the filter lists down at the bottom.