### PR TITLE
Styling changes

### DIFF
--- a/src/components/main/index.js
+++ b/src/components/main/index.js
@@ -52,6 +52,9 @@ class Main extends React.Component {
       showSpinner: !(this.props.metadataLoaded && this.props.treeLoaded)
     };
     analyticsNewPage();
+    if (window.location.pathname.includes("gisaid")) { // TODO fix this hack by moving sidebar state to URL
+      this.state.sidebarOpen = false;
+    }
   }
   static propTypes = {
     dispatch: PropTypes.func.isRequired

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -437,7 +437,7 @@ class Map extends React.Component {
       zoom: zoom,
       scrollWheelZoom: false,
       maxBounds: this.getInitialBounds(),
-      minZoom: 2,
+      minZoom: 1.2,
       maxZoom: 14,
       zoomSnap: 0.5,
       zoomControl: false,

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -93,9 +93,9 @@ const ColorBy = ({node, colorBy, colorByConfidence, colorScale, colorings}) => {
   if (colorBy === "author") {
     const authorInfo = getFullAuthorInfoFromNode(node);
     if (!authorInfo) return null;
+    // <InfoLine name="Author:" value={authorInfo.value}/> This is already displayed by AttributionInfo    
     return (
       <>
-        <InfoLine name="Author:" value={authorInfo.value}/>
         {authorInfo.title ? <InfoLine name="Title:" value={authorInfo.title}/> : null}
         {authorInfo.journal ? <InfoLine name="Journal:" value={authorInfo.journal}/> : null}
       </>
@@ -256,6 +256,21 @@ const VaccineInfo = ({node}) => {
   return renderElements;
 };
 
+/**
+ * A React component to show attribution information, if present
+ * @param  {Object} props
+ * @param  {Object} props.node  branch node which is currently highlighted
+ */
+const AttributionInfo = ({node}) => {
+  const authorInfo = getFullAuthorInfoFromNode(node);
+  if (!authorInfo) return null;
+  return (
+    <>
+      <InfoLine name="Author:" value={authorInfo.value}/>
+    </>
+  );
+};
+
 const Container = ({node, panelDims, children}) => {
   const xOffset = 10;
   const yOffset = 10;
@@ -330,6 +345,7 @@ const HoverInfoPanel = ({
           <Mutations node={node}/>
           <BranchLength node={node}/>
           <ColorBy node={node} colorBy={colorBy} colorByConfidence={colorByConfidence} colorScale={colorScale} colorings={colorings}/>
+          <AttributionInfo node={node}/>
           <Comment>Click on tip to display more info</Comment>
         </>
       ) : (


### PR DESCRIPTION
This PR does:
1. Makes min map zoom slightly wider to better fit the globe in a grid view
2. Hides sidebar if window path contains `gisaid`
3. Always puts `author` in the tip hover panel

(2) Should be revisited to allow sidebar state in the URL, but I think this is a good solution for the time being.