### PR TITLE
Issue 933: Add translators to narrative parsing

### DIFF
--- a/cli/server/parseNarrative.js
+++ b/cli/server/parseNarrative.js
@@ -28,18 +28,19 @@ const makeFrontMatterBlock = (frontMatter) => {
   const markdown = [];
   markdown.push(`# ${frontMatter.title}`);
   if (frontMatter.authors) {
-    if (typeof frontMatter.authors === 'object' && Array.isArray(frontMatter.authors)) {
-      utils.warn(`Narrative parsing -- can't do author arrays yet`);
-    } else if (typeof frontMatter.authors === 'string') {
-      if (frontMatter.authorLinks && typeof frontMatter.authorLinks === "string") {
-        markdown.push(`### Author: [${frontMatter.authors}](${frontMatter.authorLinks})`);
-      } else {
-        markdown.push(`### Author: ${frontMatter.authors}`);
-      }
+    let authors = parseContributors(frontMatter, "authors", "authorLinks");
+    if (authors) {
+      markdown.push(`### Author: ${authors}`);
       if (frontMatter.affiliations && typeof frontMatter.affiliations === "string") {
         markdown[markdown.length-1] += " <sup> 1 </sup>";
         markdown.push(`<sup> 1 </sup> ${frontMatter.affiliations}`);
       }
+    }
+  }
+  if (frontMatter.translators) {
+    let translators = parseContributors(frontMatter, "translators", "translatorLinks");
+    if (translators) {
+      markdown.push(`### Translators: ${translators}`);
     }
   }
   if (frontMatter.date && typeof frontMatter.date === "string") {
@@ -57,6 +58,57 @@ const makeFrontMatterBlock = (frontMatter) => {
   block.contents = markdown.join("\n");
   return block;
 };
+
+const parseContributors = (frontMatter, contributorsKey, contributorLinksKey) => {
+  const contributors = frontMatter[contributorsKey];
+  const contributorLinks = frontMatter[contributorLinksKey];
+
+  if (Array.isArray(contributors)) {
+    return parseContributorsArray(contributors, contributorLinks, contributorsKey, contributorLinksKey);
+  } else if (typeof contributors === 'string') {
+    return parseContributorsString(contributors, contributorLinks, contributorsKey, contributorLinksKey);
+  }
+}
+
+const parseContributorsArray = (contributors, contributorLinks, contributorsKey, contributorLinksKey) => {
+  // validate links
+  if (contributorLinks) {
+    if (!Array.isArray(contributorLinks)) {
+      utils.warn(`Narrative parsing - if ${contributorsKey} is an array, then ${contributorLinksKey} must also be an array. Skipping links.`);
+      contributorLinks = undefined;
+    } else if (contributorLinks.length != contributors.length) {
+      utils.warn(`Narrative parsing - the length of ${contributorsKey} and ${contributorLinksKey} did not match. Skipping links.`);
+      contributorLinks = undefined;
+    }
+  }
+
+  if (contributorLinks) {
+    contributors = contributors.map((contributor, idx) => {
+      return contributorLink(contributor, contributorLinks[idx]);
+    });
+  }
+
+  return contributors.join(", ");
+}
+
+const parseContributorsString = (contributors, contributorLinks, contributorsKey, contributorLinksKey) => {
+  // validate links
+  if (contributorLinks) {
+    if (typeof contributorLinks !== "string") {
+      utils.warn(`Narrative parsing - if ${contributorsKey} is a string, then ${contributorLinksKey} must also be a string. Skipping links.`);
+      contributorLinks = undefined;
+    }
+  }
+
+  return contributorLink(contributors, contributorLinks);
+}
+
+const contributorLink = (contributor, contributorLink) => {
+  if (contributorLink) {
+    return `[${contributor}](${contributorLink})`;
+  }
+  return contributor;
+}
 
 /**
  * Extract a code-block from the content, if it exists, tagged as auspiceMainDisplayMarkdown


### PR DESCRIPTION
This adds translators to the narrative frontmatter parsing as described in #933.

**Notes**
*  I noticed there was a warning for `authors` as arrays not being implemented yet. I decided that the best path forward would be to implement `authors` as arrays or strings, then share that code with the `translators` parsing. The end result is that `authors` and `translators` have the same semantics, and can be given as either a single string, or an array.
* While the issue doesn't specify it, sharing the same code means `translators` also has a `translatorLinks` key, which can be used to link to translator (a personal blog, mailto, twitter account, etc). `translatorLinks` are not necessary, and can be omitted for any/all translators.
* This adds validation around the links.
  * If the `authors` attribute is a string, then `authorLinks` must be a string. If `authors` is an array, then `authorLinks` must be an array of the same size (`null` can be used for any element that doesn't have a link).
  * The same is true for `translators` and `translatorLinks`.
  * If the validation fails, the link is omitted and a warning message is displayed that explains specifically what failed the validation.
* The only documentation I found on `authors` and `authorLinks` appeared to be in a tutorial. I didn't see reference documentation. Because I didn't want to bog down a tutorial with a more obscure attribute, I didn't add documentation for this. If there’s reference documentation anywhere point me at it and I can the documentation for these new attributes.
