### PR TITLE
Fix bugs in redux state of pathname

### DIFF
--- a/src/reducers/general.js
+++ b/src/reducers/general.js
@@ -20,11 +20,14 @@ const general = (state = {
 }, action) => {
   switch (action.type) {
     case types.PAGE_CHANGE:
-      return Object.assign({}, state, {
-        pathname: action.path,
+      const stateUpdate = {
         displayComponent: action.displayComponent,
         errorMessage: action.errorMessage
-      });
+      };
+      if (action.path) {
+        stateUpdate.pathname = action.path;
+      }
+      return Object.assign({}, state, stateUpdate);
     case types.UPDATE_PATHNAME:
       return Object.assign({}, state, {
         pathname: action.pathname


### PR DESCRIPTION
We were getting bugs due to the redux state of `general.pathname` set to `undefined` when it shouldn't be as a result of `PAGE_CHANGE` actions with no `action.path` data. This resulted in incorrect API requests and the display of results which didn't match the URL.

This should close #851 but needs more testing via nextstrain.org