### PR TITLE
Only truncate legend labels if they are strings

### DIFF
--- a/src/components/tree/legend/item.js
+++ b/src/components/tree/legend/item.js
@@ -35,7 +35,7 @@ const LegendItem = ({
       style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}
     >
       <title>{label}</title>
-      {label.substring(0, legendMaxLength)}
+      {typeof label === 'string' ? label.substring(0, legendMaxLength) : label}
     </text>
   </g>
 );


### PR DESCRIPTION
Fixes a bug where the tree legend could not be displayed for numeric color by
values because those values do not have a substring function.

Closes #926.