### PR TITLE
info-panel: round floating point numbers in info panels to 4 signific…

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -169,7 +169,13 @@ const getTraitsToDisplay = (node) => {
 };
 
 const Trait = ({node, trait, colorings}) => {
-  const value = getTraitFromNode(node, trait);
+  const value_tmp = getTraitFromNode(node, trait);
+  let value = value_tmp;
+  if (typeof value_tmp == "number"){
+    if (!Number.isInteger(value_tmp)){
+      value = Number.parseFloat(value_tmp).toPrecision(3);
+    }
+  }
   const name = (colorings && colorings[trait] && colorings[trait].title) ?
     colorings[trait].title :
     trait;


### PR DESCRIPTION
…ant digits. This will change the info panels from this 

![image](https://user-images.githubusercontent.com/8379168/71745271-f0865280-2e69-11ea-8466-ed850c3955e9.png)

to this
![tmp1](https://user-images.githubusercontent.com/8379168/71745231-d482b100-2e69-11ea-99e5-fd156b6f3a98.png)

The >10 significant digit accuracy doesn't reflect reality and makes the panel hard to read. I am not sure there might be circumstances where we want to see floating point numbers at higher accuracy though. 

