### PR TITLE
fix(styles): navigation progress buttons to not align properly on IE (version for master branch)

### DIFF
--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -116,7 +116,7 @@ class Narrative extends React.Component {
             "14px" : "6px";
           return (<div
             key={i}
-            style={{width: d, height: d, background: "#74a9cf", borderRadius: "50%", cursor: "pointer"}}
+            style={{width: d, height: d, background: "#74a9cf", borderRadius: "50%", cursor: "pointer", alignSelf: 'center', margin: 'auto' }}
             onClick={() => this.reactPageScroller.goToPage(i)}
           />);
         })}


### PR DESCRIPTION
This is a temporary fix, for what will **probably** become available after branch https://github.com/nextstrain/auspice/tree/narrative-mobile is merged.

This temporary fix would allow IE users to enjoy proper navigation in narratives until the layout is reworked in `narrative-mobile`.

Refer to the sibling PR to branch `narrative-mobile` https://github.com/nextstrain/auspice/pull/875 for more details.
