### PR TITLE
Fix Windows drag & drop bug

### DIFF
--- a/src/actions/filesDropped/constants.js
+++ b/src/actions/filesDropped/constants.js
@@ -1,0 +1,18 @@
+/*
+    Defines acceptable file types for the auspice drag & drop functionality.
+*/
+
+const csv_file_types = ["text/csv", "application/vnd.ms-excel"];
+
+// Add MacOS & Linux .tsv to accepted file types
+const accepted_file_types = csv_file_types.concat("text/tab-separated-values");
+
+// Handle Windows .tsv edge case with empty file type
+const is_windows_tsv = (file) => file.type === "" && file.name.endsWith('.tsv');
+
+const is_csv_or_tsv = (file) => accepted_file_types.includes(file.type) || is_windows_tsv(file);
+
+export {
+  csv_file_types,
+  is_csv_or_tsv
+};

--- a/src/actions/filesDropped/index.js
+++ b/src/actions/filesDropped/index.js
@@ -17,7 +17,11 @@ const handleFilesDropped = (files) => (dispatch, getState) => {
 
   const file = files[0];
   const accepted_file_types = ["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"];
-  if (accepted_file_types.includes(file.type)) {
+
+  // Handle Windows .tsv edge case
+  const is_windows_tsv = file.type === "" && file.name.endsWith('.tsv');
+
+  if (accepted_file_types.includes(file.type) || is_windows_tsv) {
     return handleMetadata(dispatch, getState, file);
   }
 

--- a/src/actions/filesDropped/index.js
+++ b/src/actions/filesDropped/index.js
@@ -1,5 +1,6 @@
 import { warningNotification } from "../notifications";
 import handleMetadata from "./metadata";
+import { is_csv_or_tsv } from "./constants";
 
 
 /**
@@ -16,12 +17,8 @@ const handleFilesDropped = (files) => (dispatch, getState) => {
   }
 
   const file = files[0];
-  const accepted_file_types = ["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"];
 
-  // Handle Windows .tsv edge case
-  const is_windows_tsv = file.type === "" && file.name.endsWith('.tsv');
-
-  if (accepted_file_types.includes(file.type) || is_windows_tsv) {
+  if (is_csv_or_tsv(file)) {
     return handleMetadata(dispatch, getState, file);
   }
 

--- a/src/actions/filesDropped/index.js
+++ b/src/actions/filesDropped/index.js
@@ -16,7 +16,8 @@ const handleFilesDropped = (files) => (dispatch, getState) => {
   }
 
   const file = files[0];
-  if (file.type === "text/csv" || file.type === "text/tab-separated-values") {
+  const accepted_file_types = ["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"];
+  if (accepted_file_types.includes(file.type)) {
     return handleMetadata(dispatch, getState, file);
   }
 

--- a/src/actions/filesDropped/metadata.js
+++ b/src/actions/filesDropped/metadata.js
@@ -1,6 +1,7 @@
 import Papa from "papaparse";
 import { errorNotification, successNotification, warningNotification } from "../notifications";
 import { ADD_COLOR_BYS } from "../types";
+import { csv_file_types, is_csv_or_tsv } from "./constants";
 
 
 /**
@@ -12,8 +13,7 @@ import { ADD_COLOR_BYS } from "../types";
  * @param {DataTransfer} file a DataTransfer object
  */
 const parseCsv = (file) => new Promise((resolve, reject) => {
-  const is_windows_tsv = file.type === "" && file.name.endsWith('.tsv');
-  if (!(["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"].includes(file.type) || is_windows_tsv)) {
+  if (!(is_csv_or_tsv(file))) {
     reject(new Error("Cannot parse this filetype"));
   }
   Papa.parse(file, {
@@ -26,7 +26,7 @@ const parseCsv = (file) => new Promise((resolve, reject) => {
     },
     encoding: "UTF-8",
     comments: "#",
-    delimiter: (file.type === "text/csv" || file.type === 'application/vnd.ms-excel') ? "," : "\t",
+    delimiter: (csv_file_types.includes(file.type)) ? "," : "\t",
     skipEmptyLines: true,
     dynamicTyping: false
   });

--- a/src/actions/filesDropped/metadata.js
+++ b/src/actions/filesDropped/metadata.js
@@ -12,7 +12,7 @@ import { ADD_COLOR_BYS } from "../types";
  * @param {DataTransfer} file a DataTransfer object
  */
 const parseCsv = (file) => new Promise((resolve, reject) => {
-  if (!["text/csv", "text/tab-separated-values"].includes(file.type)) {
+  if (!["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"].includes(file.type)) {
     reject(new Error("Cannot parse this filetype"));
   }
   Papa.parse(file, {
@@ -25,7 +25,7 @@ const parseCsv = (file) => new Promise((resolve, reject) => {
     },
     encoding: "UTF-8",
     comments: "#",
-    delimiter: file.type === "text/csv" ? "," : "\t",
+    delimiter: (file.type === "text/csv" || file.type === 'application/vnd.ms-excel') ? "," : "\t",
     skipEmptyLines: true,
     dynamicTyping: false
   });

--- a/src/actions/filesDropped/metadata.js
+++ b/src/actions/filesDropped/metadata.js
@@ -12,7 +12,8 @@ import { ADD_COLOR_BYS } from "../types";
  * @param {DataTransfer} file a DataTransfer object
  */
 const parseCsv = (file) => new Promise((resolve, reject) => {
-  if (!["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"].includes(file.type)) {
+  const is_windows_tsv = file.type === "" && file.name.endsWith('.tsv');
+  if (!(["text/csv", "text/tab-separated-values", "application/vnd.ms-excel"].includes(file.type) || is_windows_tsv)) {
     reject(new Error("Cannot parse this filetype"));
   }
   Papa.parse(file, {


### PR DESCRIPTION
Allow the drag & drop functionality to work on Windows machines for .csv and .tsv files.

Tested on Windows with Firefox, Chrome, and IE. Auspice in general failed for me when testing on Safari on this machine. The machine did not have Edge installed. 