### PR TITLE
Fix back button breaks

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -12,11 +12,9 @@ export const chooseDisplayComponentFromURL = (url) => {
   if (
     !parts.length ||
     (parts.length === 1 && parts[0] === "") ||
-    (parts.length === 1 && parts[0] === "local") ||
     (parts.length === 1 && parts[0] === "staging") ||
     (parts.length === 1 && parts[0] === "community") ||
     (parts.length === 1 && parts[0] === "narratives") ||
-    (parts.length === 2 && parts[0] === "local" && parts[1] === "narratives") ||
     (parts.length === 2 && parts[0] === "groups")
   ) {
     return "splash";

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -63,7 +63,7 @@ export const changePage = ({
     const action = {
       type: PAGE_CHANGE,
       path,
-      displayComponent: "datasetLoader",
+      displayComponent: chooseDisplayComponentFromURL(path),
       pushState: push,
       query
     };

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -16,7 +16,8 @@ export const chooseDisplayComponentFromURL = (url) => {
     (parts.length === 1 && parts[0] === "staging") ||
     (parts.length === 1 && parts[0] === "community") ||
     (parts.length === 1 && parts[0] === "narratives") ||
-    (parts.length === 2 && parts[0] === "local" && parts[1] === "narratives")
+    (parts.length === 2 && parts[0] === "local" && parts[1] === "narratives") ||
+    (parts.length === 2 && parts[0] === "groups")
   ) {
     return "splash";
   } else if (parts[0] === "status") {


### PR DESCRIPTION
This PR closes #815.

Use existing function `chooseDisplayComponentFromURL` to determine what to set as the `displayComponent` instead of hard coding to "datasetLoader". 

This function includes known urls that are hardcoded to display the Auspice splash page and I've added "group" to this list. 