### PR TITLE
Remove twitter

### DIFF
--- a/src/components/framework/monitor.js
+++ b/src/components/framework/monitor.js
@@ -17,12 +17,6 @@ class Monitor extends React.Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired
   }
-  componentWillMount() {
-    const script = document.createElement("script");
-    script.src = "https://platform.twitter.com/widgets.js";
-    script.async = true;
-    document.body.appendChild(script);
-  }
   componentDidMount() {
     /* don't need initial dimensions - they're in the redux store on load */
     window.addEventListener( // future resizes

--- a/src/css/static.css
+++ b/src/css/static.css
@@ -159,40 +159,6 @@ strong {
   font-weight: 300;
 }
 
-blockquote.twitter-tweet {
-  display: inline-block;
-  font-family: "Helvetica Neue", Roboto, "Segoe UI", Calibri, sans-serif;
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 16px;
-  border-color: #eee #ddd #bbb;
-  border-radius: 5px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-  margin: 10px 5px;
-  padding: 0 16px 16px 16px;
-  max-width: 468px;
-}
-
-blockquote.twitter-tweet p {
-  font-size: 16px;
-  font-weight: normal;
-  line-height: 20px;
-}
-
-blockquote.twitter-tweet a {
-  color: inherit;
-  font-weight: normal;
-  text-decoration: none;
-  outline: 0 none;
-}
-
-blockquote.twitter-tweet a:hover,
-blockquote.twitter-tweet a:focus {
-  text-decoration: underline;
-}
-
 /* https://stackoverflow.com/questions/16771225/css3-rotate-animation */
 .spinner {
     position: relative;

--- a/src/css/static.css
+++ b/src/css/static.css
@@ -193,25 +193,6 @@ blockquote.twitter-tweet a:focus {
   text-decoration: underline;
 }
 
-/*@media (max-width: 1100px) {
-  .static .aside {
-    font-size: 0
-  }
-}*/
-
-@media (min-width: 550px) { /* apply these styles down to/until we're at 700px */
-  .twitterRow {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-    flex-wrap: wrap;
-  }
-  .twitterColumn {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 /* https://stackoverflow.com/questions/16771225/css3-rotate-animation */
 .spinner {
     position: relative;


### PR DESCRIPTION
This PR removes 
* The loading of the twitter widget -- This was able to render tweets from narratives "nicely" however it is prudent to remove it for security reasons. An issue will be created regarding the narrative functionality. (To my knowledge no narratives relied on this.)
* Twitter-related CSS