### PR TITLE
[WIP] Cache map tiles locally server-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### App specific ###
+cache
 /dist/
 big_flu
 /data/

--- a/cli/server/TileCache.js
+++ b/cli/server/TileCache.js
@@ -1,0 +1,133 @@
+const _ = require('lodash');
+const { default: fetch, Headers } = require('node-fetch');
+const fs = require('fs-extra');
+const path = require('path');
+
+const utils = require('../utils');
+
+const TILES_CACHE_DIR = 'cache/tiles';
+
+
+function areValidCoordinates(coord) {
+  return _.every(coord, (c) => _.isInteger(_.toNumber(c)));
+}
+
+/**
+ * Caches map tiles requested by the client, so that previously seen tiles are
+ * available from localhost.
+ */
+class TileCache {
+  constructor() {
+    // TODO: setup transpiling server code to avoid .bind(this) and for other syntactic perks
+    this.requestHandler = this.requestHandler.bind(this);
+    this.getTile = this.getTile.bind(this);
+  }
+
+  /**
+   * Handles network requests
+   */
+  async requestHandler(req, res) {
+    if (!this.validateParams(req, res)) {
+      return res.status(400)
+        .type('json')
+        .send({ error: 'Bad request' });
+    }
+
+    // Send tile
+    const { s, x, y, z } = req.params;
+    try {
+      const image = await this.getTile({ s, x, y, z, headers: req.headers });
+
+      if (!image) {
+        return res.sendStatus(404);
+      }
+
+      // TODO: better performance we may implement streaming response
+      return res.type('png')
+        .send(image);
+
+
+    } catch (error) {
+      const details = error.message || 'unknown';
+      utils.error(`TileCache.requestHandler: ${details}`);
+      return res.status(500)
+        .type('json')
+        .send({ error: `server error: ${details}` });
+    }
+  }
+
+  validateParams(req) {
+    const { s, x, y, z } = req.params;
+
+    // Check `s` param
+    if (!_.isString(s) || s.length === 0) {
+      utils.error(`TileCache.requestHandler: s to be a non-empty string, got "${s}"`);
+      return false;
+    }
+
+    // Check `x, y, z` params
+    if (!(areValidCoordinates({ x, y, z }))) {
+      utils.error(`TileCache.requestHandler: { x, y, z } expected to be integral coordinates, got {"${x}", "${y}","${z}"}`);
+      return false;
+    }
+
+    return true;
+  }
+
+  async getTile({ s, x, y, z, headers }) {
+    const localPath = path.join(TILES_CACHE_DIR, `${s}-${z}-${x}-${y}.png`);
+    const remoteUrl = `https://${s}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
+
+    // If cache file for this tile exists, then read it and return
+    if ((await fs.exists(localPath)) && (await fs.stat(localPath)).isFile()) {
+      const image = fs.readFile(localPath);
+      utils.verbose(`Returning cached tile: ${remoteUrl}`);
+      return image;
+    }
+
+    // No cached tile? Request tile from the remote server, then cache it
+    utils.verbose(`Fetching tile: ${remoteUrl}`);
+    try {
+      const response = await fetch(remoteUrl, {
+        headers: new Headers({
+          Accept: 'image/png',
+
+          // Pass user-agent through from client.
+          // TODO: check with openstreetmap docs whether it's valid.
+          'User-Agent': headers['user-agent'] || headers['User-Agent']
+        })
+      });
+
+      if (response.status === 200) {
+        const image = await response.buffer();
+
+        utils.verbose(`Caching tile: ${remoteUrl} -> ${localPath}`);
+
+        // We don't wait for caching to complete.
+        // TODO: ensure that we don't serve incomplete files
+        //  (e.g. keep track of completely cached tiles)
+        fs.ensureDir(path.dirname(localPath))
+          .then(() => {
+            fs.writeFile(localPath, image);
+          });
+
+        utils.verbose(`Returning remote tile: ${remoteUrl}`);
+        return image;
+      }
+    } catch (e) {
+      //  TODO: We want to allow server to continue functioning even if network
+      //   is down and tiles cannot be fetched, however some of the errors might
+      //   still require handling.
+    }
+
+    // TODO: In case where there is no cached tile and tile cannot be fetched
+    //  remotely we currently send 404.
+    // Alternatively, we could send an empty png image 256x256 pixels:
+    // const image = fs.readFile(path.join(__dirname, '..', '..', 'src/images/empty-map-tile.png'));
+    // utils.verbose(`Returning empty tile instead of ${remoteUrl}`);
+    // return image;
+    return null;
+  }
+}
+
+module.exports = TileCache;

--- a/cli/view.js
+++ b/cli/view.js
@@ -12,6 +12,7 @@ const version = require('../src/version').version;
 const chalk = require('chalk');
 const SUPPRESS = require('argparse').Const.SUPPRESS;
 
+const TileCache = require('./server/TileCache');
 
 const addParser = (parser) => {
   const description = `Launch a local server to view locally available datasets & narratives.
@@ -59,6 +60,9 @@ const loadAndAddHandlers = ({app, handlersArg, datasetDir, narrativeDir}) => {
     handlers.getNarrative = require("./server/getNarrative")
       .setUpGetNarrativeHandler({narrativesPath});
   }
+
+  const tileCache = new TileCache();
+  app.get("/tiles/:s/:x/:y/:z", tileCache.requestHandler);
 
   /* apply handlers */
   app.get("/charon/getAvailable", handlers.getAvailable);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3755,6 +3755,16 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -5166,6 +5176,14 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -8177,6 +8195,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "express-naked-redirect": "^0.1.2",
     "express-static-gzip": "^0.2.2",
     "file-loader": "^1.1.11",
+    "fs-extra": "^8.1.0",
     "json-loader": "^0.5.1",
     "leaflet": "^1.2.0",
     "leaflet-image": "^0.4.0",

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -460,7 +460,8 @@ class Map extends React.Component {
 
     map.getRenderer(map).options.padding = 2;
 
-    L.tileLayer('https://api.mapbox.com/styles/v1/trvrb/ciu03v244002o2in5hlm3q6w2/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoidHJ2cmIiLCJhIjoiY2l1MDRoMzg5MDEwbjJvcXBpNnUxMXdwbCJ9.PMqX7vgORuXLXxtI3wISjw', {
+    // Proxy tile requests through backend, potentially with local caching
+    L.tileLayer('/tiles/{s}/{x}/{y}/{z}', {
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(map);
 


### PR DESCRIPTION
This PR attempts to implement a file-based local server-side cache for map tiles, addressing some of the concerns of #714 

### Motivation

Together with #826 this PR allows to run local server without internet connection. When reliable connection is available, user may selectively visit regions of interest on the map in order to build up the cache, and then go offline, with these same regions still being available.

### Implementation details

In order to not violate terms of currently used MapBox service, this PR switches to OpenStreetMap provider, which provides free tiles and allows (even encourages) caching.

Instead of fetching tiles directly, leaflet layer now requests tiles from `/tiles/{s}/{x}/{y}/{z}` (when running server locally, this resolves to localhost). On server side, this request is routed to `TileCache` service that initially proxies requests to the remote tile provider of choice, currently OpenStreetMap. 

The image tiles resulting from this request are sent back to client, but are also asynchronously written to filesystem. If previously seen tile is requested again, `TileCache` will return corresponding cached file instead of making requests to remote tile provider.
When remote tiles cannot be successfully retrieved, `TileCache` currently returns status 404. Leaflet in this case renders a grey tile.

### Discussion and further improvements

 - OpenStreetMap [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/#technical-usage-requirements) allows caching and proxying, but they forbid setting HTTP user agent.  However, requesting tiles with `node-fetch` always returns status 429, therefore, in this PR we forward `User-Agent` from the original client (browser) request. We have to check if this behavior is allowed.

 - Although tile images are small (10-20kb), they come in bulk numbers and overall cache size may reach limits of available disk space. We may implement various cache eviction policies (e.g. LRU) to free up disk space on user's machine.

 - Similarly, caching can be implemented client-side. The tiles can be stored in LocalStorage or in IndexedDB. This is more tricky, as it will involve modifying leaflet's layer, but is doable.

