### PR TITLE
Display repo and maintainers as byline

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@ rules:
   prefer-destructuring: off
   implicit-arrow-linebreak: off
   jsx-quotes: off
+  no-use-before-define: ["error", { "functions": false }]
 parserOptions:
   ecmaVersion: 6
   sourceType: module

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -524,8 +524,8 @@ const createMetadataStateFromJSON = (json) => {
   if (json.meta.maintainers) {
     metadata.maintainers = json.meta.maintainers;
   }
-  if (json.meta.repository) {
-    metadata.repository = json.meta.repository;
+  if (json.meta.build_url) {
+    metadata.buildUrl = json.meta.build_url;
   }
   if (json.meta.genome_annotations) {
     metadata.genomeAnnotations = json.meta.genome_annotations;

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -524,6 +524,9 @@ const createMetadataStateFromJSON = (json) => {
   if (json.meta.maintainers) {
     metadata.maintainers = json.meta.maintainers;
   }
+  if (json.meta.repository) {
+    metadata.repository = json.meta.repository;
+  }
   if (json.meta.genome_annotations) {
     metadata.genomeAnnotations = json.meta.genome_annotations;
   }

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -1,19 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
-import { withTheme } from 'styled-components';
 import ChooseDatasetSelect from "./choose-dataset-select";
 import { SidebarHeader } from "./styles";
-
-const BuildLink = withTheme((props) => {
-  const niceUrl = props.url.replace(/^(http[s]?:\/\/)/, "");
-  return (
-    <div style={{ fontSize: 14, marginTop: 5, marginBottom: 10, color: props.theme.color}}>
-      <i className="fa fa-clone fa-lg" aria-hidden="true"/>
-      <span style={{position: "relative", paddingLeft: 10}}/>
-      <a href={props.url} target="_blank">{niceUrl}</a>
-    </div>
-  );
-});
 
 // const DroppedFiles = withTheme((props) => {
 //   /* TODO: this shouldn't be in the auspice src, rather injected as an extension when needed */
@@ -47,16 +35,12 @@ class ChooseDataset extends React.Component {
       .replace(/\/$/, '')
       .split(":")[0];
     const displayedDataset = displayedDatasetString.split("/");
-    let optionForCurrentDataset = {};
     const options = [[]];
 
     this.props.available.datasets.forEach((d) => {
       const firstField = d.request.split("/")[0];
       if (!options[0].includes(firstField)) {
         options[0].push(firstField);
-      }
-      if (displayedDatasetString === d.request) {
-        optionForCurrentDataset = d;
       }
     });
 
@@ -78,9 +62,6 @@ class ChooseDataset extends React.Component {
     return (
       <>
         <SidebarHeader>Dataset</SidebarHeader>
-        {optionForCurrentDataset.buildUrl ? (
-          <BuildLink url={optionForCurrentDataset.buildUrl}/>
-        ) : null}
         {options.map((option, optionIdx) => (
           <ChooseDatasetSelect
             key={option}

--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -364,23 +364,6 @@ class Footer extends React.Component {
       </button>
     );
   }
-  hasMaintainers() {
-    return Object.prototype.hasOwnProperty.call(this.props.metadata, "maintainers")
-  }
-  renderMaintainers() {
-    const renderLink = (m) => (<a href={m.url} target="_blank">{m.name}</a>);
-    return (
-      <span style={{textAlign: "center"}}>
-        {"Build maintained by "}
-        {this.props.metadata.maintainers.map((m, i) => (
-          <React.Fragment key={m.name}>
-            {m.url ? renderLink(m) : m.name}
-            {i === this.props.metadata.maintainers.length-1 ? "" : i === this.props.metadata.maintainers.length-2 ? " and " : ", "}
-          </React.Fragment>
-        ))}
-      </span>
-    );
-  }
   getCitation() {
     return (
       <span>
@@ -411,21 +394,15 @@ class Footer extends React.Component {
             );
           })}
           <Flex style={styles.fineprint}>
-            {this.hasMaintainers() ? (
-              <>
-                {this.renderMaintainers()}
-                {dot}
-              </>
-            ) : null}
             {this.getUpdated()}
             {dot}
             {this.downloadDataButton()}
+            {dot}
+            {"Auspice v" + version}
           </Flex>
           <div style={{height: "3px"}}/>
           <Flex style={styles.fineprint}>
             {this.getCitation()}
-            {dot}
-            {"Auspice v" + version}
           </Flex>
         </div>
       </div>

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -35,80 +35,67 @@ const Byline = ({width, metadata}) => {
 };
 
 function renderAvatar(metadata) {
-  let shouldRenderAvatar = false;
-  let imageSrc = "";
-  if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
-    const repo = metadata.buildUrl;
-    if (typeof repo === 'string') {
-      if (repo.startsWith("https://github.com") || repo.startsWith("http://github.com")) {
-        const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
-        if (match[1]) {
-          imageSrc = "https://github.com/" + match[1] + ".png?size=200";
-          shouldRenderAvatar = true;
-        }
-      }
+  const repo = metadata.buildUrl;
+  if (typeof repo === 'string') {
+    const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
+    if (match && match[1]) {
+      return (
+        <img style={styles.avatar} alt="avatar" width="28" src={`https://github.com/${match[1]}.png?size=200`}/>
+      );
     }
   }
-  return (
-    shouldRenderAvatar ?
-      <img style={styles.avatar} alt="avatar" width="28" src={imageSrc}/> :
-      <span/>
-  );
+  return null;
 }
 
 function renderBuildInfo(metadata) {
-  const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
-  let renderRepo = false;
-  const repoObj = {};
-  console.log("renderBuildInfo ", metadata.buildUrl);
   if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
     const repo = metadata.buildUrl;
     if (typeof repo === 'string') {
       if (repo.startsWith("https://") || repo.startsWith("http://")) {
-        repoObj.url = repo;
-        repoObj.name = repo.replace("https://", "").replace("http://", "");
-        renderRepo = true;
+        return (
+          <span>
+            {"Built using "}
+            <Link url={repo}>
+              {repo.replace(/^(http[s]?:\/\/)/, "")}
+            </Link>
+            {". "}
+          </span>
+        );
       }
     }
   }
-  return (
-    renderRepo ?
-      <span>
-        {"Built using "}
-        {renderLink(repoObj)}
-        {". "}
-      </span> :
-      <span/>
-  );
-
+  return null;
 }
 
 function renderMaintainers(metadata) {
-  const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
-  let shouldRenderMaintainers = false;
-  let maintainersArray = {};
+  let maintainersArray;
   if (Object.prototype.hasOwnProperty.call(metadata, "maintainers")) {
     maintainersArray = metadata.maintainers;
-    if (Array.isArray(maintainersArray)) {
-      if (maintainersArray[0]) {
-        shouldRenderMaintainers = true;
-      }
+    if (Array.isArray(maintainersArray) && maintainersArray.length) {
+      return (
+        <span>
+          {"Maintained by "}
+          {maintainersArray.map((m, i) => (
+            <React.Fragment key={m.name}>
+              {m.url ? <Link url={m.url}>{m.name}</Link> : m.name}
+              {i === maintainersArray.length-1 ? "" : i === maintainersArray.length-2 ? " and " : ", "}
+            </React.Fragment>
+          ))}
+          {"."}
+        </span>
+      );
     }
   }
+  return null;
+}
+
+function Link({url, children}) {
   return (
-    shouldRenderMaintainers ?
-      <span>
-        {"Maintained by "}
-        {maintainersArray.map((m, i) => (
-          <React.Fragment key={m.name}>
-            {m.url ? renderLink(m) : m.name}
-            {i === maintainersArray.length-1 ? "" : i === maintainersArray.length-2 ? " and " : ", "}
-          </React.Fragment>
-        ))}
-        {"."}
-      </span> :
-      <span/>
+    <a style={styles.bylineWeight} rel="noopener noreferrer" href={url} target="_blank">
+      {children}
+    </a>
   );
 }
+
 
 export default Byline;

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -8,19 +8,19 @@ const styles = {
   },
   byline: {
     fontFamily: headerFont,
-    fontSize: 14,
+    fontSize: 16,
     marginLeft: 2,
     marginTop: 5,
     marginBottom: 5,
-    fontWeight: 700,
+    fontWeight: 400,
     color: "#777",
     lineHeight: 1.4,
     verticalAlign: "middle"
   },
   bylineWeight: {
     fontFamily: headerFont,
-    fontSize: 14,
-    fontWeight: 700
+    fontSize: 16,
+    fontWeight: 400
   }
 };
 

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -8,19 +8,19 @@ const styles = {
   },
   byline: {
     fontFamily: headerFont,
-    fontSize: 16,
+    fontSize: 15,
     marginLeft: 2,
     marginTop: 5,
     marginBottom: 5,
-    fontWeight: 400,
-    color: "#777",
+    fontWeight: 500,
+    color: "#555",
     lineHeight: 1.4,
     verticalAlign: "middle"
   },
   bylineWeight: {
     fontFamily: headerFont,
-    fontSize: 16,
-    fontWeight: 400
+    fontSize: 15,
+    fontWeight: 500
   }
 };
 

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -1,0 +1,114 @@
+import React from "react";
+import { headerFont } from "../../globalStyles";
+
+const styles = {
+  avatar: {
+    marginRight: 5,
+    marginBottom: 2
+  },
+  byline: {
+    fontFamily: headerFont,
+    fontSize: 14,
+    marginLeft: 2,
+    marginTop: 5,
+    marginBottom: 5,
+    fontWeight: 700,
+    color: "#777",
+    lineHeight: 1.4,
+    verticalAlign: "middle"
+  },
+  bylineWeight: {
+    fontFamily: headerFont,
+    fontSize: 14,
+    fontWeight: 700
+  }
+};
+
+const Byline = ({width, metadata}) => {
+  return (
+    <div width={width} style={styles.byline}>
+      {renderAvatar(metadata)}
+      {renderBuildInfo(metadata)}
+      {renderMaintainers(metadata)}
+    </div>
+  );
+};
+
+function renderAvatar(metadata) {
+  let shouldRenderAvatar = false;
+  let imageSrc = "";
+  if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
+    const repo = metadata.buildUrl;
+    if (typeof repo === 'string') {
+      if (repo.startsWith("https://github.com") || repo.startsWith("http://github.com")) {
+        const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
+        if (match[1]) {
+          imageSrc = "https://github.com/" + match[1] + ".png?size=200";
+          shouldRenderAvatar = true;
+        }
+      }
+    }
+  }
+  return (
+    shouldRenderAvatar ?
+      <img style={styles.avatar} alt="avatar" width="28" src={imageSrc}/> :
+      <span/>
+  );
+}
+
+function renderBuildInfo(metadata) {
+  const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
+  let renderRepo = false;
+  const repoObj = {};
+  console.log("renderBuildInfo ", metadata.buildUrl);
+  if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
+    const repo = metadata.buildUrl;
+    if (typeof repo === 'string') {
+      if (repo.startsWith("https://") || repo.startsWith("http://")) {
+        repoObj.url = repo;
+        repoObj.name = repo.replace("https://", "").replace("http://", "");
+        renderRepo = true;
+      }
+    }
+  }
+  return (
+    renderRepo ?
+      <span>
+        {"Built using "}
+        {renderLink(repoObj)}
+        {". "}
+      </span> :
+      <span/>
+  );
+
+}
+
+function renderMaintainers(metadata) {
+  const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
+  let shouldRenderMaintainers = false;
+  let maintainersArray = {};
+  if (Object.prototype.hasOwnProperty.call(metadata, "maintainers")) {
+    maintainersArray = metadata.maintainers;
+    if (Array.isArray(maintainersArray)) {
+      if (maintainersArray[0]) {
+        shouldRenderMaintainers = true;
+      }
+    }
+  }
+  return (
+    shouldRenderMaintainers ?
+      <span>
+        {"Maintained by "}
+        {maintainersArray.map((m, i) => (
+          <React.Fragment key={m.name}>
+            {m.url ? renderLink(m) : m.name}
+            {i === maintainersArray.length-1 ? "" : i === maintainersArray.length-2 ? " and " : ", "}
+          </React.Fragment>
+        ))}
+        {"."}
+      </span> :
+      <span/>
+  );
+}
+
+export default Byline;

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -37,10 +37,10 @@ const Byline = ({width, metadata}) => {
 function renderAvatar(metadata) {
   const repo = metadata.buildUrl;
   if (typeof repo === 'string') {
-    const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
-    if (match && match[1]) {
+    const match = repo.match(/(https?:\/\/)?(www\.)?github.com\/([^/]+)/);
+    if (match) {
       return (
-        <img style={styles.avatar} alt="avatar" width="28" src={`https://github.com/${match[1]}.png?size=200`}/>
+        <img style={styles.avatar} alt="avatar" width="28" src={`https://github.com/${match[3]}.png?size=200`}/>
       );
     }
   }
@@ -51,12 +51,12 @@ function renderBuildInfo(metadata) {
   if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
     const repo = metadata.buildUrl;
     if (typeof repo === 'string') {
-      if (repo.startsWith("https://") || repo.startsWith("http://")) {
+      if (repo.startsWith("https://") || repo.startsWith("http://") || repo.startsWith("www.")) {
         return (
           <span>
             {"Built using "}
             <Link url={repo}>
-              {repo.replace(/^(http[s]?:\/\/)/, "")}
+              {repo.replace(/^(http[s]?:\/\/)/, "").replace(/^www\./, "")}
             </Link>
             {". "}
           </span>

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -140,6 +140,10 @@ class Info extends React.Component {
         letterSpacing: "-0.5px",
         lineHeight: 1.2
       },
+      avatar: {
+        marginRight: 5,
+        marginBottom: 2
+      },
       byline: {
         fontFamily: headerFont,
         fontSize: 14,
@@ -148,7 +152,8 @@ class Info extends React.Component {
         marginBottom: 5,
         fontWeight: 700,
         color: "#777",
-        lineHeight: 1.4
+        lineHeight: 1.4,
+        verticalAlign: "middle"
       },
       bylineWeight: {
         fontFamily: headerFont,
@@ -248,6 +253,28 @@ class Info extends React.Component {
     );
   }
 
+  renderAvatar(styles) {
+    let renderAvatar = false;
+    let imageSrc = "";
+    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "repository")) {
+      const repo = this.props.metadata.repository;
+      if (typeof repo === 'string') {
+        if (repo.startsWith("https://github.com") || repo.startsWith("http://github.com")) {
+          const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
+          if (match[1]) {
+            imageSrc = "https://github.com/" + match[1] + ".png?size=200";
+            renderAvatar = true;
+          }
+        }
+      }
+    }
+    return (
+      renderAvatar ?
+        <img style={styles.avatar} alt="avatar" width="28" src={imageSrc}/> :
+        <span/>
+    );
+  }
+
   renderRepository(styles) {
     const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
     let renderRepo = false;
@@ -305,6 +332,7 @@ class Info extends React.Component {
   renderByline(styles) {
     return (
       <div width={this.props.width} style={styles.byline}>
+        {this.renderAvatar(styles)}
         {this.renderRepository(styles)}
         {this.renderMaintainers(styles)}
       </div>

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -256,8 +256,8 @@ class Info extends React.Component {
   renderAvatar(styles) {
     let renderAvatar = false;
     let imageSrc = "";
-    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "repository")) {
-      const repo = this.props.metadata.repository;
+    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "buildUrl")) {
+      const repo = this.props.metadata.buildUrl;
       if (typeof repo === 'string') {
         if (repo.startsWith("https://github.com") || repo.startsWith("http://github.com")) {
           const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
@@ -275,12 +275,12 @@ class Info extends React.Component {
     );
   }
 
-  renderRepository(styles) {
+  renderBuildInfo(styles) {
     const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
     let renderRepo = false;
     const repoObj = {};
-    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "repository")) {
-      const repo = this.props.metadata.repository;
+    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "buildUrl")) {
+      const repo = this.props.metadata.buildUrl;
       if (typeof repo === 'string') {
         if (repo.startsWith("https://") || repo.startsWith("http://")) {
           repoObj.url = repo;
@@ -333,7 +333,7 @@ class Info extends React.Component {
     return (
       <div width={this.props.width} style={styles.byline}>
         {this.renderAvatar(styles)}
-        {this.renderRepository(styles)}
+        {this.renderBuildInfo(styles)}
         {this.renderMaintainers(styles)}
       </div>
     );

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -7,6 +7,7 @@ import { getVisibleDateRange } from "../../util/treeVisibilityHelpers";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { months, NODE_VISIBLE } from "../../util/globals";
 import { displayFilterValueAsButton } from "../framework/footer";
+import Byline from "./byline";
 
 const plurals = {
   country: "countries",
@@ -140,26 +141,6 @@ class Info extends React.Component {
         letterSpacing: "-0.5px",
         lineHeight: 1.2
       },
-      avatar: {
-        marginRight: 5,
-        marginBottom: 2
-      },
-      byline: {
-        fontFamily: headerFont,
-        fontSize: 14,
-        marginLeft: 2,
-        marginTop: 5,
-        marginBottom: 5,
-        fontWeight: 700,
-        color: "#777",
-        lineHeight: 1.4,
-        verticalAlign: "middle"
-      },
-      bylineWeight: {
-        fontFamily: headerFont,
-        fontSize: 14,
-        fontWeight: 700
-      },
       n: {
         fontFamily: headerFont,
         fontSize: 14,
@@ -253,92 +234,6 @@ class Info extends React.Component {
     );
   }
 
-  renderAvatar(styles) {
-    let renderAvatar = false;
-    let imageSrc = "";
-    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "buildUrl")) {
-      const repo = this.props.metadata.buildUrl;
-      if (typeof repo === 'string') {
-        if (repo.startsWith("https://github.com") || repo.startsWith("http://github.com")) {
-          const match = repo.match(/https?:\/\/github.com\/([^/]+)/);
-          if (match[1]) {
-            imageSrc = "https://github.com/" + match[1] + ".png?size=200";
-            renderAvatar = true;
-          }
-        }
-      }
-    }
-    return (
-      renderAvatar ?
-        <img style={styles.avatar} alt="avatar" width="28" src={imageSrc}/> :
-        <span/>
-    );
-  }
-
-  renderBuildInfo(styles) {
-    const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
-    let renderRepo = false;
-    const repoObj = {};
-    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "buildUrl")) {
-      const repo = this.props.metadata.buildUrl;
-      if (typeof repo === 'string') {
-        if (repo.startsWith("https://") || repo.startsWith("http://")) {
-          repoObj.url = repo;
-          repoObj.name = repo.replace("https://", "").replace("http://", "");
-          renderRepo = true;
-        }
-      }
-    }
-    return (
-      renderRepo ?
-        <span>
-          {"Built using "}
-          {renderLink(repoObj)}
-          {". "}
-        </span> :
-        <span/>
-    );
-
-  }
-
-  renderMaintainers(styles) {
-    const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
-    let renderMaintainers = false;
-    let maintainersArray = {};
-    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "maintainers")) {
-      maintainersArray = this.props.metadata.maintainers;
-      if (Array.isArray(maintainersArray)) {
-        if (maintainersArray[0]) {
-          renderMaintainers = true;
-        }
-      }
-    }
-    return (
-      renderMaintainers ?
-        <span>
-          {"Maintained by "}
-          {maintainersArray.map((m, i) => (
-            <React.Fragment key={m.name}>
-              {m.url ? renderLink(m) : m.name}
-              {i === maintainersArray.length-1 ? "" : i === maintainersArray.length-2 ? " and " : ", "}
-            </React.Fragment>
-          ))}
-          {"."}
-        </span> :
-        <span/>
-    );
-  }
-
-  renderByline(styles) {
-    return (
-      <div width={this.props.width} style={styles.byline}>
-        {this.renderAvatar(styles)}
-        {this.renderBuildInfo(styles)}
-        {this.renderMaintainers(styles)}
-      </div>
-    );
-  }
-
   render() {
     if (!this.props.metadata || !this.props.nodes || !this.props.visibility) return null;
     const styles = this.getStyles(this.props.width);
@@ -365,7 +260,7 @@ class Info extends React.Component {
       <Card center infocard>
         <div style={styles.base}>
           {this.renderTitle(styles)}
-          {this.renderByline(styles)}
+          <Byline styles={styles} width={this.props.width} metadata={this.props.metadata}/>
           <div width={this.props.width} style={styles.n}>
             {animating ? `Animation in progress. ` : null}
             {this.props.selectedStrain ? this.selectedStrainButton(this.props.selectedStrain) : null}

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -140,6 +140,21 @@ class Info extends React.Component {
         letterSpacing: "-0.5px",
         lineHeight: 1.2
       },
+      byline: {
+        fontFamily: headerFont,
+        fontSize: 14,
+        marginLeft: 2,
+        marginTop: 5,
+        marginBottom: 5,
+        fontWeight: 700,
+        color: "#777",
+        lineHeight: 1.4
+      },
+      bylineWeight: {
+        fontFamily: headerFont,
+        fontSize: 14,
+        fontWeight: 700
+      },
       n: {
         fontFamily: headerFont,
         fontSize: 14,
@@ -221,6 +236,81 @@ class Info extends React.Component {
     );
   }
 
+  renderTitle(styles) {
+    let title = "";
+    if (this.props.metadata.title) {
+      title = this.props.metadata.title;
+    }
+    return (
+      <div width={this.props.width} style={styles.title}>
+        {title}
+      </div>
+    );
+  }
+
+  renderRepository(styles) {
+    const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
+    let renderRepo = false;
+    const repoObj = {};
+    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "repository")) {
+      const repo = this.props.metadata.repository;
+      if (typeof repo === 'string') {
+        if (repo.startsWith("https://") || repo.startsWith("http://")) {
+          repoObj.url = repo;
+          repoObj.name = repo.replace("https://", "").replace("http://", "");
+          renderRepo = true;
+        }
+      }
+    }
+    return (
+      renderRepo ?
+        <span>
+          {"Built using "}
+          {renderLink(repoObj)}
+          {". "}
+        </span> :
+        <span/>
+    );
+
+  }
+
+  renderMaintainers(styles) {
+    const renderLink = (m) => (<a style={styles.bylineWeight} rel="noopener noreferrer" href={m.url} target="_blank">{m.name}</a>);
+    let renderMaintainers = false;
+    let maintainersArray = {};
+    if (Object.prototype.hasOwnProperty.call(this.props.metadata, "maintainers")) {
+      maintainersArray = this.props.metadata.maintainers;
+      if (Array.isArray(maintainersArray)) {
+        if (maintainersArray[0]) {
+          renderMaintainers = true;
+        }
+      }
+    }
+    return (
+      renderMaintainers ?
+        <span>
+          {"Maintained by "}
+          {maintainersArray.map((m, i) => (
+            <React.Fragment key={m.name}>
+              {m.url ? renderLink(m) : m.name}
+              {i === maintainersArray.length-1 ? "" : i === maintainersArray.length-2 ? " and " : ", "}
+            </React.Fragment>
+          ))}
+          {"."}
+        </span> :
+        <span/>
+    );
+  }
+
+  renderByline(styles) {
+    return (
+      <div width={this.props.width} style={styles.byline}>
+        {this.renderRepository(styles)}
+        {this.renderMaintainers(styles)}
+      </div>
+    );
+  }
+
   render() {
     if (!this.props.metadata || !this.props.nodes || !this.props.visibility) return null;
     const styles = this.getStyles(this.props.width);
@@ -228,10 +318,6 @@ class Info extends React.Component {
     const animating = this.props.animationPlayPauseButton === "Pause";
     const showExtended = !animating && !this.props.selectedStrain;
     const datesMaxed = this.props.dateMin === this.props.absoluteDateMin && this.props.dateMax === this.props.absoluteDateMax;
-    let title = "";
-    if (this.props.metadata.title) {
-      title = this.props.metadata.title;
-    }
 
     /* the content is made up of two parts:
     (1) the summary - e.g. Showing 4 of 379 sequences, from 1 author, 1 country and 1 region, dated Apr 2016 to Jun 2016.
@@ -250,9 +336,8 @@ class Info extends React.Component {
     return (
       <Card center infocard>
         <div style={styles.base}>
-          <div width={this.props.width} style={styles.title}>
-            {title}
-          </div>
+          {this.renderTitle(styles)}
+          {this.renderByline(styles)}
           <div width={this.props.width} style={styles.n}>
             {animating ? `Animation in progress. ` : null}
             {this.props.selectedStrain ? this.selectedStrainButton(this.props.selectedStrain) : null}

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -21,9 +21,36 @@ const Metadata = (state = {
     case types.ADD_COLOR_BYS:
       const colorings = Object.assign({}, state.colorings, action.newColorings);
       return Object.assign({}, state, {colorings});
+    case types.SET_AVAILABLE:
+      if (state.buildUrl) {
+        return state; // do not use data from getAvailable to overwrite a buildUrl set from a dataset JSON
+      }
+      const buildUrl = getBuildUrlFromGetAvailableJson(action.data.datasets);
+      if (buildUrl) {
+        return Object.assign({}, state, {buildUrl});
+      }
+      return state;
     default:
       return state;
   }
 };
+
+function getBuildUrlFromGetAvailableJson(availableData) {
+  if (!availableData) return undefined;
+  /* check if the current dataset is present in the getAvailable data
+  We currently parse the URL (pathname) for the current dataset but this
+  really should be stored somewhere in redux */
+  const displayedDatasetString = window.location.pathname
+    .replace(/^\//, '')
+    .replace(/\/$/, '')
+    .split(":")[0];
+  for (let i=0; i<availableData.length; i++) {
+    if (availableData[i].request === displayedDatasetString) {
+      return availableData[i].buildUrl; // may be `undefined`
+    }
+  }
+  return false;
+}
+
 
 export default Metadata;


### PR DESCRIPTION
This PR aims to do two things:

1. Surface repository / build URL. It's nice to point people to GitHub readmes that have details behind how the analysis was generated.
2. Better highlight maintainers. In the continued effort to give everyone credit, probably better to move maintainers to the top of the page rather than the very bottom.

This looks like this for the Zika Tutorial build:

<img width="1041" alt="zika" src="https://user-images.githubusercontent.com/1176109/68647472-d025c180-04d2-11ea-9244-8a12c8ba9e8b.png">

This is what this looks like for the Ebola DRC build:

<img width="1041" alt="ebola" src="https://user-images.githubusercontent.com/1176109/68647757-81c4f280-04d3-11ea-82b0-3108804bfe4e.png">

(There are some more mocks in Slack here: https://bedfordlab.slack.com/archives/C116R9PR7/p1564668779044000)

This would require groups to use custom GitHub profile photos if they want their logo shared.

This uses `metadata.repository`, but could easily be changed to `metadata.buildUrl` or something else (https://github.com/nextstrain/augur/pull/408#issuecomment-552731571).

I'd imagine this working with existing community functionality in that if `metadata.repository` is not specified and charon `getAvailable` has shared `buildUrl` with auspice, then `metadata.repository` would use the URL passed in from community. `metadata.repository` would override passed in community `buildUrl` if both exist.

