### PR TITLE
'Reset Zoom' Works when Filters are Set

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -199,11 +199,6 @@ class Map extends React.Component {
     if (mapIsDrawn && allDataPresent && demesTransmissionsNotComputed) {
       timerStart("drawDemesAndTransmissions");
       /* data structures to feed to d3 latLongs = { tips: [{}, {}], transmissions: [{}, {}] } */
-      if (!this.state.boundsSet) { // we are doing the initial render -> set map to the range of the data
-        const SWNE = this.getGeoRange();
-        // L. available because leaflet() was called in componentWillMount
-        this.state.map.fitBounds(L.latLngBounds(SWNE[0], SWNE[1]));
-      }
 
       const {demeData, transmissionData, demeIndices, transmissionIndices} = createDemeAndTransmissionData(
         this.props.nodes,
@@ -230,6 +225,12 @@ class Map extends React.Component {
         this.props.dateMaxNumeric,
         this.props.pieChart
       );
+
+      if (!this.state.boundsSet) { // we are doing the initial render -> set map to the range of the data
+        const SWNE = this.getGeoRange(demeIndices, demeData);
+        // L. available because leaflet() was called in componentWillMount
+        this.state.map.fitBounds(L.latLngBounds(SWNE[0], SWNE[1]));
+      }
 
       /* Set up leaflet events */
       // this.state.map.on("viewreset", this.respondToLeafletEvent.bind(this));

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -296,16 +296,21 @@ class Map extends React.Component {
       this.setState({demeData: newDemes, transmissionData: newTransmissions});
     }
   }
-  getGeoRange() {
+  // Allow to pass in particular demeIndices & demeData for initial render, when these aren't officially set yet
+  getGeoRange(demeIndices = this.state.demeIndices, demeData = this.state.demeData) {
     const latitudes = [];
     const longitudes = [];
 
+    // Check the count data - if it has a count of 0, it's not being drawn, so don't include in Geo range!
     this.props.metadata.geoResolutions.forEach((geoData) => {
       if (geoData.key === this.props.geoResolution) {
         const demeToLatLongs = geoData.demes;
         Object.keys(demeToLatLongs).forEach((deme) => {
-          latitudes.push(demeToLatLongs[deme].latitude);
-          longitudes.push(demeToLatLongs[deme].longitude);
+          if ((!demeIndices && !demeData) || // if we haven't loaded these yet, take all locations
+              (demeIndices && demeData[demeIndices[deme]].count !== 0)) { // if have, only those with counts!
+            latitudes.push(demeToLatLongs[deme].latitude);
+            longitudes.push(demeToLatLongs[deme].longitude);
+          }
         });
       }
     });


### PR DESCRIPTION
Should resolve #863 !

When deciding what lat-longs should be added to set the map resolution, it now checks the `counts` for each deme - if 0, it's not added. 

So, this means you can now select a filter (or multiple) and then click 'reset zoom' and it'll auto-adjust! Most visible with selection regions and stuff, but also works with other filters, too:
![map-zoom-with-filter](https://user-images.githubusercontent.com/14290674/73462348-f6ddf080-437b-11ea-94c7-e178e1a0a994.gif)

At the moment this *doesn't* auto zoom to the right resolution if you load up with a filter in the URL:
![map-zoom-with-filter-loading](https://user-images.githubusercontent.com/14290674/73462502-3278ba80-437c-11ea-84a5-75c09fcb8260.gif)

This requires changing the initial rendering order, and I was unsure if this is ok, or might break something else. I will put this functionality in, in a separate commit, so that it can be reversed or modified if needed!
