### PR TITLE
Handle long names in tree legend

### DIFF
--- a/src/components/tree/legend/item.js
+++ b/src/components/tree/legend/item.js
@@ -4,7 +4,6 @@ import { dataFont, darkGrey } from "../../../globalStyles";
 
 const LegendItem = ({
   dispatch,
-  transform,
   legendRectSize,
   legendSpacing,
   rectStroke,
@@ -12,30 +11,35 @@ const LegendItem = ({
   label,
   value
 }) => (
-  <g
-    transform={transform}
+  <li
     onMouseEnter={() => {
       dispatch(updateTipRadii({selectedLegendItem: value}));
     }}
     onMouseLeave={() => {
       dispatch(updateTipRadii());
     }}
+    style={{listStyleType: "none", marginLeft: "10px", marginBottom: "2px"}}
   >
-    <rect
-      style={{strokeWidth: 2}}
-      width={legendRectSize}
-      height={legendRectSize}
-      fill={rectFill}
-      stroke={rectStroke}
-    />
-    <text
+    <span
+      style={{
+        float: "left",
+        width: (legendRectSize-2) + "px",
+        height: (legendRectSize-2) + "px",
+        background: rectFill,
+        border: "2px solid " + rectStroke,
+        marginRight: "8px"
+      }}>
+    </span>
+    <span
       x={legendRectSize + legendSpacing + 5}
       y={legendRectSize - legendSpacing}
-      style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}
+      style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont, overflowWrap: "anywhere"}}
     >
       {label}
-    </text>
-  </g>
+    </span>
+    <div style={{clear:"both"}}>
+    </div>
+  </li>
 );
 
 export default LegendItem;

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -59,15 +59,6 @@ class Legend extends React.Component {
     return this.getTitleWidth() + 20;
   }
 
-  getTransformationForLegendItem(i) {
-    const count = this.props.colorScale.legendValues.length;
-    const stack = Math.ceil(count / 2);
-    const fromRight = Math.floor(i / stack);
-    const fromTop = (i % stack);
-    const horz = fromRight * 145 + 10;
-    const vert = fromTop * (legendRectSize + legendSpacing);
-    return "translate(" + horz + "," + vert + ")";
-  }
   getTitleString() {
     if (isColorByGenotype(this.props.colorBy)) {
       const genotype = decodeColorByGenotype(this.props.colorBy);
@@ -169,7 +160,6 @@ class Legend extends React.Component {
             legendSpacing={legendSpacing}
             rectFill={rgb(this.props.colorScale.scale(d)).brighter([0.35]).toString()}
             rectStroke={rgb(this.props.colorScale.scale(d)).toString()}
-            transform={this.getTransformationForLegendItem(i)}
             key={d}
             value={d}
             label={this.styleLabelText(d)}
@@ -185,12 +175,11 @@ class Legend extends React.Component {
     //   transition: `${fastTransitionDuration}ms ease-in-out`
     //   }}>
     return (
-      <g id="ItemsContainer">
-        <rect width="290" height={this.getSVGHeight()} fill="rgba(255,255,255,.85)"/>
-        <g id="Items" transform="translate(0,20)">
+      <div id="ItemsContainer">
+        <ul id="Items" style={{"-moz-columns": 2, "-webkit-columns": 2, columns: 2, marginBlockStart: 0, marginBlockEnd: 0, paddingInlineStart: 0, background: "rgba(255,255,255,.85)"}}>
           {items}
-        </g>
-      </g>
+        </ul>
+      </div>
     );
   }
 
@@ -214,9 +203,13 @@ class Legend extends React.Component {
         id="TreeLegendContainer"
         width={this.getSVGWidth()}
         height={this.getSVGHeight()}
-        style={styles.svg}
+        style={{...styles.svg, overflow: "visible"}}
       >
-        {this.legendItems()}
+        <foreignObject x="0" y="20" width={this.getSVGWidth()} height={this.getSVGHeight()}
+          style={this.state.legendVisible ? null : {display: "none"}}
+        >
+          {this.legendItems()}
+        </foreignObject>
         <g
           id="TitleAndChevron"
           onClick={() => this.toggleLegend()}

--- a/src/css/browserCompatability.css
+++ b/src/css/browserCompatability.css
@@ -392,3 +392,17 @@ optgroup {
    ==========================================================================
    MOVED TO GLOBAL.CSS
    */
+
+/**
+ * Safari and Firefox overflowing text in tree legend
+ */
+_:default:not(:root:root), #ItemsContainer li span {
+  float: left;
+  word-break: break-all;
+  max-width: 102px;
+}
+@-moz-document url-prefix() {
+  #ItemsContainer li span {
+    word-break: break-all;
+  }
+}


### PR DESCRIPTION
Potential fix for #899 - long names in the legend of the tree view. I considered long labels with and without any whitespace

The current menu (SVG, absolute positions) is replaced with HTML + CSS.

Chrome-based browsers work best - in the middle left column you can see samples which carry over to a second line:

![Screen Shot 2020-03-01 at 2 42 14 AM](https://user-images.githubusercontent.com/643918/75622920-6873af00-5b73-11ea-904b-62ae248061bd.png)

Firefox and Safari, with identical settings, would move a long label without whitespace over to the next line:

![Screen Shot 2020-03-01 at 3 02 13 AM](https://user-images.githubusercontent.com/643918/75622963-c30d0b00-5b73-11ea-922c-e9ea1438c523.png)

With some CSS for compatibility, Firefox and Safari are now level with the other labels. The downside is they will break a word if it overflows

![Screen Shot 2020-03-01 at 4 09 17 AM](https://user-images.githubusercontent.com/643918/75622936-8fca7c00-5b73-11ea-9912-0df1faa61711.png)
