### PR TITLE
allow navigation in narratives via arrow keys

### DIFF
--- a/docs-src/docs/narratives/create-pdf.md
+++ b/docs-src/docs/narratives/create-pdf.md
@@ -1,0 +1,63 @@
+---
+title: "Converting a narrative to PDF"
+---
+
+This documentation will walk through how to turn a narrative into a static PDF.
+We understand that there are multiple reasons why PDFs may be a necessary method of distribution, but stress that narratives are designed to be viewed through auspice where you have the ability to interact with and interrogate the data.
+
+If you run into any bugs, please [get in contact with us (email)](mailto:hello@nextstrain.org).
+
+## Prerequisites
+
+This requires [Decktape](https://github.com/astefanutti/decktape) to be installed, which itself requires Node.js.
+If you've followed the [auspice install instructions](../introduction/install) and are using a conda environment then this is straightforward.
+If not, you can create the necessary conda environment via:
+
+```bash
+conda create --name auspice nodejs=10
+```
+
+Install Decktape via:
+```bash
+conda activate auspice # or whichever conda environment has nodejs
+npm install --global decktape
+```
+
+
+## Saving an online narrative to PDF
+
+Let's say we want to save the example Genomic-Epi Situation Report for Ebola in the DRC available at [nextstrain.org/narratives/inrb-ebola-example-sit-rep](https://nextstrain.org/narratives/inrb-ebola-example-sit-rep) which you can see has 6 different "pages" of content.
+We use decktape to access these different pages & save their output as PDF via:
+
+```bash
+decktape generic --load-pause 3000 --key ArrowDown --size 1600x900 \
+  https://nextstrain.org/narratives/inrb-ebola-example-sit-rep example.pdf
+```
+You'll see a lot of bad-looking warning messages printed in the terminal 😱, but as long as you see "Printed 7 slides" or similar then the command has worked.
+You should now be able to view a static PDF of the narrative, in this case at `example.pdf`.
+Feel free to play around with the different options available to decktape (run `decktape generic --help` to see them).
+
+> Note that this technique won't work if authentication is required. Please refer to the section on saving local narratives to PDF for how to do this.
+
+## Saving a local narrative to PDF
+
+If you have a local narrative then the concept is similar to saving an online narrative, except we need to start a auspice server locally to display our narrative & allow it to be accessed by decktape.
+These instructions assume you have installed auspice into a conda enviornment as per the [auspice install instructions](../introduction/install).
+
+Start up auspice locally, sourcing your own datasets & narratives via:
+```bash
+conda activate auspice # or whichever conda environment has auspice installed
+auspice view --datasetDir <path-to-datasets> --narrativeDir <path-to-narratives>
+```
+
+You should now be able to view your narrative at [localhost:4000](http://localhost:4000).
+For the purposes of this guide, i'll assume that we've followed the [Writing a Narrative](how-to-write) guide, and thus have a narrative describing mumps in North America available at [localhost:4000/narratives/example](http://localhost:4000/narratives/example).
+
+In a separate terminal window, run
+```bash
+conda activate auspice # or whichever conda environment has dectape installed from earlier
+decktape generic --load-pause 3000 --key ArrowDown --size 1600x900 \
+  http://localhost:4000/narratives/example example.pdf
+```
+You'll see a lot of bad-looking warning messages printed in the terminal 😱, but as long as you see "Printed 11 slides" or similar then the command has worked.
+You should now be able to view a static PDF of the narrative, in this case at `example.pdf`.

--- a/docs-src/docs/narratives/how-to-write.md
+++ b/docs-src/docs/narratives/how-to-write.md
@@ -11,8 +11,7 @@ You can skip this step if you have generated your own dataset, but for the purpo
 
 ```bash
 mkdir datasets
-curl http://data.nextstrain.org/mumps_na_meta.json --compressed -o datasets/mumps_na_meta.json
-curl http://data.nextstrain.org/mumps_na_tree.json --compressed -o datasets/mumps_na_tree.json
+curl http://data.nextstrain.org/mumps_na.json --compressed -o datasets/mumps_na.json
 ```
 
 You should now be able to visualise the dataset (without any narrative functionality) via `auspice view --datasetDir datasets`

--- a/docs-src/website/sidebars.json
+++ b/docs-src/website/sidebars.json
@@ -21,7 +21,8 @@
     ],
     "Narratives": [
       "narratives/introduction",
-      "narratives/how-to-write"
+      "narratives/how-to-write",
+      "narratives/create-pdf"
     ],
     "Release Notes": [
       "releases/changelog",


### PR DESCRIPTION
This adds support to navigate between "pages" when in narrative mode via the arrow keys. This is both useful for general usage, and allows us to use programs such as `decktape` to generate PDFs from narratives.