### PR TITLE
Gap, X, N Bases Are Always Grey & Last in Legend

### DIFF
--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -123,13 +123,17 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     legendValues = orderOfGenotypeAppearance(tree.nodes, controls.mutType);
     const trueValues = controls.mutType === "nuc" ? legendValues.filter((x) => x !== "X" && x !== "-" && x !== "N") :
       legendValues.filter((x) => x !== "X" && x !== "-");
-    const unkValues = controls.mutType === "nuc" ? legendValues.filter((x) => x === "X" || x === "-" || x === "N") :
-      legendValues.filter((x) => x === "X" || x === "-");
-    let domain = [undefined, ...trueValues];
-    let range = [unknownColor, ...genotypeColors.slice(0, trueValues.length)];
-    if (unkValues.length) { // we must add these to the domain + provide a value in the range
-      domain = domain.concat(unkValues);
-      range = range.concat(createListOfColors(unkValues.length, [rgb(192, 192, 192), rgb(32, 32, 32)]));
+    const domain = [undefined, ...legendValues];
+    const range = [unknownColor, ...genotypeColors.slice(0, trueValues.length)];
+    // Bases are returned by orderOfGenotypeAppearance in order, unknowns at end
+    if (legendValues.indexOf("-") !== -1) {
+      range.push(rgb(217, 217, 217));
+    }
+    if (legendValues.indexOf("N") !== -1 && controls.mutType === "nuc") {
+      range.push(rgb(153, 153, 153));
+    }
+    if (legendValues.indexOf("X") !== -1) {
+      range.push(rgb(102, 102, 102));
     }
     colorScale = scaleOrdinal()
           .domain(domain)

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -120,10 +120,20 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     console.error("calcColorScale called before tree is ready.");
     error = true;
   } else if (genotype) { /* G E N O T Y P E */
-    legendValues = orderOfGenotypeAppearance(tree.nodes);
+    legendValues = orderOfGenotypeAppearance(tree.nodes, controls.mutType);
+    const trueValues = controls.mutType === "nuc" ? legendValues.filter((x) => x !== "X" && x !== "-" && x !== "N") :
+      legendValues.filter((x) => x !== "X" && x !== "-");
+    const unkValues = controls.mutType === "nuc" ? legendValues.filter((x) => x === "X" || x === "-" || x === "N") :
+      legendValues.filter((x) => x === "X" || x === "-");
+    let domain = [undefined, ...trueValues];
+    let range = [unknownColor, ...genotypeColors.slice(0, trueValues.length)];
+    if (unkValues.length) { // we must add these to the domain + provide a value in the range
+      domain = domain.concat(unkValues);
+      range = range.concat(createListOfColors(unkValues.length, [rgb(192, 192, 192), rgb(32, 32, 32)]));
+    }
     colorScale = scaleOrdinal()
-      .domain([undefined, ...legendValues])
-      .range([unknownColor, ...genotypeColors]);
+          .domain(domain)
+          .range(range);
   } else if (colorings && colorings[colorBy]) {
     let minMax;
     /* Is the scale set in the provided colorings object? */

--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -49,7 +49,7 @@ export const setGenotype = (nodes, prot, positions) => {
   // console.log(`set ${ancNodes.length} nodes to the ancestral state: ${ancState}`)
 };
 
-export const orderOfGenotypeAppearance = (nodes) => {
+export const orderOfGenotypeAppearance = (nodes, mutType) => {
   const seen = {};
   nodes.forEach((n) => {
     let numDate = getTraitFromNode(n, "num_date");
@@ -60,5 +60,22 @@ export const orderOfGenotypeAppearance = (nodes) => {
   });
   const ordered = Object.keys(seen);
   ordered.sort((a, b) => seen[a] < seen[b] ? -1 : 1);
-  return ordered;
+  let orderedBases;
+  // remove 'non-bases' (X - N)
+  if (mutType === "nuc") {
+    orderedBases = ordered.filter((x) => x !== "X" && x !== "-" && x !== "N");
+  } else {
+    orderedBases = ordered.filter((x) => x !== "X" && x !== "-");
+  }
+  // Add back on non-bases in a specific order
+  if (ordered.indexOf("-") !== -1) {
+    orderedBases.push("-");
+  }
+  if (ordered.indexOf("N") !== -1 && mutType === "nuc") {
+    orderedBases.push("N");
+  }
+  if (ordered.indexOf("X") !== -1) {
+    orderedBases.push("X");
+  }
+  return orderedBases;
 };


### PR DESCRIPTION
This is partial implemention of PR #739 . Deciding exactly what colours to use for which nucleotides/AA will require more discussion, and should be tackled after releasing `v2`. 

However, it seems that the idea of colouring gaps, X, and N (in nucleotides) grey is widely accepted.

This PR implements just this change. Gaps (-), X, and N characters will always appear at the end of the legend, and be coloured in shades of grey. This can make it much easier to see how much data is missing. 

I work with a few datasets where this is a big issue, so this colouring/ordering would be very helpful for me.

This changes from [this](https://nextstrain.org/community/emmahodcroft/echo30/vp1/all-clin?c=gt-VP1_285):
![image](https://user-images.githubusercontent.com/14290674/65837220-147b4a80-e2f5-11e9-81bb-79f016bb70bf.png)

To this:
![image](https://user-images.githubusercontent.com/14290674/65837228-24932a00-e2f5-11e9-8c86-838865ce71f4.png)

Or [this](https://nextstrain.org/enterovirus/d68/genome?c=gt-nuc_7324):
![image](https://user-images.githubusercontent.com/14290674/65837280-b1d67e80-e2f5-11e9-929d-6f7ba4b46a6f.png)

To this:
![image](https://user-images.githubusercontent.com/14290674/65837287-c0bd3100-e2f5-11e9-81a8-ee40f33439a8.png)


Grey colours may go too dark too quickly - I used existing code for missing discrete values, but the range could be easily adjusted.