### PR TITLE
Prototype of SVG gradient for tree branches

### DIFF
--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -370,8 +370,11 @@ export const mapToScreen = function mapToScreen() {
     this.nodes.forEach((d) => {
       const stem_offset = 0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0;
       const childrenY = [this.yScale(d.yRange[0]), this.yScale(d.yRange[1])];
+      // Note that a branch cannot be perfectly horizontal and also have a (linear) gradient applied to it
+      // So we add a tiny amount of jitter (e.g 1/1000px) to the horizontal line (d.branch[0])
+      // see https://stackoverflow.com/questions/13223636/svg-gradient-for-perfectly-horizontal-path
       d.branch =[
-        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip}`],
+        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip+0.001}`],
         [` M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`]
       ];
       if (this.params.confidence) {

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -370,7 +370,10 @@ export const mapToScreen = function mapToScreen() {
     this.nodes.forEach((d) => {
       const stem_offset = 0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0;
       const childrenY = [this.yScale(d.yRange[0]), this.yScale(d.yRange[1])];
-      d.branch =[` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip} M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`];
+      d.branch =[
+        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip}`],
+        [` M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`]
+      ];
       if (this.params.confidence) {
         d.confLine =` M ${this.xScale(d.conf[0])},${d.yBase} L ${this.xScale(d.conf[1])},${d.yTip}`;
       }

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -63,6 +63,7 @@ PhyloTree.prototype.drawBranches = renderers.drawBranches;
 PhyloTree.prototype.drawVaccines = renderers.drawVaccines;
 PhyloTree.prototype.drawRegression = renderers.drawRegression;
 PhyloTree.prototype.removeRegression = renderers.removeRegression;
+PhyloTree.prototype.makeLinearGradient = renderers.makeLinearGradient;
 
 /* C A L C U L A T E    G E O M E T R I E S  E T C   ( M O D I F I E S    N O D E S ,    N O T    S V G ) */
 PhyloTree.prototype.setDistance = layouts.setDistance;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -171,6 +171,22 @@ export const drawBranches = function drawBranches() {
   }
 
   /* PART 2: draw the branch stems (i.e. the actual branches) */
+
+  /* PART 2a: Create linear gradient definitions which can be applied to branch stems for which
+  the start & end stroke colour is different */
+  if (!this.groups.branchGradientDefs) {
+    this.groups.branchGradientDefs = this.svg.append("defs");
+  }
+  this.groups.branchGradientDefs.selectAll("*").remove();
+  // TODO -- explore if duplicate <def> elements (e.g. same colours on each end) slow things down
+  this.nodes.forEach((d) => {
+    const a = d.parent.branchStroke;
+    const b = d.branchStroke;
+    if (a===b) return;
+    this.makeLinearGradient(`${d.parent.n.arrayIdx}:${d.n.arrayIdx}`, [[0, a], [100, b]]);
+  });
+
+  /* PART 2b: Draw the stems */
   if (!("branchStem" in this.groups)) {
     this.groups.branchStem = this.svg.append("g").attr("id", "branchStem");
   }
@@ -182,10 +198,15 @@ export const drawBranches = function drawBranches() {
         .attr("class", "branch S")
         .attr("id", (d) => getDomId("branchS", d.n.name))
         .attr("d", (d) => d.branch[0])
-        .style("stroke", (d) => d.branchStroke || params.branchStroke)
+        .style("stroke", (d) => {
+          if (!d.branchStroke) return params.branchStroke;
+          if (d.branchStroke === d.parent.branchStroke) {
+            return d.branchStroke;
+          }
+          return `url(#${d.parent.n.arrayIdx}:${d.n.arrayIdx})`;
+        })
         .style("stroke-linecap", "round")
-        .style("stroke-width", (d) => d['stroke-width']+"px" || params.branchStrokeWidth)
-        .style("fill", "none")
+        .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
         .style("visibility", getBranchVisibility)
         .style("cursor", (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default")
         .style("pointer-events", "auto")
@@ -243,6 +264,20 @@ export const removeRegression = function removeRegression() {
  */
 export const clearSVG = function clearSVG() {
   this.svg.selectAll("*").remove();
+};
+
+export const makeLinearGradient = function makeLinearGradient(id, stops) {
+  const linearGradient = this.groups.branchGradientDefs.append("linearGradient")
+    .attr("id", id)
+    .attr("x1", "0%") // TODO -- customise these via args, will be needed for non horizontal lines
+    .attr("x2", "100%")
+    .attr("y1", "0%")
+    .attr("y2", "0%");
+  stops.forEach((stop) => {
+    linearGradient.append("stop")
+    .attr("offset", `${stop[0]}%`)
+    .attr("stop-color", stop[1]);
+  });
 };
 
 function getRateEstimate(regression, maxDivergence) {

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -1,10 +1,7 @@
-import { rgb } from "d3-color";
-import { interpolateRgb } from "d3-interpolate";
 import { updateVisibleTipsAndBranchThicknesses} from "../../../actions/tree";
-import { branchOpacityFunction } from "../../../util/colorHelpers";
+import { getEmphasizedColor } from "../../../util/colorHelpers";
 import { NODE_VISIBLE } from "../../../util/globals";
 import { getDomId } from "../phyloTree/helpers";
-import { getTraitFromNode } from "../../../util/treeMiscHelpers";
 
 /* Callbacks used by the tips / branches when hovered / selected */
 
@@ -38,22 +35,24 @@ export const onTipClick = function onTipClick(d) {
 
 export const onBranchHover = function onBranchHover(d) {
   if (d.visibility !== NODE_VISIBLE) return;
-  /* emphasize the color of the branch */
+
+  /* We want to emphasize the colour of the branch. How we do this depends on how the branch was rendered in the first place! */
+  const emphasizedStrokeColor = getEmphasizedColor(d.branchStroke);
+
   for (const id of [getDomId("#branchS", d.n.name), getDomId("#branchT", d.n.name)]) {
-    if (this.props.colorByConfidence) {
-      this.state.tree.svg.select(id)
-        .style("stroke", (el) => { // eslint-disable-line no-loop-func
-          const entropyValue = getTraitFromNode(this.props.tree.nodes[el.n.arrayIdx], this.props.colorBy, {entropy: true});
-          const ramp = branchOpacityFunction(entropyValue);
-          const raw = this.props.tree.nodeColors[el.n.arrayIdx];
-          const base = el.branchStroke;
-          return rgb(interpolateRgb(raw, base)(ramp)).toString();
-        });
+    const el = this.state.tree.svg.select(id);
+    if (el.empty()) continue; // Some displays don't have S & T parts of the branch
+    const currentStroke = el.style("stroke");
+    if (currentStroke.startsWith("url")) {
+      const gradientId = `${d.parent.n.arrayIdx}:${d.n.arrayIdx}:highlighted`;
+      d.that.makeLinearGradient(gradientId, [[0, getEmphasizedColor(d.parent.branchStroke)], [100, emphasizedStrokeColor]]);
+      el.style("stroke", `url(#${gradientId})`);
     } else {
-      this.state.tree.svg.select(id)
-        .style("stroke", (el) => this.props.tree.nodeColors[el.n.arrayIdx]);
+      el.style("stroke", emphasizedStrokeColor);
     }
   }
+
+  /* if temporal confidence bounds are defined for this branch, then display them on hover */
   if (this.props.temporalConfidence.exists && this.props.temporalConfidence.display && !this.props.temporalConfidence.on) {
     const tree = d.that.params.orientation[0] === 1 ? this.state.tree : this.state.treeToo;
     if (!("confidenceIntervals" in tree.groups)) {
@@ -65,6 +64,8 @@ export const onBranchHover = function onBranchHover(d) {
       .enter()
         .call((sel) => tree.drawSingleCI(sel, 0.5));
   }
+
+  /* Set the hovered state so that an info box can be displayed */
   this.setState({
     hovered: {d, type: ".branch"}
   });
@@ -102,14 +103,28 @@ export const onBranchClick = function onBranchClick(d) {
 
 /* onBranchLeave called when mouse-off, i.e. anti-hover */
 export const onBranchLeave = function onBranchLeave(d) {
+  /* Reset the stroke back to what it was before */
   for (const id of [getDomId("#branchT", d.n.name), getDomId("#branchS", d.n.name)]) {
-    this.state.tree.svg.select(id)
-      .style("stroke", (el) => el.branchStroke);
+    const el = this.state.tree.svg.select(id);
+    if (el.empty()) continue; // Some displays don't have S & T parts of the branch
+    const currentStroke = el.style("stroke");
+    if (currentStroke.startsWith("url")) {
+      el.style("stroke", `url(#${d.parent.n.arrayIdx}:${d.n.arrayIdx})`);
+      /* remove the <def> of the highlighed (hovered) state */
+      d.that.groups.branchGradientDefs
+        .selectAll("linearGradient")
+        .filter((_, i, l) => l.length-1 === i)
+        .remove();
+    } else {
+      el.style("stroke", (dd) => dd.branchStroke);
+    }
   }
+  /* Remove the temporal confidence bar unless it's meant to be displayed */
   if (this.props.temporalConfidence.exists && this.props.temporalConfidence.display && !this.props.temporalConfidence.on) {
     const tree = d.that.params.orientation[0] === 1 ? this.state.tree : this.state.treeToo;
     tree.removeConfidence();
   }
+  /* Set hovered state to `null`, which will remove the info box */
   if (this.state.hovered) {
     this.setState({hovered: null});
   }

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -1,4 +1,4 @@
-import { rgb } from "d3-color";
+import { rgb, hsl } from "d3-color";
 import { interpolateRgb } from "d3-interpolate";
 import { scalePow } from "d3-scale";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
@@ -103,4 +103,15 @@ export const calcBranchStrokeCols = (tree, confidence, colorBy) => {
   return tree.nodeColors.map((col) => {
     return rgb(interpolateRgb(col, branchInterpolateColour)(branchOpacityConstant)).toString();
   });
+};
+
+
+/**
+ * Return an emphasized color
+ */
+export const getEmphasizedColor = (color) => {
+  const hslColor = hsl(color);
+  hslColor.s *= 1.8; // more saturation
+  hslColor.l /= 1.2; // less luminance
+  return rgb(hslColor).toString();
 };


### PR DESCRIPTION
See #896 for intention.

![image](https://user-images.githubusercontent.com/8350992/74618029-f1aedd00-5194-11ea-9916-06c6a75dfa4c.png)

This requires using SVG `rect`angles for the branch stem as gradients are overly complex to add to `path`s. As such, lots of things are broken (e.g. all layouts except rect), and some functionality (branch hover colour changes, branch click to zoom) is disabled here.

I think it looks really good, but wanted to discuss this before we commit to cleaning up the code so that previous functionality is restored. cc @trvrb @rneher 

