### PR TITLE
Implementing Custom Clade Labels for Zoom!

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -445,7 +445,7 @@ const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelect
     oldState.selectedStrain = tipSelected;
   }
   if (cladeSelected) {
-    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, "clade", cladeSelected);
+    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, cladeSelected["label"], cladeSelected["selected"]);
     oldState.selectedClade = cladeSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState); // tipSelectedIdx, oldState);
   }
@@ -630,6 +630,18 @@ export const createStateFromQueryOrJSONs = ({
     controls.colorByConfidence = doesColorByHaveConfidence(controls, controls.colorBy);
     tree.nodeColorsVersion = colorScale.version;
     tree.nodeColors = nodeColors;
+  }
+
+  // 'clade' zoom could now be under any label - check for first available query key that
+  // matches available branch labels, and convert it to be 'query.clade'
+  // This currently leaves any other 'clade zoom' requests in the URL dangling - they do nothing but remain
+  // Don't know if there's a better way to handle this?
+  const queryKeys = Object.keys(query);
+  for (const possibleClade of queryKeys) {
+    if (tree.availableBranchLabels.includes(possibleClade)) {
+      query.clade = {label: possibleClade, selected: query[possibleClade]};
+      break;
+    }
   }
 
   if (query.clade) {

--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -77,6 +77,13 @@ export const updateVisibleTipsAndBranchThicknesses = (
 ) => {
   return (dispatch, getState) => {
     const { tree, treeToo, controls, frequencies } = getState();
+    console.log("tree.selectedClade", tree.selectedClade);
+    // If going back to root or to unlabelled branch from 'custom' label branch, need to 
+    // expliticly set that 'label' to undefined, so it gets deleted from URL!
+    if (tree.selectedClade && !cladeSelected) {
+      cladeSelected = tree.selectedClade;
+      cladeSelected["selected"] = undefined;
+    }
     if (root[0] === undefined && !cladeSelected && tree.selectedClade) {
       /* if not resetting tree to root, maintain previous selectedClade if one exists */
       cladeSelected = tree.selectedClade;

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -79,13 +79,15 @@ export const onBranchClick = function onBranchClick(d) {
   // At the moment only branches with 1 label will work - if it has 2 it won't. Could be
   // changed to just use the 'first' (unsure if that would be consistant) on multi-label branches.
   // Also, can't use the AA mut lists as zoom labels - they look really bad in URL!!
-  if (
-    d.n.branch_attrs &&
-    d.n.branch_attrs.labels !== undefined &&
-    Object.keys(d.n.branch_attrs.labels).length === 1 &&
-    Object.keys(d.n.branch_attrs.labels)[0] !== "aa"
-  ) {
-    const key = Object.keys(d.n.branch_attrs.labels)[0];
+  let legalBranchLabels;
+  // Check has some branch labels, and remove 'aa' ones.
+  if (d.n.branch_attrs &&
+      d.n.branch_attrs.labels !== undefined) {
+    legalBranchLabels = Object.keys(d.n.branch_attrs.labels).filter((label) => label !== "aa");
+  }
+  // If has some, and only 1 left, then allow to use as a clade label
+  if (legalBranchLabels && legalBranchLabels.length === 1) {
+    const key = legalBranchLabels[0];
     cladeSelected = {label: key, selected: d.n.branch_attrs.labels[key]};
   }
   if (d.that.params.orientation[0] === 1) root[0] = d.n.arrayIdx;

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -75,12 +75,18 @@ export const onBranchClick = function onBranchClick(d) {
   if (this.props.narrativeMode) return;
   const root = [undefined, undefined];
   let cladeSelected;
+  console.log("clicked branch d.n.branch_attrs.labels", d.n.branch_attrs.labels);
+  // At the moment only branches with 1 label will work - if it has 2 it won't. Could be
+  // changed to just use the 'first' (unsure if that would be consistant) on multi-label branches.
+  // Also, can't use the AA mut lists as zoom labels - they look really bad in URL!!
   if (
     d.n.branch_attrs &&
     d.n.branch_attrs.labels !== undefined &&
-    d.n.branch_attrs.labels.clade !== undefined
+    Object.keys(d.n.branch_attrs.labels).length === 1 &&
+    Object.keys(d.n.branch_attrs.labels)[0] !== "aa"
   ) {
-    cladeSelected = d.n.branch_attrs.labels.clade;
+    const key = Object.keys(d.n.branch_attrs.labels)[0];
+    cladeSelected = {label: key, selected: d.n.branch_attrs.labels[key]};
   }
   if (d.that.params.orientation[0] === 1) root[0] = d.n.arrayIdx;
   else root[1] = d.n.arrayIdx;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -173,6 +173,16 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
   }
 
   /* small modifications to desired pathname / query */
+
+  // Custom labels come in under 'query.clade' but have their own label (may not be 'clade')
+  // to act appropriately, put them in 'query' under their own 'label'.
+  // Ex: query.clade = {label: animal, selected: dog}   becomes   query.animal = dog
+  if (query["clade"] && query["clade"] !== "" && query["clade"]["label"]) {
+    const label = query["clade"]["label"];
+    const selected = query["clade"]["selected"];
+    if (label !== "clade") { delete query["clade"]; } // get rid of query.clade unless label is 'clade'
+    query[label] = selected; // add the new query
+  }
   Object.keys(query).filter((q) => query[q] === "").forEach((k) => delete query[k]);
   let search = queryString.stringify(query).replace(/%2C/g, ',').replace(/%2F/g, '/');
   if (search) {search = "?" + search;}


### PR DESCRIPTION
This branch is 1 commit behind master ( it's parallel to [this commit](https://github.com/nextstrain/auspice/commit/32b2688c1ca56b17ffd3ae96c57a8fead2756653)) , as the latest merge commit (#826) breaks Auspice for me...

This PR is to create a way to have custom 'clade' labels in Auspice that can be used to zoom. It's already possible in the V2 JSON format to specify multiple `labels` for a branch under `branch_attrs`. Currently these are commonly used to specify `clade`, which gives the clade designations from `augur clade`, and `aa` which gives the AA mut labels. 

At the moment, Auspice only recognises `clade` for the purposes of changing the URL and thus only things labelled by `clade` can be specified for zooming via URL (and thus in narratives!).

This PR changes the functionality so that any "'label' 'selected'" pair can be used to identify nodes, change the URL, and thus be zoomed. 
This generally works by, instead of passing and expecting things like `clade=A2`, passing and expecting `clade={label: "clade", selected: "A2"}`
This allows the user to use whatever combination of branch labels they like. 

----

At the moment in this PR Auspice will only detect a branch as having a possible label (and thus able to go into the URL) if it **only** has _one_ branch label. And, it does not count or consider the `aa` labels (they look really ugly in the URL and I also think this isn't their purpose, so I disregard them). 

However, you can always manually change the URL to zoom to any branch, with any number of labels - they'll all end up in the same place. (There's no restriction on this end.)

This _could_ be changed to be allowed for branches with 2 labels -- we'd just have to pick one to put in the URL when the user clicks! Unsure what behaviour we want - feedback appreciated! It might be better to have 'something' than inexplicably be unable to specify a label you can see on a branch as a zoom point...?

---

One of the coolest things about this feature (I think) is that you can now have 'invisible zoom'. As in, you can zoom in to clusters that have been labelled via something other than `clade`, without having to clutter up the tree view by actually adding more text (via `clade`). You can of course also change the branch labels to show the other views, but you can have any branch label (or none) visible, and the zoom will still work for any of them.
_(This is actually what inspired me to do this - I really would like to send some more zoomed in views to collaborators, but I don't want to confuse them/clutter the tree by adding more clade annotations that aren't really clades.)_

---

I haven't tested this extensively with V1 to ensure it works fine - it should, but would be worth someone checking.
Would also benefit from some extra general testing. You can easily add extra labels to existing V2 JSONS by adding fields under "branch_attrs" "labels" in the format ex: "cluster": "African" etc. 
Would also appreciate extra eyes on the code to ensure I'm not doing things super-inefficiently :)

There's a little bit of existing debug to clean up once we are happy with the code.

**The next step** for this direction would be to update `augur clades` and `augur export` so that we can specify the clade 'name' (defaulting to 'clade' to preserve exact functionality with existing builds) and export these straight into the JSON. I don't expect this to be too difficult - but might wait until after `v6` release for everyone's sanity!  (Unless there's a strong preference otherwise.) I'd be happy to label a few things manually to zoom via URL until then :D



