### PR TITLE
Search highlights tips as you type

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -204,7 +204,7 @@ export const changeDateFilter = ({newMin = false, newMax = false, quickdraw = fa
  * @return {null} side-effects: a single action
  */
 export const updateTipRadii = (
-  {tipSelectedIdx = false, selectedLegendItem = false} = {}
+  {tipSelectedIdx = false, selectedLegendItem = false, searchNodes = false} = {}
 ) => {
   return (dispatch, getState) => {
     const { controls, tree, treeToo } = getState();
@@ -222,6 +222,9 @@ export const updateTipRadii = (
     } else if (selectedLegendItem !== false) {
       d.data = calcTipRadii({selectedLegendItem, colorScale, tree});
       if (tt) d.dataToo = calcTipRadii({selectedLegendItem, colorScale, tree: treeToo});
+    } else if (searchNodes !== false) {
+      d.data = calcTipRadii({searchNodes, colorScale, tree});
+      if (tt) d.dataToo = calcTipRadii({searchNodes, colorScale, tree: treeToo});
     } else {
       d.data = calcTipRadii({colorScale, tree});
       if (tt) d.dataToo = calcTipRadii({colorScale, tree: treeToo});

--- a/src/components/controls/search.js
+++ b/src/components/controls/search.js
@@ -72,6 +72,12 @@ class SearchStrains extends React.Component {
     const awesomplete = new Awesomplete(this.ref, {
       maxItems: 1000
     });
+    this.ref.addEventListener('input', (e) => {
+      const strain = e.target.value.toLowerCase().trim();
+      this.props.dispatch(updateTipRadii({
+        searchNodes: (strain.length > 1) ? strain : ""
+      }));
+    });
     this.ref.addEventListener('awesomplete-selectcomplete', (e) => {
       const strain = e.text.value;
       for (let i = 0; i < this.props.nodes.length; i++) {

--- a/src/util/tipRadiusHelpers.js
+++ b/src/util/tipRadiusHelpers.js
@@ -29,9 +29,11 @@ const determineLegendMatch = (selectedLegendItem, node, colorScale) => {
 * @param tree
 * @returns null (if data not ready) or array of tip radii
 */
-export const calcTipRadii = ({tipSelectedIdx = false, selectedLegendItem = false, colorScale, tree}) => {
+export const calcTipRadii = ({tipSelectedIdx = false, selectedLegendItem = false, searchNodes = false, colorScale, tree}) => {
   if (selectedLegendItem !== false && tree && tree.nodes) {
     return tree.nodes.map((d) => determineLegendMatch(selectedLegendItem, d, colorScale) ? tipRadiusOnLegendMatch : tipRadius);
+  } else if (searchNodes) {
+    return tree.nodes.map((d) => d.name.toLowerCase().includes(searchNodes) ? tipRadiusOnLegendMatch : tipRadius);
   } else if (tipSelectedIdx) {
     const radii = tree.nodes.map(() => tipRadius);
     radii[tipSelectedIdx] = tipRadiusOnLegendMatch + 3;


### PR DESCRIPTION
Fixes #929 
As you are typing in the "Search Strains" autocomplete, it will highlight the tips of matching strains. Just like the autocomplete, the highlight goes away if you have 0-1 characters, or pick one of the nodes

Screenshot:
![Screen Shot 2020-03-08 at 11 15 23 PM](https://user-images.githubusercontent.com/643918/76179919-cebf8980-6192-11ea-9d28-aefb5862dcc1.png)
