### PR TITLE
[feature] Improve smoothness of temporalWindow animation over short time frames

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -179,7 +179,7 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
 
   /* background temporal time slice */
   if (extras.timeSliceHasPotentiallyChanged) {
-    this.addTemporalSlice();
+    this.showTemporalSlice();
   }
 
   /* branch labels */
@@ -208,7 +208,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     this.drawTips();
     this.updateTipLabels();
     if (this.vaccines) this.drawVaccines();
-    this.addTemporalSlice();
+    this.showTemporalSlice();
     if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
     if (elemsToUpdate.has(".branchLabel")) this.drawBranchLabels(this.params.branchLabelKey);
   };
@@ -230,7 +230,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     .remove()
     .on("start", () => inProgress++)
     .on("end", step2);
-  this.removeTemporalSlice();
+  this.hideTemporalSlice();
   if (!transitionTimeFadeOut) timerFlush();
 };
 
@@ -309,7 +309,8 @@ export const change = function change({
     elemsToUpdate.add(".vaccineCross").add(".vaccineDottedLine").add(".conf");
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
     elemsToUpdate.add(".grid").add(".regression");
-    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity").add("visibility");
+    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity")
+.add("visibility");
   }
 
   /* change the requested properties on the nodes */

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -309,8 +309,7 @@ export const change = function change({
     elemsToUpdate.add(".vaccineCross").add(".vaccineDottedLine").add(".conf");
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
     elemsToUpdate.add(".grid").add(".regression");
-    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity")
-.add("visibility");
+    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity").add("visibility");
   }
 
   /* change the requested properties on the nodes */

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -357,7 +357,7 @@ export const temporalWindowTransition = transition('temporalWindowTransition')
  */
 export const showTemporalSlice = function showTemporalSlice() {
   if (this.layout !== "rect" || this.distance !== "num_date") {
-    this.groups.temporalWindow.style('visibility', 'hidden');
+    this.hideTemporalSlice();
     return;
   }
 
@@ -381,7 +381,7 @@ export const showTemporalSlice = function showTemporalSlice() {
       translateX_startRegion = xWindow[0];
     }
 
-    const wasStartRegionVisible = this.groups.temporalWindowStart.attr('opacity') === 1;
+    const wasStartRegionVisible = this.groups.temporalWindowStart.attr('opacity') === '1';
 
     this.groups.temporalWindowStart
       .attr('opacity', 1)
@@ -405,31 +405,36 @@ export const showTemporalSlice = function showTemporalSlice() {
   let xStart_endRegion = xWindow[1]; // starting X coordinate of the "end" rectangle
   let width_endRegion = totalWidth - this.params.margins.right - xWindow[1];
 
+  let transform_endRegion = `translate(${totalWidth - this.params.margins.right},0) scale(-1,1)`;
   // With a right hand tree, the coordinate system flips (right to left)
   if (rightHandTree) {
     xStart_endRegion = this.params.margins.right;
     width_endRegion = xWindow[1] - this.params.margins.right;
+    transform_endRegion = `translate(${xStart_endRegion},0)`;
   }
 
   if (width_endRegion > minPxThreshold) {
-    const wasEndRegionVisible = this.groups.temporalWindowEnd.attr('opacity') === 1;
+    const wasEndRegionVisible = this.groups.temporalWindowEnd.attr('opacity') === '1';
 
     this.groups.temporalWindowEnd
       .attr('opacity', 1)
       .attr("height", height)
-      .attr("fill", fill);
+      .attr("fill", fill)
+      .attr("transform", transform_endRegion);
+
+
     // Only apply animation if rectangle was already visible in the previous frame.
     // Unlike the startingRegion, this panel cannot depend
     // on letting the SVG boundaries clip part of the rectangle.
-    // As a result, we'll have to animate width AND height.
+    // As a result, we'll have to animate width instead of position
+    // If performance becomes an issue, try add a custom clip-path with
+    // a fixed-width region instead.
     if (wasEndRegionVisible) {
       this.groups.temporalWindowEnd
         .transition('temporalWindowTransition')
-        .attr("transform", `translate(${xStart_endRegion},0)`)
         .attr("width", width_endRegion);
     } else {
       this.groups.temporalWindowEnd
-        .attr("transform", `translate(${xStart_endRegion},0)`)
         .attr("width", width_endRegion);
     }
   } else {

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -22,7 +22,7 @@ const addSVGGroupsIfNeeded = (groups, svg) => {
   if (!("temporalWindow" in groups)) {
     groups.temporalWindow = svg.append("g").attr("id", "temporalWindow");
 
-    // Technically rects aren't groups, but store them to avoid searching for them on each "addTemporalSlice" render.
+    // Technically rects aren't groups, but store them to avoid searching for them on each "showTemporalSlice" render.
     groups.temporalWindowStart = groups.temporalWindow.append('rect')
       .attr('class', 'temporalWindowStart');
     groups.temporalWindowEnd = groups.temporalWindow.append('rect')
@@ -342,8 +342,9 @@ export const addGrid = function addGrid() {
   timerEnd("addGrid");
 };
 
-export const removeTemporalSlice = function removeTemporalSlice() {
-  this.groups.temporalWindow.selectAll("*").remove();
+export const hideTemporalSlice = function hideTemporalSlice() {
+  this.groups.temporalWindowStart.attr('visibility', 'hidden');
+  this.groups.temporalWindowEnd.attr('visibility', 'hidden');
 };
 
 // d3-transition to ensure both rectangles move at the same rate
@@ -354,12 +355,11 @@ export const temporalWindowTransition = transition('temporalWindowTransition')
 /**
  * add background grey rectangles to demarcate the temporal slice
  */
-export const addTemporalSlice = function addTemporalSlice() {
+export const showTemporalSlice = function showTemporalSlice() {
   if (this.layout !== "rect" || this.distance !== "num_date") {
     this.groups.temporalWindow.style('visibility', 'hidden');
     return;
   }
-  this.groups.temporalWindow.style('visibility', 'visible');
 
   const xWindow = [this.xScale(this.dateRange[0]), this.xScale(this.dateRange[1])];
   const height = this.yScale.range()[1];
@@ -382,11 +382,14 @@ export const addTemporalSlice = function addTemporalSlice() {
     }
 
     this.groups.temporalWindowStart
+      .attr('visibility', 'visible')
       .attr("height", height)
       .attr("width", totalWidth)
       .attr("fill", fill)
       .transition('temporalWindowTransition')
       .attr("transform", `translate(${translateX_startRegion},0)`);
+  } else {
+    this.groups.temporalWindowStart.attr('visibility', 'hidden');
   }
 
   /* the gray region between the maximum selected date and the last tip */

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -343,8 +343,8 @@ export const addGrid = function addGrid() {
 };
 
 export const hideTemporalSlice = function hideTemporalSlice() {
-  this.groups.temporalWindowStart.attr('visibility', 'hidden');
-  this.groups.temporalWindowEnd.attr('visibility', 'hidden');
+  this.groups.temporalWindowStart.attr('opacity', 0);
+  this.groups.temporalWindowEnd.attr('opacity', 0);
 };
 
 // d3-transition to ensure both rectangles move at the same rate
@@ -372,24 +372,33 @@ export const showTemporalSlice = function showTemporalSlice() {
 
   /* the gray region between the root (ish) and the minimum date */
   if (Math.abs(xWindow[0]-rootXPos) > minPxThreshold) { /* don't render anything less than this num of px */
-    let xEnd_startRegion = xWindow[0]; // ending X coordinate of the "start" rectangle
-    let translateX_startRegion = -totalWidth + xEnd_startRegion; // translation distance for the start rectangle
+    let width_startRegion = xWindow[0];
+    let translateX_startRegion = 0;
 
     // With right hand tree, the coordinate system flips (right to left)
     if (rightHandTree) {
-      xEnd_startRegion = totalWidth - xWindow[0];
+      width_startRegion = totalWidth - xWindow[0];
       translateX_startRegion = xWindow[0];
     }
 
+    const wasStartRegionVisible = this.groups.temporalWindowStart.attr('opacity') === 1;
+
     this.groups.temporalWindowStart
-      .attr('visibility', 'visible')
+      .attr('opacity', 1)
       .attr("height", height)
-      .attr("width", totalWidth)
-      .attr("fill", fill)
-      .transition('temporalWindowTransition')
-      .attr("transform", `translate(${translateX_startRegion},0)`);
+      .attr("transform", `translate(${translateX_startRegion},0)`)
+      .attr("fill", fill);
+
+    // Only apply animation if rectangle was already visible in the previous frame.
+    if (wasStartRegionVisible) {
+      this.groups.temporalWindowStart.transition('temporalWindowTransition')
+        .attr("width", width_startRegion);
+    } else {
+      this.groups.temporalWindowStart
+        .attr("width", width_startRegion);
+    }
   } else {
-    this.groups.temporalWindowStart.attr('visibility', 'hidden');
+    this.groups.temporalWindowStart.attr('opacity', 0);
   }
 
   /* the gray region between the maximum selected date and the last tip */
@@ -403,17 +412,27 @@ export const showTemporalSlice = function showTemporalSlice() {
   }
 
   if (width_endRegion > minPxThreshold) {
+    const wasEndRegionVisible = this.groups.temporalWindowEnd.attr('opacity') === 1;
+
     this.groups.temporalWindowEnd
-      .attr('visibility', 'visible')
+      .attr('opacity', 1)
       .attr("height", height)
-      .attr("fill", fill)
-      .transition('temporalWindowTransition')
-      .attr("transform", `translate(${xStart_endRegion},0)`)
-      // Unlike the startingRegion, this panel cannot depend
+      .attr("fill", fill);
+    // Only apply animation if rectangle was already visible in the previous frame.
+    // Unlike the startingRegion, this panel cannot depend
     // on letting the SVG boundaries clip part of the rectangle.
     // As a result, we'll have to animate width AND height.
-      .attr("width", width_endRegion);
+    if (wasEndRegionVisible) {
+      this.groups.temporalWindowEnd
+        .transition('temporalWindowTransition')
+        .attr("transform", `translate(${xStart_endRegion},0)`)
+        .attr("width", width_endRegion);
+    } else {
+      this.groups.temporalWindowEnd
+        .attr("transform", `translate(${xStart_endRegion},0)`)
+        .attr("width", width_endRegion);
+    }
   } else {
-    this.groups.temporalWindowEnd.attr('visibility', 'hidden');
+    this.groups.temporalWindowEnd.attr('opacity', 0);
   }
 };

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -89,7 +89,7 @@ PhyloTree.prototype.removeTipLabels = labels.removeTipLabels;
 /* G R I D */
 PhyloTree.prototype.hideGrid = grid.hideGrid;
 PhyloTree.prototype.addGrid = grid.addGrid;
-PhyloTree.prototype.addTemporalSlice = grid.addTemporalSlice;
-PhyloTree.prototype.removeTemporalSlice = grid.removeTemporalSlice;
+PhyloTree.prototype.showTemporalSlice = grid.showTemporalSlice;
+PhyloTree.prototype.hideTemporalSlice = grid.hideTemporalSlice;
 
 export default PhyloTree;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -43,7 +43,7 @@ export const render = function render(svg, layout, distance, parameters, callbac
   /* draw functions */
   if (this.params.showGrid) {
     this.addGrid();
-    this.addTemporalSlice();
+    this.showTemporalSlice();
   }
   this.drawBranches();
   this.drawTips();

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -2,13 +2,13 @@ import { scaleLinear, scaleSqrt } from "d3-scale";
 import { hasExtension, getExtension } from "../util/extensions";
 
 export const colorOptions = {
-  "country": {"key": "country", "legendTitle": "Country", "menuItem": "country", "type": "discrete"},
-  "region": {"key": "region", "legendTitle": "Region", "menuItem": "region", "type": "discrete"},
-  "num_date": {"key": "num_date", "legendTitle": "Sampling date", "menuItem": "date", "type": "continuous"},
-  "ep": {"key": "ep", "legendTitle": "Epitope Mutations", "menuItem": "epitope mutations", "type": "continuous"},
-  "ne": {"key": "ne", "legendTitle": "Non-epitope Mutations", "menuItem": "nonepitope mutations", "type": "continuous"},
-  "rb": {"key": "rb", "legendTitle": "Receptor Binding Mutations", "menuItem": "RBS mutations", "type": "continuous"},
-  "gt": {"key": "genotype", "legendTitle": "Genotype", "menuItem": "genotype", "type": "discrete"}
+  country: {key: "country", legendTitle: "Country", menuItem: "country", type: "discrete"},
+  region: {key: "region", legendTitle: "Region", menuItem: "region", type: "discrete"},
+  num_date: {key: "num_date", legendTitle: "Sampling date", menuItem: "date", type: "continuous"},
+  ep: {key: "ep", legendTitle: "Epitope Mutations", menuItem: "epitope mutations", type: "continuous"},
+  ne: {key: "ne", legendTitle: "Non-epitope Mutations", menuItem: "nonepitope mutations", type: "continuous"},
+  rb: {key: "rb", legendTitle: "Receptor Binding Mutations", menuItem: "RBS mutations", type: "continuous"},
+  gt: {key: "genotype", legendTitle: "Genotype", menuItem: "genotype", type: "discrete"}
 };
 
 /* static for now, then hand rolled version of https://github.com/digidem/react-dimensions */
@@ -29,7 +29,7 @@ export const defaultDistanceMeasure = "num_date";
 export const defaultDateRange = 6;
 export const date_select = true;
 export const file_prefix = "Zika_";
-export const restrictTo = {"region": "all"};
+export const restrictTo = {region: "all"};
 export const time_window = 3.0;
 export const fullDataTimeWindow = 1.5;
 export const time_ticks = [2013.0, 2013.5, 2014.0, 2014.5, 2015.0, 2015.5, 2016.0];
@@ -63,6 +63,7 @@ export const slowTransitionDuration = 1400; // in milliseconds
 export const animationWindowWidth = 0.075; // width of animation window relative to date slider
 export const minDistanceDateSlider = 0.075;
 export const animationTick = 50; // animation tick in milliseconds
+export const animationInterpolationDuration = 10; // how long d3 temporalWindow transitions last in milliseconds. Must be shorter than animationTick.
 export const HIColorDomain = genericDomain.map((d) => {
   return Math.round(100 * (d * 3.6)) / 100;
 });
@@ -130,8 +131,8 @@ export const colors = [
   ["#511EA8", "#4928B4", "#4334BF", "#4041C7", "#3F50CC", "#3F5ED0", "#416CCE", "#4379CD", "#4784C7", "#4B8FC1", "#5098B9", "#56A0AF", "#5CA7A4", "#63AC99", "#6BB18E", "#73B583", "#7CB878", "#86BB6E", "#90BC65", "#9ABD5C", "#A4BE56", "#AFBD4F", "#B9BC4A", "#C2BA46", "#CCB742", "#D3B240", "#DAAC3D", "#DFA43B", "#E39B39", "#E68F36", "#E68234", "#E67431", "#E4632E", "#E1512A", "#DF4027", "#DC2F24"]
 ];
 
-export const filterAbbrFwd = {"geo": "geographic location", "all": "all"};
-export const filterAbbrRev = {"geographic location": "geo", "all": "all"};
+export const filterAbbrFwd = {geo: "geographic location", all: "all"};
+export const filterAbbrRev = {"geographic location": "geo", all: "all"};
 
 export const titleColors = ["#4377CD", "#5097BA", "#63AC9A", "#7CB879", "#9ABE5C", "#B9BC4A", "#D4B13F", "#E49938", "#E67030", "#DE3C26"];
 export const notificationDuration = 10000;


### PR DESCRIPTION
## Motivation

- Fixes #918, which described a bug with temporal animations in the tree view. Users would get choppy results when the time interval spanned months or shorter instead of years.

## Changes

- Video with updated performance using `d3.transition` instead of destroying/creating the rectangles on every iteration of `addTemporalSlice`: https://a.cl.ly/jkuKeJn7
- Rewrote rectangle movement to use CSS transforms instead of setting the x and y attributes
- Adjusted the "transitioned" set of properties to the minimal set (x position), since it's simpler if height/width don't need to be modified on every frame.

## Testing

```bash
mkdir data
curl http://data.nextstrain.org/ncov.json --compressed -o data/ncov.json
curl http://data.nextstrain.org/zika.json --compressed -o data/zika.json
node auspice view --datasetDir data
```

Feel free to test with other layouts or datasets, I tested exclusively with `zika` and `nkov` using the links provided by @trvrb [here](https://github.com/nextstrain/auspice/issues/918#issuecomment-594968336).

- http://localhost:4000/zika?animate=2005-12-15,2019-07-06,1,0,30000&p=grid
- http://localhost:4000/ncov?animate=2019-12-12,2020-03-06,0,0,30000&d=tree&p=full
