### PR TITLE
Custom Clade Labels for Zoom - Revisited

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -181,7 +181,8 @@ const fetchDataAndDispatch = async (dispatch, url, query, narrativeBlocks) => {
         query,
         narrativeBlocks,
         mainTreeName: secondTreeUrl ? mainDatasetUrl : null,
-        secondTreeName: secondTreeUrl ? secondTreeUrl : null
+        secondTreeName: secondTreeUrl ? secondTreeUrl : null,
+        dispatch
       })
     });
 
@@ -233,7 +234,7 @@ export const loadSecondTree = (secondTreeUrl, firstTreeUrl) => async (dispatch, 
     return;
   }
   const oldState = getState();
-  const newState = createTreeTooState({treeTooJSON: secondJson.tree, oldState, originalTreeUrl: firstTreeUrl, secondTreeUrl: secondTreeUrl});
+  const newState = createTreeTooState({treeTooJSON: secondJson.tree, oldState, originalTreeUrl: firstTreeUrl, secondTreeUrl: secondTreeUrl, dispatch});
   dispatch({type: types.TREE_TOO_DATA, ...newState});
 };
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -445,7 +445,7 @@ const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelect
     oldState.selectedStrain = tipSelected;
   }
   if (cladeSelected) {
-    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, "clade", cladeSelected);
+    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, cladeSelected["label"], cladeSelected["selected"]);
     oldState.selectedClade = cladeSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState); // tipSelectedIdx, oldState);
   }
@@ -633,6 +633,24 @@ export const createStateFromQueryOrJSONs = ({
     controls.colorByConfidence = doesColorByHaveConfidence(controls, controls.colorBy);
     tree.nodeColorsVersion = colorScale.version;
     tree.nodeColors = nodeColors;
+  }
+
+  // 'clade' zoom can now be under any label - check for first available query key that
+  // matches available branch labels, and convert it to be 'query.clade'
+  // If the 'label' doesnt exist on the tree (ex: in label=clade:T, if 'clade' doesn't exist) then
+  // the URL is cleared as well as the tree doing nothing.
+  // However, if the 'selection' doesnt exist on the tree (ex: in label=clade:T, if 'clade' exists but 'T' doesnt)
+  // then the tree does nothing and the URL is not cleared. (This is current behaviour.)
+  const queryKeys = Object.keys(query);
+  if (queryKeys.includes("label")) {
+    const label_parts = query["label"].split(":");
+    const possibleClade = label_parts[0];
+    if (tree.availableBranchLabels.includes(possibleClade)) {
+      query.clade = {label: possibleClade, selected: label_parts[1]};
+    } else {
+      query.clade = undefined;
+      delete query["label"];
+    }
   }
 
   if (query.clade) {

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -435,7 +435,7 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree) => {
   return state;
 };
 
-const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelected, controlsState) => {
+const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelected, controlsState, dispatch) => {
   /* calculate new branch thicknesses & visibility */
   let tipSelectedIdx = 0;
   /* check if the query defines a strain to be selected */
@@ -445,7 +445,7 @@ const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelect
     oldState.selectedStrain = tipSelected;
   }
   if (cladeSelected) {
-    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, cladeSelected["label"], cladeSelected["selected"]);
+    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, cladeSelected["label"], cladeSelected["selected"], dispatch);
     oldState.selectedClade = cladeSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState); // tipSelectedIdx, oldState);
   }
@@ -573,7 +573,8 @@ export const createStateFromQueryOrJSONs = ({
   narrativeBlocks = false,
   mainTreeName = false,
   secondTreeName = false,
-  query
+  query,
+  dispatch
 }) => {
   let tree, treeToo, entropy, controls, metadata, narrative, frequencies;
   /* first task is to create metadata, entropy, controls & tree partial state */
@@ -654,15 +655,15 @@ export const createStateFromQueryOrJSONs = ({
   }
 
   if (query.clade) {
-    tree = modifyTreeStateVisAndBranchThickness(tree, undefined, query.clade, controls);
+    tree = modifyTreeStateVisAndBranchThickness(tree, undefined, query.clade, controls, dispatch);
   } else { /* if not specifically given in URL, zoom to root */
-    tree = modifyTreeStateVisAndBranchThickness(tree, undefined, undefined, controls);
+    tree = modifyTreeStateVisAndBranchThickness(tree, undefined, undefined, controls, dispatch);
   }
-  tree = modifyTreeStateVisAndBranchThickness(tree, query.s, undefined, controls);
+  tree = modifyTreeStateVisAndBranchThickness(tree, query.s, undefined, controls, dispatch);
   if (treeToo && treeToo.loaded) {
     treeToo.nodeColorsVersion = tree.nodeColorsVersion;
     treeToo.nodeColors = calcNodeColor(treeToo, controls.colorScale);
-    treeToo = modifyTreeStateVisAndBranchThickness(treeToo, query.s, undefined, controls);
+    treeToo = modifyTreeStateVisAndBranchThickness(treeToo, query.s, undefined, controls, dispatch);
     controls = modifyControlsViaTreeToo(controls, treeToo.name);
     treeToo.tangleTipLookup = constructVisibleTipLookupBetweenTrees(tree.nodes, treeToo.nodes, tree.visibility, treeToo.visibility);
   }
@@ -697,7 +698,8 @@ export const createTreeTooState = ({
   treeTooJSON, /* raw json data */
   oldState,
   originalTreeUrl,
-  secondTreeUrl /* treeToo URL */
+  secondTreeUrl, /* treeToo URL */
+  dispatch
 }) => {
   /* TODO: reconsile choices (filters, colorBys etc) with this new tree */
   /* TODO: reconcile query with visibility etc */
@@ -709,7 +711,7 @@ export const createTreeTooState = ({
   treeToo.debug = "RIGHT";
   controls = modifyControlsStateViaTree(controls, tree, treeToo, oldState.metadata.colorings);
   controls = modifyControlsViaTreeToo(controls, secondTreeUrl);
-  treeToo = modifyTreeStateVisAndBranchThickness(treeToo, tree.selectedStrain, undefined, controls);
+  treeToo = modifyTreeStateVisAndBranchThickness(treeToo, tree.selectedStrain, undefined, controls, dispatch);
 
   /* calculate colours if loading from JSONs or if the query demands change */
   const colorScale = calcColorScale(controls.colorBy, controls, tree, treeToo, oldState.metadata);

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -445,8 +445,15 @@ const modifyTreeStateVisAndBranchThickness = (oldState, tipSelected, cladeSelect
     oldState.selectedStrain = tipSelected;
   }
   if (cladeSelected) {
-    const cladeSelectedIdx = cladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, cladeSelected["label"], cladeSelected["selected"], dispatch);
-    oldState.selectedClade = cladeSelected;
+    // Check and fix old format 'clade=B' - in this case selectionClade is just 'B'
+    let safeCladeSelected = {};
+    if (typeof cladeSelected === "string" && cladeSelected !== 'root') {
+      safeCladeSelected = {label: "clade", selected: cladeSelected};
+    } else {
+      safeCladeSelected = cladeSelected;
+    }
+    const cladeSelectedIdx = safeCladeSelected === 'root' ? 0 : getIdxMatchingLabel(oldState.nodes, safeCladeSelected["label"], safeCladeSelected["selected"], dispatch);
+    oldState.selectedClade = safeCladeSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState); // tipSelectedIdx, oldState);
   }
   const visAndThicknessData = calculateVisiblityAndBranchThickness(

--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -77,6 +77,12 @@ export const updateVisibleTipsAndBranchThicknesses = (
 ) => {
   return (dispatch, getState) => {
     const { tree, treeToo, controls, frequencies } = getState();
+    // If going back to root or to unlabelled branch from 'custom' label branch, need to
+    // expliticly set that 'label' to undefined, so it gets deleted from URL!
+    if (tree.selectedClade && !cladeSelected) {
+      cladeSelected = tree.selectedClade;
+      cladeSelected["selected"] = undefined;
+    }
     if (root[0] === undefined && !cladeSelected && tree.selectedClade) {
       /* if not resetting tree to root, maintain previous selectedClade if one exists */
       cladeSelected = tree.selectedClade;

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -75,12 +75,25 @@ export const onBranchClick = function onBranchClick(d) {
   if (this.props.narrativeMode) return;
   const root = [undefined, undefined];
   let cladeSelected;
-  if (
-    d.n.branch_attrs &&
-    d.n.branch_attrs.labels !== undefined &&
-    d.n.branch_attrs.labels.clade !== undefined
-  ) {
-    cladeSelected = d.n.branch_attrs.labels.clade;
+  // Branches with multiple labels will be used in the order specified by this.props.tree.availableBranchLabels
+  // (The order of the drop-down on the menu)
+  // Can't use AA mut lists as zoom labels currently - URL is bad, but also, means every node has a label, and many conflict...
+  let legalBranchLabels;
+  // Check has some branch labels, and remove 'aa' ones.
+  if (d.n.branch_attrs &&
+    d.n.branch_attrs.labels !== undefined) {
+    legalBranchLabels = Object.keys(d.n.branch_attrs.labels).filter((label) => label !== "aa");
+  }
+  // If has some, then could be clade label - but sort first
+  if (legalBranchLabels) {
+    const availableBranchLabels = this.props.tree.availableBranchLabels;
+    // sort the possible branch labels by the order of those available on the tree
+    legalBranchLabels.sort((a, b) =>
+      availableBranchLabels.indexOf(a) - availableBranchLabels.indexOf(b)
+    );
+    // then use the first!
+    const key = legalBranchLabels[0];
+    cladeSelected = {label: key, selected: d.n.branch_attrs.labels[key]};
   }
   if (d.that.params.orientation[0] === 1) root[0] = d.n.arrayIdx;
   else root[1] = d.n.arrayIdx;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -177,11 +177,20 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
   // to act appropriately, put them in 'query' under their own 'label'.
   // Ex: query.clade = {label: animal, selected: dog}   becomes   query.label = animal:dog
   // Need to run this whether it's from a click event ('clade') or from a URL load ('label')
-  if ((query["clade"] && query["clade"] !== "" && query["clade"]["label"]) ||
+  if ((query["clade"] && query["clade"] !== "") ||
       (query["label"] && query["label"] !== "")) {
     const label_parts = query["label"] ? query["label"].split(":") : "";
-    const label = query["clade"] ? query["clade"]["label"] : label_parts[0];
-    const selected = query["clade"] ? query["clade"]["selected"] : label_parts[1];
+
+    let label;
+    let selected;
+    // If old format ('?clade=B') need to recognise and act appropriately
+    if (typeof query["clade"] === 'string') {
+      label = "clade";
+      selected = query["clade"];
+    } else {
+      label = query["clade"] ? query["clade"]["label"] : label_parts[0];
+      selected = query["clade"] ? query["clade"]["selected"] : label_parts[1];
+    }
     delete query["clade"]; // get rid of query.clade
     query["label"] = selected ? ""+label+":"+selected : selected;
   }

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -173,8 +173,20 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
   }
 
   /* small modifications to desired pathname / query */
+  // Custom labels come in under 'query.clade' but have their own label (may not be 'clade')
+  // to act appropriately, put them in 'query' under their own 'label'.
+  // Ex: query.clade = {label: animal, selected: dog}   becomes   query.label = animal:dog
+  // Need to run this whether it's from a click event ('clade') or from a URL load ('label')
+  if ((query["clade"] && query["clade"] !== "" && query["clade"]["label"]) ||
+      (query["label"] && query["label"] !== "")) {
+    const label_parts = query["label"] ? query["label"].split(":") : "";
+    const label = query["clade"] ? query["clade"]["label"] : label_parts[0];
+    const selected = query["clade"] ? query["clade"]["selected"] : label_parts[1];
+    delete query["clade"]; // get rid of query.clade
+    query["label"] = selected ? ""+label+":"+selected : selected;
+  }
   Object.keys(query).filter((q) => query[q] === "").forEach((k) => delete query[k]);
-  let search = queryString.stringify(query).replace(/%2C/g, ',').replace(/%2F/g, '/');
+  let search = queryString.stringify(query).replace(/%2C/g, ',').replace(/%2F/g, '/').replace(/%3A/g, ':');
   if (search) {search = "?" + search;}
   if (!pathname.startsWith("/")) {pathname = "/" + pathname;}
 

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -1,6 +1,7 @@
 import { freqScale, NODE_NOT_VISIBLE, NODE_VISIBLE_TO_MAP_ONLY, NODE_VISIBLE } from "./globals";
 import { calcTipCounts } from "./treeCountingHelpers";
 import { getTraitFromNode } from "./treeMiscHelpers";
+import { warningNotification } from "../actions/notifications";
 
 export const getVisibleDateRange = (nodes, visibility) => nodes
   .filter((node, idx) => (visibility[idx] === NODE_VISIBLE && !node.hasChildren))
@@ -30,7 +31,7 @@ export const strainNameToIdx = (nodes, name) => {
  * @param {string} labelValue label value
  * @returns {int} the index of the matching node (0 if no match found)
  */
-export const getIdxMatchingLabel = (nodes, labelName, labelValue) => {
+export const getIdxMatchingLabel = (nodes, labelName, labelValue, dispatch) => {
   let i;
   let found = 0;
   for (i = 0; i < nodes.length; i++) {
@@ -43,11 +44,21 @@ export const getIdxMatchingLabel = (nodes, labelName, labelValue) => {
         found = i;
       } else {
         console.error(`getIdxMatchingLabel found multiple labels ${labelName}===${labelValue}`);
+        dispatch(warningNotification({
+          message: "Specified Zoom Label Found Multiple Times!",
+          details: "Multiple nodes in the tree are labelled '"+labelName+" "+labelValue+"' - no zoom performed"
+        }));
         return 0;
       }
     }
   }
-  if (found === 0) { console.error(`getIdxMatchingLabel couldn't find label ${labelName}===${labelValue}`); }
+  if (found === 0) { 
+    console.error(`getIdxMatchingLabel couldn't find label ${labelName}===${labelValue}`);
+    dispatch(warningNotification({
+      message: "Specified Zoom Label Value Not Found!",
+      details: "The label '"+labelName+"' value '"+labelValue+"' was not found in the tree - no zoom performed"
+    }));
+  }
   return found;
 };
 

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -32,17 +32,23 @@ export const strainNameToIdx = (nodes, name) => {
  */
 export const getIdxMatchingLabel = (nodes, labelName, labelValue) => {
   let i;
+  let found = 0;
   for (i = 0; i < nodes.length; i++) {
     if (
       nodes[i].branch_attrs &&
       nodes[i].branch_attrs.labels !== undefined &&
       nodes[i].branch_attrs.labels[labelName] === labelValue
     ) {
-      return i;
+      if (found === 0) {
+        found = i;
+      } else {
+        console.error(`getIdxMatchingLabel found multiple labels ${labelName}===${labelValue}`);
+        return 0;
+      }
     }
   }
-  console.error(`getIdxMatchingLabel couldn't find label ${labelName}===${labelValue}`);
-  return 0;
+  if (found === 0) { console.error(`getIdxMatchingLabel couldn't find label ${labelName}===${labelValue}`); }
+  return found;
 };
 
 /** calcBranchThickness **


### PR DESCRIPTION
I wanted to revisit this idea, which I originally brought up in Nov 2019, in PR #831 . I think, in particular, it could come in handy very soon for the nCoV narratives, as we'll have more structure in the tree soon and it may be helpful to be able to do fancy zooming.

Most of this is about the same as previously but I've addressed almost all of the requests that @jameshadfield [made on the previous PR](https://github.com/nextstrain/auspice/pull/831#issuecomment-559288177):

1. `clade` is no longer specially treated. The URL now used is, as was suggested by James, `?label=myLabel:myValue`. For example, for clades: `?label=clade:A` or for something else: `?label=grouping:hospital` . Labels and values can be anything at all. `clade` is still 'specially treated' in other senses, in that it shows up by default (if present) in the Auspice view, etc.

2. As before, you can now zoom to a 'hidden' (not displayed) clade label. This will show in the URL if there's a clade label in the tree but not displayed. Unlike before, you can now zoom to a node with multiple labels - they are ordered, as suggested, by the oder in the drop-down on the controls. So, if `clade` is present, it'll be first-choice for the zoom URL, for example. 

3. I still haven't included AA labels. Not only is the URL parsing much trickier, but this ends up meaning almost every node in the tree has a 'label', so every single branch you click on changes the URL (and often in a really long way). It's also not uncommon to have clashes (same value in multiple nodes) here. I'm just not sure it's useful, but we can definitely revisit this later, perhaps with a bit more thinking through.

4. See 2 - if a node has multiple labels, they're ordered by the order in the drop-down menu (excluding `aa`). This is despite what's visible - so for a branch with `clade:A` and `groupings:hospital`, even if you have `grouping` selected for the branch labels, you'll still get `clade:A` as the URL. (You can still put `groupings:hospital` in the URL yourself and get the same zoom result.) I think we could address in future for perfect behaviour but I don't think this should stop us implementing this now.

5. When clicking to zoom, there is no awareness of whether there are multiple labels with the same value in the tree. (This is also true with current behaviour of clade zooming.) It will just load the values of the node that's been clicked, even if they are also elsewhere. Again we could perfect this in future but it's the same as current and I think fine for now. 

6. If you specify a `label` value that exists two place in the tree, via URL, it currently throws a `console.error` and doesn't zoom at all. This is *better* than current behaviour with clades, which just zooms to whatever is encountered first when traversing the tree, with no warning. **However** I will now push a commit which makes a pop-up warning for the user to make this clearer. I'm doing this separately as I'm not 100% this is a good way to do it, so it could be undone easily if it's too much and better to stick with the basics for now, and come back to this later.


-----

As before, the coolest thing about this is that you can now put custom 'clade' labels in the JSON and use them to zoom via URL without having to display a bunch of additional `clade` labels all over your tree.  I think this will be *great* for narratives. 

As before, this currently has to be done manually as there's no corresponding `augur` function to do anything but the 'official' `clades` values, but I can start working on this next. For the moment, even though it's manual, I still think it'll be super useful for us!

----

Hopefully this should create some kind of Heroku version that can be tested out!
