### PR TITLE
Narrative: explore data & leave narrative 

### DIFF
--- a/src/components/main/index.js
+++ b/src/components/main/index.js
@@ -128,7 +128,9 @@ class Main extends React.Component {
           navBarHandler={() => {this.setState({sidebarOpen: !this.state.sidebarOpen});}}
         />
         <PanelsContainer width={availableWidth} height={availableHeight} left={this.state.sidebarOpen ? sidebarWidth : 0}>
-          {this.props.narrativeIsLoaded ? renderNarrativeToggle(this.props.dispatch, this.props.displayNarrative) : null}
+          {this.props.narrativeIsLoaded && !this.props.panelsToDisplay.includes("EXPERIMENTAL_MainDisplayMarkdown") ?
+            renderNarrativeToggle(this.props.dispatch, this.props.displayNarrative) : null
+          }
           {this.props.displayNarrative ? null : <Info width={calcUsableWidth(availableWidth, 1)} />}
           {this.props.panelsToDisplay.includes("tree") ? <Tree width={big.width} height={big.height} /> : null}
           {this.props.panelsToDisplay.includes("map") ? <Map width={big.width} height={big.height} justGotNewDatasetRenderNewMap={false} /> : null}

--- a/src/components/narrative/MobileNarrativeDisplay.js
+++ b/src/components/narrative/MobileNarrativeDisplay.js
@@ -4,7 +4,6 @@ import React from "react";
 import { connect } from "react-redux";
 import queryString from "query-string";
 import { changePage, EXPERIMENTAL_showMainDisplayMarkdown } from "../../actions/navigation";
-import { TOGGLE_NARRATIVE } from "../../actions/types";
 import {
   linkStyles,
   MobileBannerTop,
@@ -61,7 +60,7 @@ class MobileNarrativeDisplay extends React.Component {
     };
 
     this.exitNarrativeMode = () => {
-      this.props.dispatch({type: TOGGLE_NARRATIVE, display: false});
+      this.props.dispatch(changePage({ path: this.props.blocks[0].dataset, query: true }));
     };
 
     this.goToNextPage = () => {

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -14,7 +14,7 @@ import {
 } from './styles';
 import ReactPageScroller from "./ReactPageScroller";
 import { changePage, EXPERIMENTAL_showMainDisplayMarkdown } from "../../actions/navigation";
-import { CHANGE_URL_QUERY_BUT_NOT_REDUX_STATE, TOGGLE_NARRATIVE } from "../../actions/types";
+import { CHANGE_URL_QUERY_BUT_NOT_REDUX_STATE } from "../../actions/types";
 import { narrativeNavBarHeight } from "../../util/globals";
 
 /* regarding refs: https://reactjs.org/docs/refs-and-the-dom.html#exposing-dom-refs-to-parent-components */
@@ -41,7 +41,7 @@ class Narrative extends React.Component {
     super(props);
     this.state = {showingEndOfNarrativePage: false};
     this.exitNarrativeMode = () => {
-      this.props.dispatch({type: TOGGLE_NARRATIVE, display: false});
+      this.props.dispatch(changePage({ path: this.props.blocks[0].dataset, query: true }));
     };
     this.changeAppStateViaBlock = (reactPageScrollerIdx) => {
       const idx = reactPageScrollerIdx-1;


### PR DESCRIPTION
This PR resolves #871 

1. Hide "Explore the data yourself" button when on main display markdown page
2. Clicking on "Leave the narrative..." button completely exits the narrative and changes to the dataset page.