### PR TITLE
Slightly revise entropy blending on branches

### DIFF
--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -73,13 +73,13 @@ export const calcNodeColor = (tree, colorScale) => {
 };
 
 
+// scale entropy such that higher entropy maps to a grayer less-certain branch
 const branchInterpolateColour = "#BBB";
 const branchOpacityConstant = 0.6;
-const branchOpacityLowerBound = 0.4;
 export const branchOpacityFunction = scalePow()
-  .exponent([0.3])
-  .domain([0, 1])
-  .range([branchOpacityLowerBound, 1])
+  .exponent([0.6])
+  .domain([0, 2.0])
+  .range([0.4, 1])
   .clamp(true);
 // entropy calculation precomputed in augur
 // export const calcEntropyOfValues = (vals) =>


### PR DESCRIPTION
It had been such that a branch with 80% certainty in a particular location was completely gray. This felt off. In the revised behavior, we hit fully gray at about 50% certainty. This originally leaned quite heavily on gray because we were concerned that measures like 80% shouldn't actually be interpreted as "80%" due to over-confidence in the phylogeo reconstruction. Now, augur traits has `--sampling-bias-correction`, which corrects this at the source. Better to have auspice give an honest accounting at this point.

Viewable in Heroku review app. A couple good places to look:
* https://auspice-entropy-blendin-vnbbv2.herokuapp.com/dengue/denv1?c=region
* https://auspice-entropy-blendin-vnbbv2.herokuapp.com/ncov
* https://auspice-entropy-blendin-vnbbv2.herokuapp.com/flu/seasonal/h3n2/ha/2y?c=region