### PR TITLE
Geo zoom

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -75,6 +75,7 @@ class Map extends React.Component {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md#es6-classes
     this.playPauseButtonClicked = this.playPauseButtonClicked.bind(this);
     this.resetButtonClicked = this.resetButtonClicked.bind(this);
+    this.resetZoomButtonClicked = this.resetZoomButtonClicked.bind(this);
   }
 
   componentWillMount() {
@@ -505,12 +506,40 @@ class Map extends React.Component {
     return (<div/>);
   }
 
+  resetZoomButton() {
+    if (this.props.narrativeMode) return null;
+    const buttonBaseStyle = {
+      color: "#FFFFFF",
+      fontWeight: 400,
+      fontSize: 12,
+      borderRadius: 3,
+      padding: 12,
+      border: "none",
+      zIndex: 900,
+      position: "absolute",
+      textTransform: "uppercase"
+    };
+
+    return (
+      <div>
+        <button
+          style={{...buttonBaseStyle, bottom: 27, right: 50, width: 60, backgroundColor: goColor}}
+          onClick={this.resetZoomButtonClicked}
+        >
+          Reset Zoom
+        </button>
+      </div>
+    );
+
+  }
+
   maybeCreateMapDiv() {
     let container = null;
     if (this.state.responsive) {
       container = (
         <div style={{position: "relative"}}>
           {this.animationButtons()}
+          {this.resetZoomButton()}
           <div id="map"
             style={{
               height: this.state.responsive.height,
@@ -532,6 +561,12 @@ class Map extends React.Component {
   resetButtonClicked() {
     this.props.dispatch({type: MAP_ANIMATION_PLAY_PAUSE_BUTTON, data: "Play"});
     this.props.dispatch(changeDateFilter({newMin: this.props.absoluteDateMin, newMax: this.props.absoluteDateMax, quickdraw: false}));
+  }
+  resetZoomButtonClicked() {
+    const SWNE = this.getGeoRange();
+    // L. available because leaflet() was called in componentWillMount
+    this.state.map.fitBounds(L.latLngBounds(SWNE[0], SWNE[1]));
+    this.maybeDrawDemesAndTransmissions();
   }
   render() {
     const transmissionsExist = this.state.transmissionData && this.state.transmissionData.length;

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -300,11 +300,13 @@ class Map extends React.Component {
     const longitudes = [];
 
     this.props.metadata.geoResolutions.forEach((geoData) => {
-      const demeToLatLongs = geoData.demes;
-      Object.keys(demeToLatLongs).forEach((deme) => {
-        latitudes.push(demeToLatLongs[deme].latitude);
-        longitudes.push(demeToLatLongs[deme].longitude);
-      });
+      if (geoData.key === this.props.geoResolution) {
+        const demeToLatLongs = geoData.demes;
+        Object.keys(demeToLatLongs).forEach((deme) => {
+          latitudes.push(demeToLatLongs[deme].latitude);
+          longitudes.push(demeToLatLongs[deme].longitude);
+        });
+      }
     });
 
     const maxLat = _max(latitudes);


### PR DESCRIPTION
I am excited to propose this new functionality!! 😄 

Currently the zoom that's chosen for the map when you load up a dataset is the zoom level that will encompass (as much as possible) ALL the `geo_resolution` information you've passed in. At every level. 

So, if you have country-level `geo` info, even if you're loading up with the default `geo` set to something much smaller (a set of cities in one country), or specifying `geo` as such in the URL, you'll still have a zoom level that matches ALL available country info.

So below, I have world-wide country info, but even when I specify that I want `geo` to be for Quarters (city-areas) in Basel, my zoom is like this:
![image](https://user-images.githubusercontent.com/14290674/66034910-6e089280-e50a-11e9-8219-824890ad5709.png)

(This is the default loading, with `geo` to country - so you can see why the map zooms to here:
![image](https://user-images.githubusercontent.com/14290674/66034987-94c6c900-e50a-11e9-9b61-5ade3cde774c.png)
)

Then, you have to click like a zillion times to get close into Basel to actually see what you want. And, if you want to send someone this view, or set it as default view, they will also have to click a zillion times.

I found that we can make this work quite beautifully with a simple change so that on loading, you only take into account the lat-long values for the *currently set `geo` level*.

Now it loads like this! (I've also set color-by to `Quarter` so it looks prettier...):
![image](https://user-images.githubusercontent.com/14290674/66035232-09016c80-e50b-11e9-9f42-7ccee35a73c4.png)

The default load still looks the same - since default `geo` is country here, without any URL specifications, it'll load up zoomed out to country, as above. 

-----

But of course this introduces perhaps a problem - if you load up zoomed into `geo`=Quarter and then switch to `geo`=country, you can't see anything, and now you have to click a zillion times to zoom out (or reload the page):
![image](https://user-images.githubusercontent.com/14290674/66035411-5e3d7e00-e50b-11e9-99e5-85ea0a2900fb.png)

To counter this I introduced that little button on the bottom left... `Reset Zoom` (maybe should be instead `Auto Zoom`?).

Click this and it will re-zoom the map to whatever you currently have selected for `geo`. Here's a nice gif!
![resetZoom](https://user-images.githubusercontent.com/14290674/66035783-10754580-e50c-11e9-8a6c-9271450acfb2.gif)

----

So here's the motivation behind this... zooming in Narratives! It's not perfect, because you've got to trigger a map redraw to zoom (if buttons are disabled, which they are in narrative view). There's probably a nice solution to this, but in the meantime, removing and adding the map is a demo-worthy work-around.

Here I start with `geo`=country. I get rid of the map to force re-zoom, then bring it back with `geo`=quarter` and then `geo`=block:
(I recorded just half of the narrative screen, not showing the narrative text on the left.)
![resetZoom-narrative](https://user-images.githubusercontent.com/14290674/66036572-db69f280-e50d-11e9-8a97-7bd53be0234a.gif)

----

The people for whom we are working on this would like to share a narrative like this with collaborators etc, so it would be great if we can see (if all agree) if this could be implemented :)


