### PR TITLE
[webpack] Transpile non-es5 third party dependencies

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,6 +112,16 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
             cwd: path.resolve(__dirname)
           }
         },
+        // To regenerate the regular expression for selecting non-ES5 dependencies, run:
+        // npx are-you-es5 check . -r | tail -n 1
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+          exclude: /[\\/]node_modules[\\/](?!(chalk|express-naked-redirect|node-fetch|typeface-lato)[\\/])/,
+          options: {
+            cwd: path.resolve(__dirname)
+          }
+        },
         {
           test: /\.css$/,
           use: ["style-loader", "css-loader"]


### PR DESCRIPTION
## Summary

This a pass at using the `are-you-es5` library (https://github.com/obahareth/are-you-es5 ) to determine which of the current dependencies need to be transpiled to ES5 to support older browsers. It appears that we have some dependencies that don't have non-ES5 entrypoints even before getting the extension system involved. 

If this works, we could apply the `are-you-es5` script programmatically to the extensions directory, and can in the longer term help with #902 .

The fuller solution would be to run this script as a postinstall as described in [this article](https://developer.epages.com/blog/coding/how-to-transpile-node-modules-with-babel-and-webpack-in-a-monorepo/), but I wanted to first confirm whether transpiling these specific modules actually solved the issue in older browsers (which I currently don't have access to).


