### PR TITLE
Improve which branches we display labels for

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -69,19 +69,26 @@ const branchLabelFontWeight = (key) => {
  * @param {str} key e.g. "aa" or "clade"
  * @param {str} layout
  * @param {int} totalTipsInView visible tips also in view
- * @return {func||str}
+ * @return {func||str} Returns either a string ("visible") or a function.
+ *                     The function returned is handed nodes and returns either
+ *                     "visible" or "hidden". This function should only be
+ *                     provided nodes for which the label exists on that node.
  */
 const createBranchLabelVisibility = (key, layout, totalTipsInView) => {
-  if (key === "clade") return "visible";
+  if (key !== "aa") return "visible";
   const magicTipFractionToShowBranchLabel = 0.05;
   return (d) => {
+    if (layout !== "rect") {
+      return "hidden";
+    }
+    /* if any other labelling is defined on the branch, then show AA mutations */
+    if (Object.keys(d.n.branch_attrs.labels).filter((k) => k!=="aa").length) {
+      return "visible";
+    }
     /* if the number of _visible_ tips descending from this node are over the
     magicTipFractionToShowBranchLabel (c/w the total numer of _visible_ and
     _inView_ tips then display the label */
-    if (
-      d.n.tipCount > magicTipFractionToShowBranchLabel * totalTipsInView &&
-      layout === "rect"
-    ) {
+    if (d.n.tipCount > magicTipFractionToShowBranchLabel * totalTipsInView) {
       return "visible";
     }
     return "hidden";


### PR DESCRIPTION
Auspice was build during a time when only "clade" and "aa" labels existed. We always showed labels for the former, and only showed the latter for branches with a large number of descendants.

Auspice now supports different labels, and this commit makes it so that any non "aa" label is always displayed. "aa" labels are shown if the branch has any other labels defined or if there are enough descendants.

See #905 for more information.