### PR TITLE
Allows "Unknown" and other city names in geo demes

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -316,8 +316,11 @@ class Map extends React.Component {
       if (geoData.key === this.props.geoResolution) {
         const demeToLatLongs = geoData.demes;
         Object.keys(demeToLatLongs).forEach((deme) => {
-          if (!demeIndices || !demeData) {
+          if (!demeIndices || !demeData || !demeIndices[deme]) {
             /* include them all */
+            if (!demeIndices[deme]) {
+              console.warn("This location is missing from demeIndices: " + deme);
+            }
             latitudes.push(demeToLatLongs[deme].latitude);
             longitudes.push(demeToLatLongs[deme].longitude);
           } else {


### PR DESCRIPTION
Fixes #907 by outputting a ```console.warn``` but otherwise gracefully continues when a city name is unknown, with lat/lng provided or blank.

I don't know how to activate the transmission-routes view which you see on NextStrain to test that, but I did see the code in mapHelpersLatLong which is already written to filter out Unknown.