### PR TITLE
read (& send) JSONs as streams where possible

### DIFF
--- a/cli/server/getDataset.js
+++ b/cli/server/getDataset.js
@@ -8,7 +8,6 @@ const setUpGetDatasetHandler = ({datasetsPath}) => {
       const info = helpers.interpretRequest(req, datasetsPath);
       helpers.extendDataPathsToMatchAvailable(info, availableDatasets);
       helpers.makeFetchAddresses(info, datasetsPath, availableDatasets);
-      console.log(info);
       await helpers.sendJson(res, info);
     } catch (err) {
       console.trace(err);


### PR DESCRIPTION
Background: The auspice server (and the nextstrain.org server, but that's not part of this PR) read JSON data into memory during `getDataset` request handling and then send the data as a response to the client. For all non-v1 JSONs these data are passed through unmodified by the server.

This PR shifts to reading in data as a stream and piping this data to the response (which is also a stream). This results in some nice memory savings (green vs orange lines):

<img width="881" alt="image" src="https://user-images.githubusercontent.com/8350992/69508565-1a12ab00-0f9b-11ea-857f-81cec2dbee30.png">
_H3N2 datasets, all v2 JSONs, no tip-frequencies_
