### PR TITLE
Pass width to nav-bar as prop

### DIFF
--- a/src/components/navBar/index.js
+++ b/src/components/navBar/index.js
@@ -33,6 +33,7 @@ const NavBar = ({sidebar, mobileDisplay, toggleHandler, narrativeTitle, width}) 
       <Content
         narrativeTitle={narrativeTitle}
         sidebar={sidebar}
+        width={width}
       />
       <SidebarChevron navHeight={normalNavBarHeight} navWidth={width} display={showSidebarToggle} onClick={toggleHandler}/>
     </NavBarContainer>


### PR DESCRIPTION
This wasn't defined in the API but was expected by the nextstrain nav-bar.

How nextstrain currently looks:
![image](https://user-images.githubusercontent.com/8350992/73151652-f7367b80-4130-11ea-9cc8-576320927a29.png)

How nextstrain.org was designed to look (and will look with this PR):
![image](https://user-images.githubusercontent.com/8350992/73151640-e980f600-4130-11ea-8d44-069ce68d6a31.png)
