### PR TITLE
fix: ensure Lato font correctly falls back to sans-serif

### DIFF
--- a/src/components/narrative/styles.js
+++ b/src/components/narrative/styles.js
@@ -144,7 +144,7 @@ export const linkStyles = { // would be better to get CSS specificity working
   color: "#5097BA",
   textDecoration: "none",
   cursor: "pointer",
-  fontFamily: "Lato",
+  fontFamily: `"Lato", "Helvetica Neue", "Helvetica", "sans-serif"`,
   fontWeight: "400",
   fontSize: "1.8em"
 };

--- a/src/css/entropy.css
+++ b/src/css/entropy.css
@@ -15,7 +15,7 @@
 }
 
 #d3entropy .niceText {
-  font-family: "Lato";
+  font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-size: 14px;
   font-style: italic;
   color: var(--medGrey);

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -33,7 +33,7 @@ a, .link {
   color: #5097BA;
   text-decoration: none;
   cursor: pointer;
-  font-family: "Lato";
+  font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-weight: 400;
   font-size: 94%;
 }

--- a/src/css/static.css
+++ b/src/css/static.css
@@ -131,7 +131,7 @@ strong {
   color: #5097BA;
   text-decoration: none;
   cursor: pointer;
-  font-family: "Lato";
+  font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-weight: 400;
   font-size: 94%;
 }


### PR DESCRIPTION
Currently, some of the text elements, for example `<a/>`, are forced to be rendered using Lato font (which is a sans-serif font). When text contains Unicode characters (for example, from Chinese and Cyrillic alphabets) which are missing in our current version of Lato font, these characters are automatically substituted from other fonts.

However, this substitution is unpredictable (depends on browser implementation, platform, font and characters in question) and in some cases leads to inconsistent results.

This adds Helvetica and sans-serif alternatives to the places where only Lato was specified, thus at least ensuring that Unicode will properly falls back to sans.

Example with Russian:

Before - Cyrillic characters in these `<a/>` tags on my machine are rendered with Tinos font, which is serif and looks smaller:
![ru_serif](https://user-images.githubusercontent.com/9403403/73599090-f726e900-453f-11ea-950f-4feb9fbf4e79.png)

After - Cyrillic characters in these `<a/>` tags are rendered with Arimo font (sans):
![ru_sans](https://user-images.githubusercontent.com/9403403/73599105-305f5900-4540-11ea-8828-959555e63fc6.png)

