### PR TITLE
Fix webpack transforms for different install methods

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,22 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
   /* which directories should be parsed by babel and other loaders? */
   const directoriesToTransform = [path.join(__dirname, 'src')];
 
+  /* which font modules need to be able to be loaded by auspice? */
+  const fontModules = ["font-awesome", "leaflet", "typeface-lato"];
+  /* note that the directory structure is different depending on whether auspice
+  is installed from source, a global npm install or a project's dependency. E.g.
+  Global install & from source: `${__dirname}/node_modules/font-awesome`
+  Project dependency:           `${__dirname}/../font-awesome`
+  This implementation is a short-term solution and should be improved */
+  let fileLoaderDirectoriesToTransform;
+  if (fs.existsSync(path.join(__dirname, "node_modules", fontModules[0]))) {
+    // global npm install or install from source
+    fileLoaderDirectoriesToTransform = fontModules.map((d) => path.join(__dirname, "node_modules", d));
+  } else {
+    // auspice is a project's dependency
+    fileLoaderDirectoriesToTransform = fontModules.map((d) => path.join(__dirname, "..", d));
+  }
+
   /* webpack alias' used in code import / require statements */
   const aliasesToResolve = {
     "@extensions": '.', /* must provide a default, else it won't compile */
@@ -121,9 +137,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
           use: "file-loader",
           include: [
             ...directoriesToTransform,
-            path.join(__dirname, 'node_modules/font-awesome'),
-            path.join(__dirname, 'node_modules/leaflet'),
-            path.join(__dirname, 'node_modules/typeface-lato')
+            ...fileLoaderDirectoriesToTransform
           ]
         }
       ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,22 +14,6 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
   /* which directories should be parsed by babel and other loaders? */
   const directoriesToTransform = [path.join(__dirname, 'src')];
 
-  /* which font modules need to be able to be loaded by auspice? */
-  const fontModules = ["font-awesome", "leaflet", "typeface-lato"];
-  /* note that the directory structure is different depending on whether auspice
-  is installed from source, a global npm install or a project's dependency. E.g.
-  Global install & from source: `${__dirname}/node_modules/font-awesome`
-  Project dependency:           `${__dirname}/../font-awesome`
-  This implementation is a short-term solution and should be improved */
-  let fileLoaderDirectoriesToTransform;
-  if (fs.existsSync(path.join(__dirname, "node_modules", fontModules[0]))) {
-    // global npm install or install from source
-    fileLoaderDirectoriesToTransform = fontModules.map((d) => path.join(__dirname, "node_modules", d));
-  } else {
-    // auspice is a project's dependency
-    fileLoaderDirectoriesToTransform = fontModules.map((d) => path.join(__dirname, "..", d));
-  }
-
   /* webpack alias' used in code import / require statements */
   const aliasesToResolve = {
     "@extensions": '.', /* must provide a default, else it won't compile */
@@ -134,11 +118,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
         },
         {
           test: /\.(gif|png|jpe?g|svg|woff2?|eot|otf|ttf)$/i,
-          use: "file-loader",
-          include: [
-            ...directoriesToTransform,
-            ...fileLoaderDirectoriesToTransform
-          ]
+          use: "file-loader"
         }
       ]
     }


### PR DESCRIPTION
The directory structure of npm dependencies is different
depending on whether auspice is installed from source, a
global npm install or a project's dependency. E.g. for webpack
to process the `font-awesome` dependency, then:
Global install & from source: `${__dirname}/node_modules/font-awesome`
Project dependency:              `${__dirname}/../font-awesome`

This bug comes from #826 which specified the first of the above
two scenarios.

Tested with projects using auspice (incl client-side customisations)
via global npm auspice install, auspice as a npm dependency and  auspice via `npm link <path>`


Note that this PR implements a short-term solution. In general, there are a a lot of
complex issues related to `npm` and using auspice to build custom bundles, including
but not limited to #689. I plan to write up a detailed issue for these shortly.