### PR TITLE
Made tree text unselectable

### DIFF
--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -202,7 +202,8 @@ class Legend extends React.Component {
         left: 5,
         top: 26,
         borderRadius: 4,
-        zIndex: 1000
+        zIndex: 1000,
+        "user-select": "none"
       }
     };
   }

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -112,7 +112,7 @@ class Tree extends React.Component {
     return (
       <svg
         id={mainTree ? "MainTree" : "SecondTree"}
-        style={{pointerEvents: "auto", cursor: "default"}}
+        style={{pointerEvents: "auto", cursor: "default", "user-select": "none"}}
         width={width}
         height={height}
         ref={(c) => {mainTree ? this.domRefs.mainTree = c : this.domRefs.secondTree = c;}}


### PR DESCRIPTION
Uses `user-select: none` CSS on the legend and tree to make the text unselectable.

Closes #405 