### PR TITLE
Allow auspice to run on Heroku

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ big_flu
 /static/
 s3/
 /local_narratives/
+/narratives/
 
 ### OSX ###
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint": "eslint src",
     "get-data": "./scripts/get-data.sh",
     "get-narratives": "./scripts/get-narratives.sh",
-    "redeploy-site": "./scripts/redeploy-site.sh",
     "rebuild-docker-image": "./scripts/rebuild-docker-image.sh",
     "gzip-and-upload": "./scripts/gzip-and-upload.sh",
     "build-docs": "echo 'see ./docs-src/README.md'"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint src",
     "get-data": "./scripts/get-data.sh",
     "get-narratives": "./scripts/get-narratives.sh",
+    "heroku-postbuild": "npm run build && npm run get-data && npm run get-narratives",
     "rebuild-docker-image": "./scripts/rebuild-docker-image.sh",
     "gzip-and-upload": "./scripts/gzip-and-upload.sh",
     "build-docs": "echo 'see ./docs-src/README.md'"

--- a/scripts/create-data-dir.sh
+++ b/scripts/create-data-dir.sh
@@ -2,7 +2,7 @@ if ! [ -d "data" ]; then
   echo "Creating empty data directory"
   mkdir data
 fi
-if ! [ -d "local_narratives" ]; then
-  echo "Creating empty local_narratives directory"
-  mkdir local_narratives
+if ! [ -d "narratives" ]; then
+  echo "Creating empty narratives directory"
+  mkdir narratives
 fi


### PR DESCRIPTION
This allows auspice to run on a heroku app by running the get-data and
get-narratives scripts on startup. This allows us to use heroku's
review-apps functionality. Note that `npm run build` is not automatically
run if `heroku-postbuild` is set. Note also that the HOST env variable
needs to be set to 0.0.0.0 on heroku for the auspice server to work.