### PR TITLE
Replace remote styles and fonts with the ones served locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
     -->
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:100,200,300,400,500,700">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
     https://stackoverflow.com/questions/9271276/is-the-recommendation-to-include-css-before-javascript-invalid
     -->
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:100,200,300,400,500,700">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,13 +15,5 @@
     <!-- asyncronously load the (entry) react bundle -->
     <script async src="/dist/auspice.bundle.js"></script>
 
-    <!-- by placing this in the body, we mimic async ability
-    This is important as sometimes unpkg takes 10s to return and, if in the header
-    this blocks the page load.
-    https://codepen.io/tigt/post/async-css-without-javascript
-    https://stackoverflow.com/questions/9271276/is-the-recommendation-to-include-css-before-javascript-invalid
-    -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:100,200,300,400,500,700">
-
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8122,6 +8122,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typeface-lato": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/typeface-lato/-/typeface-lato-0.0.75.tgz",
+      "integrity": "sha512-iA5uJD4PSTyIE4BDiSOexQeXkDkiJuX4Hu3wh3saJ06EB2TvJayab1Lbbmqq2je/LQv7KCQZHZmC0k4hedd8sw=="
+    },
     "ua-parser-js": {
       "version": "0.7.20",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3702,6 +3702,11 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "run-sequence": "~0.3.6",
     "style-loader": "^0.13.2",
     "styled-components": "^4.0.3",
+    "typeface-lato": "^0.0.75",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.1.2",
     "webpack-dev-middleware": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "express-naked-redirect": "^0.1.2",
     "express-static-gzip": "^0.2.2",
     "file-loader": "^1.1.11",
+    "font-awesome": "^4.7.0",
     "json-loader": "^0.5.1",
     "leaflet": "^1.2.0",
     "leaflet-image": "^0.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ import "./css/notifications.css";
 import "./css/boxed.css";
 import "./css/select.css";
 
+/* FONTS */
+import 'typeface-lato';
+
 const store = configureStore();
 
 /* set up non-redux state storage for the animation - use this conservitavely! */

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { Provider } from "react-redux";
 import configureStore from "./store";
 import { initialiseGoogleAnalyticsIfRequired } from "./util/googleAnalytics";
 /* S T Y L E S H E E T S */
+import "font-awesome/css/font-awesome.css";
 import "leaflet/dist/leaflet.css";
 import "./css/global.css";
 import "./css/browserCompatability.css";

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { Provider } from "react-redux";
 import configureStore from "./store";
 import { initialiseGoogleAnalyticsIfRequired } from "./util/googleAnalytics";
 /* S T Y L E S H E E T S */
+import "leaflet/dist/leaflet.css";
 import "./css/global.css";
 import "./css/browserCompatability.css";
 import "./css/bootstrapCustomized.css";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,7 +119,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
         {
           test: /\.(gif|png|jpe?g|svg)$/i,
           use: "file-loader",
-          include: directoriesToTransform
+          include: [...directoriesToTransform, path.join(__dirname, 'node_modules/leaflet')]
         }
       ]
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,9 +117,13 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
           use: ["style-loader", "css-loader"]
         },
         {
-          test: /\.(gif|png|jpe?g|svg)$/i,
+          test: /\.(gif|png|jpe?g|svg|woff2?|eot|otf|ttf)$/i,
           use: "file-loader",
-          include: [...directoriesToTransform, path.join(__dirname, 'node_modules/leaflet')]
+          include: [
+            ...directoriesToTransform,
+            path.join(__dirname, 'node_modules/font-awesome'),
+            path.join(__dirname, 'node_modules/leaflet')
+          ]
         }
       ]
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,7 +122,8 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
           include: [
             ...directoriesToTransform,
             path.join(__dirname, 'node_modules/font-awesome'),
-            path.join(__dirname, 'node_modules/leaflet')
+            path.join(__dirname, 'node_modules/leaflet'),
+            path.join(__dirname, 'node_modules/typeface-lato')
           ]
         }
       ]


### PR DESCRIPTION
This PR attempts to address some of the points in issue #714 (Improve offline functionality):

 - `leaflet`'s stylesheets are now bundled with webpack.
 - `font-awesome`'s stylesheets and fonts are are now bundled with webpack. Official `font-awesome` package is added as a dependency.
 - "Lato" font is bundled and served statically, so there no need to hit Google Font API anymore. Dependency to [`typeface-lato`](https://github.com/KyleAMathews/typefaces) is added. This package includes `woff` and `woff2` formats and this should cover the majority of target browsers, including IE 9 and Safari 5 (see: [caniuse.com/woff](https://caniuse.com/woff))

### Verification

 - Check out this pull request:
    ```bash
    git clone https://github.com/nextstrain/auspice
    cd auspice
    git pull origin pull/826/head
  
    ```
 - Add data and narratives, install packages, launch dev server as usual.
 - Open app in the chrome. In dev tools Network tab, type into filter input box  `-domain:localhost` (meaning "not",  "domain", "localhost").
 - Make sure that no requests are shown other than to `api.mapbox.com` and, eventually, `chrome-extension://*/backend.js` from installed Chrome extensions.
