### PR TITLE
hover: fix bug when authorInfo is null

### DIFF
--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -269,7 +269,7 @@ const VaccineInfo = ({node}) => {
 const AttributionInfo = ({node}) => {
   const renderElements = [];
   const authorInfo = getFullAuthorInfoFromNode(node);
-  if (authorInfo.value) {
+  if (authorInfo) {
     renderElements.push(<InfoLine name="Author:" value={authorInfo.value} key="author"/>);
   }
 


### PR DESCRIPTION
This PR closes #854 

Check for `authorInfo` instead of `authorInfo.value` since`authorInfo` can be returned as `undefined`.