### PR TITLE
Special case GISAID EPI ISL and Genbank accession

### DIFF
--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -61,11 +61,33 @@ function renderBuildInfo(metadata) {
             <Link url={repo}>
               {repo.replace(/^(http[s]?:\/\/)/, "").replace(/^www\./, "")}
             </Link>
+            <PotentialGisaidExtraByline/>
             {". "}
           </span>
         );
       }
     }
+  }
+  return null;
+}
+
+/** Additional byline content to be added when certain criteria met.
+ * This was introduced during the 2019 nCoV outbreak. In the future this
+ * design should be switched a JSON key or a nextstrain.org auspice customisation
+ */
+function PotentialGisaidExtraByline() {
+  if (
+    window.location.hostname === "nextstrain.org" && // use "localhost" for testing
+    window.location.pathname.startsWith("/ncov")
+  ) {
+    return (
+      <span>
+        {" using data from "}
+        <a key={1} href="https://gisaid.org" target="_blank" rel="noopener noreferrer">
+          <img src="https://www.gisaid.org/fileadmin/gisaid/img/schild.png" alt="gisaid-logo" width="65"/>
+        </a>
+      </span>
+    );
   }
   return null;
 }

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -47,6 +47,9 @@ function renderAvatar(metadata) {
   return null;
 }
 
+/**
+ * Render the byline of the page to indicate the source of the build (often a GitHub repo)
+ */
 function renderBuildInfo(metadata) {
   if (Object.prototype.hasOwnProperty.call(metadata, "buildUrl")) {
     const repo = metadata.buildUrl;
@@ -54,7 +57,7 @@ function renderBuildInfo(metadata) {
       if (repo.startsWith("https://") || repo.startsWith("http://") || repo.startsWith("www.")) {
         return (
           <span>
-            {"Built using "}
+            {"Built with "}
             <Link url={repo}>
               {repo.replace(/^(http[s]?:\/\/)/, "").replace(/^www\./, "")}
             </Link>

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -50,59 +50,42 @@ const formatURL = (url) => {
   return url;
 };
 
+const Link = ({url, title, value}) => (
+  <tr>
+    <th style={infoPanelStyles.item}>{title}</th>
+    <td style={infoPanelStyles.item}>
+      <a href={url} target="_blank" rel="noopener noreferrer">{value}</a>
+    </td>
+  </tr>
+);
+
 const AccessionAndUrl = ({node}) => {
   const accession = getAccessionFromNode(node);
   const url = getUrlFromNode(node);
-  const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
   const genbank_accession = getTraitFromNode(node, "genbank_accession");
 
-  if (isValueValid(gisaid_epi_isl) && isValueValid(genbank_accession)) {
-    const epi_isl = gisaid_epi_isl.split("_")[2];
-    const genbank_url = "https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession;
+  /* `gisaid_epi_isl` is a special value attached to nodes introduced during the 2019 nCoV outbreak.
+  If set, the display is different from the normal behavior */
+  const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
+  if (isValueValid(gisaid_epi_isl)) {
     return (
-      <React.Fragment>
-        <tr>
-          <th style={infoPanelStyles.item}>GISAID EPI ISL</th>
-          <td style={infoPanelStyles.item}>
-            <a href="https://gisaid.org" target="_blank" rel="noopener noreferrer">{epi_isl}</a>
-          </td>
-        </tr>
-        <tr>
-          <th style={infoPanelStyles.item}>Genbank accession</th>
-          <td style={infoPanelStyles.item}>
-            <a href={genbank_url} target="_blank" rel="noopener noreferrer">{genbank_accession}</a>
-          </td>
-        </tr>
-      </React.Fragment>
+      <>
+        <Link title={"GISAID EPI ISL"} value={gisaid_epi_isl.split("_")[2]} url={"https://gisaid.org"}/>
+        {isValueValid(genbank_accession) ?
+          <Link title={"Genbank accession"} value={genbank_accession} url={"https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession}/> :
+          null
+        }
+      </>
     );
-  } else if (isValueValid(gisaid_epi_isl)) {
-    const epi_isl = gisaid_epi_isl.split("_")[2];
+  }
+
+  if (isValueValid(genbank_accession)) {
     return (
-      <tr>
-        <th style={infoPanelStyles.item}>GISAID EPI ISL</th>
-        <td style={infoPanelStyles.item}>
-          <a href="https://gisaid.org" target="_blank" rel="noopener noreferrer">{epi_isl}</a>
-        </td>
-      </tr>
-    );
-  } else if (isValueValid(genbank_accession)) {
-    const genbank_url = "https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession;
-    return (
-      <tr>
-        <th style={infoPanelStyles.item}>Genbank accession</th>
-        <td style={infoPanelStyles.item}>
-          <a href={genbank_url} target="_blank" rel="noopener noreferrer">{genbank_accession}</a>
-        </td>
-      </tr>
+      <Link title={"Genbank accession"} value={genbank_accession} url={"https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession}/>
     );
   } else if (isValueValid(accession) && isValueValid(url)) {
     return (
-      <tr>
-        <th style={infoPanelStyles.item}>Accession</th>
-        <td style={infoPanelStyles.item}>
-          <a href={formatURL(url)} target="_blank" rel="noopener noreferrer">{accession}</a>
-        </td>
-      </tr>
+      <Link url={formatURL(url)} value={accession} title={"Accession"}/>
     );
   } else if (isValueValid(accession)) {
     return (
@@ -110,12 +93,7 @@ const AccessionAndUrl = ({node}) => {
     );
   } else if (isValueValid(url)) {
     return (
-      <tr>
-        <th style={infoPanelStyles.item}>Strain URL</th>
-        <td style={infoPanelStyles.item}>
-          <a href={formatURL(url)} target="_blank"><em>click here</em></a>
-        </td>
-      </tr>
+      <Link title={"Strain URL"} url={formatURL(url)} value={"click here"}/>
     );
   }
   return null;

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -53,14 +53,54 @@ const formatURL = (url) => {
 const AccessionAndUrl = ({node}) => {
   const accession = getAccessionFromNode(node);
   const url = getUrlFromNode(node);
+  const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
+  const genbank_accession = getTraitFromNode(node, "genbank_accession");
 
-
-  if (isValueValid(accession) && isValueValid(url)) {
+  if (isValueValid(gisaid_epi_isl) && isValueValid(genbank_accession)) {
+    const epi_isl = gisaid_epi_isl.split("_")[2];
+    const genbank_url = "https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession;
+    return (
+      <React.Fragment>
+        <tr>
+          <th style={infoPanelStyles.item}>GISAID EPI ISL</th>
+          <td style={infoPanelStyles.item}>
+            <a href="https://gisaid.org" target="_blank" rel="noopener noreferrer">{epi_isl}</a>
+          </td>
+        </tr>
+        <tr>
+          <th style={infoPanelStyles.item}>Genbank accession</th>
+          <td style={infoPanelStyles.item}>
+            <a href={genbank_url} target="_blank" rel="noopener noreferrer">{genbank_accession}</a>
+          </td>
+        </tr>
+      </React.Fragment>
+    );
+  } else if (isValueValid(gisaid_epi_isl)) {
+    const epi_isl = gisaid_epi_isl.split("_")[2];
+    return (
+      <tr>
+        <th style={infoPanelStyles.item}>GISAID EPI ISL</th>
+        <td style={infoPanelStyles.item}>
+          <a href="https://gisaid.org" target="_blank" rel="noopener noreferrer">{epi_isl}</a>
+        </td>
+      </tr>
+    );
+  } else if (isValueValid(genbank_accession)) {
+    const genbank_url = "https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession;
+    return (
+      <tr>
+        <th style={infoPanelStyles.item}>Genbank accession</th>
+        <td style={infoPanelStyles.item}>
+          <a href={genbank_url} target="_blank" rel="noopener noreferrer">{genbank_accession}</a>
+        </td>
+      </tr>
+    );
+  } else if (isValueValid(accession) && isValueValid(url)) {
     return (
       <tr>
         <th style={infoPanelStyles.item}>Accession</th>
         <td style={infoPanelStyles.item}>
-          <a href={formatURL(url)} target="_blank">{accession}</a>
+          <a href={formatURL(url)} target="_blank" rel="noopener noreferrer">{accession}</a>
         </td>
       </tr>
     );
@@ -164,7 +204,7 @@ const SampleDate = ({node}) => {
 const getTraitsToDisplay = (node) => {
   // TODO -- this should be centralised somewhere
   if (!node.node_attrs) return [];
-  const ignore = ["author", "div", "num_date"];
+  const ignore = ["author", "div", "num_date", "gisaid_epi_isl", "genbank_accession"];
   return Object.keys(node.node_attrs).filter((k) => !ignore.includes(k));
 };
 

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -267,11 +267,15 @@ const AttributionInfo = ({node}) => {
   if (authorInfo.value) {
     renderElements.push(<InfoLine name="Author:" value={authorInfo.value} key="author"/>);
   }
+
+  /* The `gisaid_epi_isl` is a special value attached to nodes introduced during the 2019 nCoV outbreak.
+  If set, we display this extra piece of information on hover */
   const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
   if (isValueValid(gisaid_epi_isl)) {
     const epi_isl = gisaid_epi_isl.split("_")[2];
     renderElements.push(<InfoLine name="GISAID EPI ISL:" value={epi_isl} key="gisaid_epi_isl"/>);
   }
+
   return renderElements;
 };
 

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -93,7 +93,7 @@ const ColorBy = ({node, colorBy, colorByConfidence, colorScale, colorings}) => {
   if (colorBy === "author") {
     const authorInfo = getFullAuthorInfoFromNode(node);
     if (!authorInfo) return null;
-    // <InfoLine name="Author:" value={authorInfo.value}/> This is already displayed by AttributionInfo    
+    // <InfoLine name="Author:" value={authorInfo.value}/> This is already displayed by AttributionInfo
     return (
       <>
         {authorInfo.title ? <InfoLine name="Title:" value={authorInfo.title}/> : null}
@@ -262,13 +262,17 @@ const VaccineInfo = ({node}) => {
  * @param  {Object} props.node  branch node which is currently highlighted
  */
 const AttributionInfo = ({node}) => {
+  const renderElements = [];
   const authorInfo = getFullAuthorInfoFromNode(node);
-  if (!authorInfo) return null;
-  return (
-    <>
-      <InfoLine name="Author:" value={authorInfo.value}/>
-    </>
-  );
+  if (authorInfo.value) {
+    renderElements.push(<InfoLine name="Author:" value={authorInfo.value} key="author"/>);
+  }
+  const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
+  if (isValueValid(gisaid_epi_isl)) {
+    const epi_isl = gisaid_epi_isl.split("_")[2];
+    renderElements.push(<InfoLine name="GISAID EPI ISL:" value={epi_isl} key="gisaid_epi_isl"/>);
+  }
+  return renderElements;
 };
 
 const Container = ({node, panelDims, children}) => {


### PR DESCRIPTION
We want the ability to have accessions for viruses that are in _both_ GISAID and Genbank. This PR watches for nodes with attrs `gisaid_epi_isl` and `genbank_accession` and treats them separately from the normal `accession` and `url` logic.

GISAID EPI ISL gets a hover element, while both GISAID EPI ISL and Genbank accession get click elements.