### PR TITLE
fix(styles): navigation progress buttons to not align properly on IE

### DIFF
--- a/src/components/narrative/styles.js
+++ b/src/components/narrative/styles.js
@@ -163,6 +163,11 @@ export const ProgressButton = styled.div`
   background: #74a9cf;
   border-radius: 50%;
   cursor: pointer;
+
+  // BEGIN: mitigate ie flexbug-15: https://github.com/philipwalton/flexbugs#flexbug-15
+  align-self: center;
+  margin: auto;
+  // END mitigate ie flexbug-15
 `;
 
 const baseBannerStyles = css`


### PR DESCRIPTION
@kairstenfay
Hi Kairsten,

Pardon me for this blatant intrusion into your private branch.

I was [playing with IE fixes today](https://github.com/nextstrain/nextstrain.org/pull/109) and noticed that one of the styling bugs is much easier to fix on your branch (compared to master). It probably will be merged soon(ish) anyway, right? So I decided to base my fix here, rather that dealing with master, which has the component in question in a bit of a hairy state.

Anyways, this commit fixes navigation progress buttons to not align properly in flexbox container when browsing using Internet Explorer (any version).

This is, what I believe to be a browser bug, so called "flexbug-15" as described in:
https://github.com/philipwalton/flexbugs#flexbug-15
I applied the workaround as described there.

Originally reported by @emmahodcroft at: https://github.com/nextstrain/auspice/issues/655


There are still styling issues in IE, but at least working navigation makes narrative usable for these folks who still use IE.

Before: 
![before](https://user-images.githubusercontent.com/9403403/73497859-08df8380-43bc-11ea-98a9-5c6f8134e444.png)

After: 
![after](https://user-images.githubusercontent.com/9403403/73497882-16950900-43bc-11ea-96b4-a97ff9f1a3b8.png)

Do you think you can merge these changes along with yours?
