### PR TITLE
Totally Dynamic Map Zooming in Narratives

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -642,7 +642,7 @@ export const createStateFromQueryOrJSONs = ({
 
 
   /* calculate colours if loading from JSONs or if the query demands change */
-  if (json || controls.colorBy !== oldState.colorBy) {
+  if (json || controls.colorBy !== oldState.controls.colorBy) {
     const colorScale = calcColorScale(controls.colorBy, controls, tree, treeToo, metadata);
     const nodeColors = calcNodeColor(tree, colorScale);
     controls.colorScale = colorScale;

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -75,7 +75,6 @@ class Map extends React.Component {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md#es6-classes
     this.playPauseButtonClicked = this.playPauseButtonClicked.bind(this);
     this.resetButtonClicked = this.resetButtonClicked.bind(this);
-    this.resetZoomButtonClicked = this.resetZoomButtonClicked.bind(this);
     this.fitMapBoundsToData = this.fitMapBoundsToData.bind(this);
   }
 
@@ -560,10 +559,6 @@ class Map extends React.Component {
     this.state.currentBounds = window.L.latLngBounds(SWNE[0], SWNE[1]);
     this.state.map.fitBounds(window.L.latLngBounds(SWNE[0], SWNE[1]));
   }
-  resetZoomButtonClicked() {
-    this.fitMapBoundsToData();
-    this.maybeDrawDemesAndTransmissions();
-  }
   getStyles = () => {
     const activeResetZoomButton = true;
     return {
@@ -587,7 +582,7 @@ class Map extends React.Component {
         {this.props.narrativeMode ? null : (
           <button
             style={{...tabSingle, ...styles.resetZoomButton}}
-            onClick={this.resetZoomButtonClicked}
+            onClick={this.fitMapBoundsToData}
           >
             reset zoom
           </button>

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -234,10 +234,16 @@ class Map extends React.Component {
         this.props.pieChart
       );
 
+      const SWNE = this.getGeoRange(demeIndices, demeData);
+      const maybeNewBounds = L.latLngBounds(SWNE[0], SWNE[1]);
       if (!this.state.boundsSet) { // we are doing the initial render -> set map to the range of the data
-        const SWNE = this.getGeoRange(demeIndices, demeData);
         // L. available because leaflet() was called in componentWillMount
-        this.state.map.fitBounds(L.latLngBounds(SWNE[0], SWNE[1]));
+        this.state.currentBounds = maybeNewBounds;
+        this.state.map.fitBounds(maybeNewBounds);
+      } else if (!this.state.currentBounds.equals(maybeNewBounds)) {
+        // check to see if the new bounds would be different for any reason - if so, change them!
+        this.state.currentBounds = maybeNewBounds;
+        this.state.map.fitBounds(maybeNewBounds);
       }
 
       /* Set up leaflet events */
@@ -551,6 +557,7 @@ class Map extends React.Component {
   fitMapBoundsToData() {
     const SWNE = this.getGeoRange();
     // window.L available because leaflet() was called in componentWillMount
+    this.state.currentBounds = window.L.latLngBounds(SWNE[0], SWNE[1]);
     this.state.map.fitBounds(window.L.latLngBounds(SWNE[0], SWNE[1]));
   }
   resetZoomButtonClicked() {

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -553,7 +553,9 @@ class Map extends React.Component {
       container = (
         <div style={{position: "relative"}}>
           {this.animationButtons()}
-          <div id="map"
+          <div
+            onClick={() => {this.setState({userHasInteractedWithMap: true});}}
+            id="map"
             style={{
               height: this.state.responsive.height,
               width: this.state.responsive.width
@@ -628,22 +630,21 @@ class Map extends React.Component {
     const transmissionsExist = this.state.transmissionData && this.state.transmissionData.length;
     // clear layers - store all markers in map state https://github.com/Leaflet/Leaflet/issues/3238#issuecomment-77061011
     return (
-      <div style={{display: "inline-block"}} onClick={() => {this.setState({userHasInteractedWithMap: true});}}>
-        <Card center title={transmissionsExist ? "Transmissions" : "Geography"}>
-          {this.maybeCreateMapDiv()}
-          {this.props.narrativeMode ? null : (
-            <button
-              style={{...tabSingle, ...styles.resetZoomButton}}
-              onClick={() => {
-                this.fitMapBoundsToData(this.state.demeData, this.state.demeIndices);
-                this.setState({userHasInteractedWithMap: false});
-              }}
-            >
-              reset zoom
-            </button>
-          )}
-        </Card>
-      </div>
+      <Card center title={transmissionsExist ? "Transmissions" : "Geography"}>
+        {this.maybeCreateMapDiv()}
+        {this.props.narrativeMode ? null : (
+          <button
+            style={{...tabSingle, ...styles.resetZoomButton}}
+            onClick={() => {
+              this.fitMapBoundsToData(this.state.demeData, this.state.demeIndices);
+              console.log("Button click")
+              this.setState({userHasInteractedWithMap: false});
+            }}
+          >
+            reset zoom
+          </button>
+        )}
+      </Card>
     );
   }
 }

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -240,7 +240,7 @@ class Map extends React.Component {
         // L. available because leaflet() was called in componentWillMount
         this.state.currentBounds = maybeNewBounds;
         this.state.map.fitBounds(maybeNewBounds);
-      } else if (!this.state.currentBounds.equals(maybeNewBounds)) {
+      } else if (this.props.narrativeMode && !this.state.currentBounds.equals(maybeNewBounds)) {
         // check to see if the new bounds would be different for any reason - if so, change them!
         this.state.currentBounds = maybeNewBounds;
         this.state.map.fitBounds(maybeNewBounds);

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -115,7 +115,6 @@ class Map extends React.Component {
     }
   }
   componentDidMount() {
-    console.log("CDM");
     this.maybeChangeSize(this.props);
     const removed = this.maybeRemoveAllDemesAndTransmissions(this.props); /* geographic resolution just changed (ie., country to division), remove everything. this change is upstream of maybeDraw */
     // TODO: if demes are color blended circles, updating rather than redrawing demes would do
@@ -125,7 +124,6 @@ class Map extends React.Component {
     this.maybeInvalidateMapSize(this.props);
   }
   componentWillReceiveProps(nextProps) {
-    console.log("CWRP");
     this.modulateInterfaceForNarrativeMode(nextProps);
     this.maybeChangeSize(nextProps);
     const removed = this.maybeRemoveAllDemesAndTransmissions(nextProps); /* geographic resolution just changed (ie., country to division), remove everything. this change is upstream of maybeDraw */
@@ -139,7 +137,6 @@ class Map extends React.Component {
     if (this.props.nodes === null) { return; }
     this.maybeCreateLeafletMap(); /* puts leaflet in the DOM, only done once */
     this.maybeSetupD3DOMNode(); /* attaches the D3 SVG DOM node to the Leaflet DOM node, only done once */
-    console.log("CDU")
     this.maybeDrawDemesAndTransmissionsAndMoveMap(prevProps); /* it's the first time, or they were just removed because we changed dataset or colorby or resolution */
   }
   maybeInvalidateMapSize(nextProps) {
@@ -203,8 +200,6 @@ class Map extends React.Component {
     if (mapIsDrawn && allDataPresent && demesTransmissionsNotComputed) {
       timerStart("drawDemesAndTransmissions");
       /* data structures to feed to d3 latLongs = { tips: [{}, {}], transmissions: [{}, {}] } */
-      console.log("\tDrawDemesAndTransmissions");
-
 
       const {demeData, transmissionData, demeIndices, transmissionIndices} = createDemeAndTransmissionData(
         this.props.nodes,
@@ -270,7 +265,6 @@ class Map extends React.Component {
     const colorByChanged = (nextProps.colorScaleVersion !== this.props.colorScaleVersion);
     if (mapIsDrawn && (geoResolutionChanged || dataChanged || colorByChanged)) {
       this.state.d3DOMNode.selectAll("*").remove();
-      console.log("\tREMOVE")
       this.setState({
         d3elems: null,
         demeData: null,
@@ -301,7 +295,6 @@ class Map extends React.Component {
 
       const newDemes = updateDemeDataLatLong(this.state.demeData, this.state.map);
       const newTransmissions = updateTransmissionDataLatLong(this.state.transmissionData, this.state.map);
-      console.log("\tupdateOnMoveEnd")
       updateOnMoveEnd(
         newDemes,
         newTransmissions,
@@ -314,7 +307,6 @@ class Map extends React.Component {
     }
   }
   getGeoRange(demeData, demeIndices) {
-    console.log("\t\tgetGeoRange");
     const latitudes = [];
     const longitudes = [];
 
@@ -365,7 +357,6 @@ class Map extends React.Component {
 
     if (!(visibilityChange && haveData)) { return; }
 
-    console.log("\tUpdateDemesAndTransmissions")
     timerStart("updateDemesAndTransmissions");
     if (this.props.geoResolution !== nextProps.geoResolution) {
       /* This `if` statement added as part of https://github.com/nextstrain/auspice/issues/722
@@ -579,9 +570,7 @@ class Map extends React.Component {
   }
   moveMapAccordingToData({geoResolutionChanged, visibilityChanged, demeData, demeIndices}) {
     /* Given d3 data (may not be drawn) we can compute map bounds & move as appropriate */
-    console.log("\tmoveMapAccordingToData. userHasInteractedWithMap:", this.state.userHasInteractedWithMap);
     if (!this.state.boundsSet) {
-      console.log("\t\tSetting for the first time");
       /* we are doing the initial render -> set map to the range of the data in view */
       /* P.S. This is how upon initial loading the map zooms into the data */
       this.fitMapBoundsToData(demeData, demeIndices);
@@ -590,7 +579,6 @@ class Map extends React.Component {
 
     /* if we're animating, then we don't want to move the map all the time */
     if (this.props.animationPlayPauseButton === "Pause") {
-      console.log("Animating -> don't move map");
       return;
     }
 
@@ -606,7 +594,6 @@ class Map extends React.Component {
   }
 
   fitMapBoundsToData(demeData, demeIndices) {
-    console.log("\tfitMapBoundsToData");
     const SWNE = this.getGeoRange(demeData, demeIndices);
     // window.L available because leaflet() was called in componentWillMount
     this.state.currentBounds = window.L.latLngBounds(SWNE[0], SWNE[1]);
@@ -637,7 +624,6 @@ class Map extends React.Component {
             style={{...tabSingle, ...styles.resetZoomButton}}
             onClick={() => {
               this.fitMapBoundsToData(this.state.demeData, this.state.demeIndices);
-              console.log("Button click")
               this.setState({userHasInteractedWithMap: false});
             }}
           >

--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -401,6 +401,7 @@ export const createDemeAndTransmissionData = (
   colorBy,
   dispatch
 ) => {
+  console.log("\tcreateDemeAndTransmissionData()");
   /*
     walk through nodes and collect all data
     for demeData we have:

--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -401,7 +401,6 @@ export const createDemeAndTransmissionData = (
   colorBy,
   dispatch
 ) => {
-  console.log("\tcreateDemeAndTransmissionData()");
   /*
     walk through nodes and collect all data
     for demeData we have:

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -210,7 +210,7 @@ const Trait = ({node, trait, colorings}) => {
 const TipClickedPanel = ({tip, goAwayCallback, colorings}) => {
   if (!tip) {return null;}
   const panelStyle = { ...infoPanelStyles.panel};
-  panelStyle.height = "70%";
+  panelStyle.maxHeight = "70%";
   const node = tip.n;
   return (
     <div style={infoPanelStyles.modalContainer} onClick={() => goAwayCallback(tip)}>


### PR DESCRIPTION
This is a super-master PR for all the great Zoom work!

It incorporates my PR for the 'Reset Zoom' working with filter changes. And @jameshadfield's PR for detecting geo_resolution changes in Narratives and changing the zoom. (And my tiny push to master for the tip-boxes - accidentally.)

PLUS something that takes advantage of all of this - and means we can now auto-zoom in narratives if the filter changes (and this would change the geo boundaries).

Here's an example that first uses Jame's auto-switch for changing the geo-resolution, then mine for detecting a filter change!:
![narrative-all-auto-zoom](https://user-images.githubusercontent.com/14290674/73475115-05ce9e00-4390-11ea-97b4-4ff17b81a6ea.gif)

We can start doing some very cool stuff with this! It would be great to use this, and the cluster zoom, to do some neat stuff in the next nCoV narrative update :)