### PR TITLE
Date axis

### DIFF
--- a/scripts/get-data.sh
+++ b/scripts/get-data.sh
@@ -55,6 +55,7 @@ data_files=(
   "flu_seasonal_yam_na_12y.json" "flu_seasonal_yam_na_12y_tip-frequencies.json" \
   "enterovirus_d68_genome_meta.json" "enterovirus_d68_genome_tree.json" \
   "enterovirus_d68_vp1_meta.json" "enterovirus_d68_vp1_tree.json" \
+  "ncov.json" \
 )
 
 rm -rf data/

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -3,9 +3,9 @@ import { dataFont, darkGrey } from "../../../globalStyles";
 export const createDefaultParams = () => ({
   regressionStroke: darkGrey,
   regressionWidth: 6,
-  majorGridStroke: "#CCC",
+  majorGridStroke: "#DDD",
   majorGridWidth: 2,
-  minorGridStroke: "#DDD",
+  minorGridStroke: "#EEE",
   minorGridWidth: 1,
   tickLabelSize: 12,
   tickLabelFill: darkGrey,

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -9,7 +9,6 @@ export const createDefaultParams = () => ({
   minorGridWidth: 1,
   tickLabelSize: 12,
   tickLabelFill: darkGrey,
-  minorTicksTimeTree: 3,
   minorTicks: 4,
   orientation: [1, 1],
   margins: {left: 25, right: 15, top: 10, bottom: 30},


### PR DESCRIPTION
Here we change the concept of minor grid lines for temporal trees to represent "sensible" periods of time rather than fitting a fixed number between major grid points. This will greatly aid in epidemiological understanding of trees. Major grid lines are also chosen using a new heuristic which attempts to pick sensible periods, and is responsive to screen sizes to avoid a squashed grid on small screens.

No modifications are made to the calculation of grids for divergence trees.

Examples:

![image](https://user-images.githubusercontent.com/8350992/72866481-469b3700-3d40-11ea-8412-911f8c3f673f.png)
☝️ minor grid lines represent days here

![image](https://user-images.githubusercontent.com/8350992/72866499-5e72bb00-3d40-11ea-9e6c-9d9a050ac530.png)
☝️ small screens look better, and the minor gridlines are still meaningful (here each minor grid is 1 week)

![image](https://user-images.githubusercontent.com/8350992/72866596-c6290600-3d40-11ea-9f50-2b9374c09c3b.png)
☝️ large screens can show lots of information. Here minor gridlines represent months.

![image](https://user-images.githubusercontent.com/8350992/72866623-e48f0180-3d40-11ea-8ebc-fe4a4c9c5e1b.png)
☝️ a potentially unwanted side effect -- here weeks don't fit nicely into multi-month major gridlines, so the spacing of minor gridlines is less aesthetically pleasing. I'd argue it's more epidemiologically informative. This can be changed - for instance here we could have minor grid lines show months instead.

![image](https://user-images.githubusercontent.com/8350992/72866700-2750d980-3d41-11ea-9878-fc276c832e24.png)
☝️ a improvement common to a lot of datasets - minor gridlines represent months

![image](https://user-images.githubusercontent.com/8350992/72866748-5a936880-3d41-11ea-9913-0140c6148241.png)
☝️ often you see fewer grid lines, but they are easier to understand