### PR TITLE
[tree] Don't allow tiny x-axis domains

### DIFF
--- a/scripts/get-data.sh
+++ b/scripts/get-data.sh
@@ -53,6 +53,7 @@ data_files=(
   "flu_seasonal_yam_na_3y.json" "flu_seasonal_yam_na_3y_tip-frequencies.json" \
   "flu_seasonal_yam_na_6y.json" "flu_seasonal_yam_na_6y_tip-frequencies.json" \
   "flu_seasonal_yam_na_12y.json" "flu_seasonal_yam_na_12y_tip-frequencies.json" \
+  "tb_global_meta.json" "tb_global_tree.json" \
   "enterovirus_d68_genome_meta.json" "enterovirus_d68_genome_tree.json" \
   "enterovirus_d68_vp1_meta.json" "enterovirus_d68_vp1_tree.json" \
   "ncov.json" "ncov_2020-01-25.json" "ncov_2020-01-23.json" \

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -324,12 +324,20 @@ export const mapToScreen = function mapToScreen() {
     maxY += delta;
   }
 
+  /* Don't allow tiny x-axis domains -- e.g. if zoomed into a polytomy where the
+  divergence values are all tiny, then we don't want to display the tree topology */
+  const minimumXAxisSpan = 1E-8;
+  let spanX = maxX-minX;
+  if (spanX < minimumXAxisSpan) {
+    maxX = minimumXAxisSpan - minX;
+    spanX = minimumXAxisSpan;
+  }
+
   /* set the domain of the x & y scales */
   if (this.layout === "radial" || this.layout === "unrooted") {
     // handle "radial and unrooted differently since they need to be square
     // since branch length move in x and y direction
     // TODO: should be tied to svg dimensions
-    const spanX = maxX-minX;
     const spanY = maxY-minY;
     const maxSpan = max([spanY, spanX]);
     const ySlack = (spanX>spanY) ? (spanX-spanY)*0.5 : 0.0;


### PR DESCRIPTION
Don't allow tiny x-axis domains -- e.g. if zoomed into a polytomy where the divergence values are all tiny, then we don't want to display the tree topology.

The threshold for tiny is set here arbitrarily at 1E-8, however this will become problematic if we get eukaryotic genomes in nextstrain.

Added the TB dataset so that we can test that in review apps.

Closes #901

Looks good for rectangular trees. Radial / unrooted don't look great, but that's not a regression and needs more work in the future.

![image](https://user-images.githubusercontent.com/8350992/75299097-10019080-5899-11ea-8e47-e6fa5c9acd2d.png)
