### PR TITLE
Make Infobox Y-Scroll and Limit Its Size

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -209,10 +209,12 @@ const Trait = ({node, trait, colorings}) => {
  */
 const TipClickedPanel = ({tip, goAwayCallback, colorings}) => {
   if (!tip) {return null;}
+  const panelStyle = { ...infoPanelStyles.panel};
+  panelStyle.height = "70%";
   const node = tip.n;
   return (
     <div style={infoPanelStyles.modalContainer} onClick={() => goAwayCallback(tip)}>
-      <div className={"panel"} style={infoPanelStyles.panel} onClick={(e) => stopProp(e)}>
+      <div className={"panel"} style={panelStyle} onClick={(e) => stopProp(e)}>
         <StrainName>{node.name}</StrainName>
         <table>
           <tbody>

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -224,8 +224,8 @@ export const infoPanelStyles = {
     fontSize: 18,
     lineHeight: 1,
     fontWeight: 300,
-    maxWidth: 500,
-    overflow: "scroll"
+    maxWidth: "80%",
+    overflowY: "auto"
   },
   modalHeading: {
     fontSize: 24,


### PR DESCRIPTION
This attempts to address #842 . Probably the info-box could still be improved, but this should make things work a bit better, anyway!

Simple adjustments that restrict the tip-click info box height and width, and allow Y-scrolling (if needed). As a side-effect, gets rid of the previously unusable but present scrolls bars.

In my tests there was always enough room around the box to click outside of it and exit, but this should be confirmed. Otherwise (or either way) the X-box that James mentioned could be added.

I currently do the height restriction in `src/components/tree/infoPanel/click.js` by copying the `infoPanelStyles.panel` object from `src/globalStyles.js`, as I wasn't sure if anything else might use this style, and didn't want to accidentally cause unintentional changes elsewhere. This code could be simplified to just changing the `globalStyles.js` file, if it this won't mess up anything else!

------

Before:
![image](https://user-images.githubusercontent.com/14290674/73362363-f7588780-42a6-11ea-96c2-efe3fcf6f2e4.png)
(note that though a scroll bar is visible, it doesn't work)

After:
![image](https://user-images.githubusercontent.com/14290674/73362287-e0b23080-42a6-11ea-9ce9-cfbc40d0a060.png)


-----

Before, when zoom very high - infobox takes up whole screen - can't click away to close!
![image](https://user-images.githubusercontent.com/14290674/73362447-27078f80-42a7-11ea-8e6c-bb19ac67d876.png)

After - same zoom. Infobox now scan scroll, and doesn't take up whole screen, so can click away!
![image](https://user-images.githubusercontent.com/14290674/73362489-3b4b8c80-42a7-11ea-96b6-2ab08c20a217.png)

