### PR TITLE
[map] reset zoom on geoResolution changes in narrative mode

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -76,6 +76,7 @@ class Map extends React.Component {
     this.playPauseButtonClicked = this.playPauseButtonClicked.bind(this);
     this.resetButtonClicked = this.resetButtonClicked.bind(this);
     this.resetZoomButtonClicked = this.resetZoomButtonClicked.bind(this);
+    this.fitMapBoundsToData = this.fitMapBoundsToData.bind(this);
   }
 
   componentWillMount() {
@@ -136,6 +137,13 @@ class Map extends React.Component {
     if (this.props.nodes === null) { return; }
     this.maybeCreateLeafletMap(); /* puts leaflet in the DOM, only done once */
     this.maybeSetupD3DOMNode(); /* attaches the D3 SVG DOM node to the Leaflet DOM node, only done once */
+
+    /* If we are changing the geo resolution in a narrative, then we want to mimic the RESET ZOOM
+    button by resetting the map bounds to fit the data */
+    const mapIsDrawn = !!this.state.map;
+    if (mapIsDrawn && this.props.narrativeMode && prevProps.geoResolution !== this.props.geoResolution) {
+      this.fitMapBoundsToData();
+    }
     this.maybeDrawDemesAndTransmissions(prevProps); /* it's the first time, or they were just removed because we changed dataset or colorby or resolution */
   }
   maybeInvalidateMapSize(nextProps) {
@@ -534,10 +542,13 @@ class Map extends React.Component {
     this.props.dispatch({type: MAP_ANIMATION_PLAY_PAUSE_BUTTON, data: "Play"});
     this.props.dispatch(changeDateFilter({newMin: this.props.absoluteDateMin, newMax: this.props.absoluteDateMax, quickdraw: false}));
   }
-  resetZoomButtonClicked() {
+  fitMapBoundsToData() {
     const SWNE = this.getGeoRange();
-    // L. available because leaflet() was called in componentWillMount
-    this.state.map.fitBounds(L.latLngBounds(SWNE[0], SWNE[1]));
+    // window.L available because leaflet() was called in componentWillMount
+    this.state.map.fitBounds(window.L.latLngBounds(SWNE[0], SWNE[1]));
+  }
+  resetZoomButtonClicked() {
+    this.fitMapBoundsToData();
     this.maybeDrawDemesAndTransmissions();
   }
   getStyles = () => {


### PR DESCRIPTION
See https://github.com/nextstrain/auspice/pull/802#issuecomment-579863257 for context.

Allows narrative pages to specify different geo resolutions and have the display adjust accordingly.
Note that this behavior would also be desirable when viewing normal datasets _if_ the map hasn't been panned / zoomed by the user.

@emmahodcroft can you please test on different datasets / narratives?

My test set was https://github.com/blab/zika-colombia/tree/master/auspice with the following narrative

```json
---
title: RESET ZOOM on ∆geo-res
authors: "James Hadfield"
authorLinks: "https://twitter.com/hamesjadfield"
affiliations: "Fred Hutch, Seattle, USA"
date: "Jan 2020"
dataset: "https://nextstrain.org/zika-colombia?d=tree"
abstract: "Implementing the RESET ZOOM functionality when the geo-resolution changes"
---

# [Showing REGION](localhost:4001/zika-colombia?d=map&r=region)

Map should be south america on left, australia on far right

# [Showing COUNTRY](localhost:4001/zika-colombia?d=map&r=country)

Map should be zoomed in, with the south pacific ocean roughly in the center

```


![map-reset-zoom](https://user-images.githubusercontent.com/8350992/73420660-298de600-4388-11ea-90e1-66415765be4a.gif)
