### PR TITLE
feat (docs): Local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See [here](https://nextstrain.github.io/auspice/introduction/install) for full i
 
 ## Quickstart
 
-Install dependencies; this will create a `/data` folder for your datasets.
+Install dependencies; this will also create a `/data` folder for your datasets.
 
 ```
 npm install

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Auspice may be used to explore datasets locally or run as a as a server to share
 
 ## Installation
 
+Install as a global command.
 ```bash
 npm install --global auspice
 ```
@@ -38,22 +39,33 @@ See [here](https://nextstrain.github.io/auspice/introduction/install) for full i
 
 ## Quickstart
 
-In order to get up & running you'll need to have some datasets to visualise.
-Please see the [nextstrain docs](https://nextstrain.org/docs/) for tutorials on how to do this.
-For the purposes of getting started, you can download the current zika dataset via:
+Install dependencies; this will create a `/data` folder for your datasets.
 
 ```
-mkdir datasets
+npm install
+```
+
+In order to get up & running you'll need datasets to visualise.
+Please see the [nextstrain docs](https://nextstrain.org/docs/) for tutorials on how to do this.
+To get started, you can download the current zika dataset into the `data` folder:
+
+```
 curl http://data.nextstrain.org/zika.json --compressed -o data/zika.json
 ```
 
-And then run `auspice` via:
+You can then run `auspice` via:
 ```
 auspice view --datasetDir data
 ```
 This will allow you to run auspice locally (i.e. from your computer) and view the dataset which is behind [nextstrain.org/zika](https://nextstrain.org/zika).
 
-To download all the datasets at once, the following helper command will populate the `/data` folder.
+You can run and develop locally with 
+
+```
+npm run dev
+```
+
+To download all the example datasets at once, the following helper command will populate the `/data` folder.
 
 ```bash
   npm run get-data

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can run and develop locally with
 npm run dev
 ```
 
+to serve the datasets in your `data` folder.
+
 To download all the example datasets at once, the following helper command will populate the `/data` folder.
 
 ```bash

--- a/docs-src/README.md
+++ b/docs-src/README.md
@@ -29,8 +29,16 @@ npm install
 ```
 
 #### Developing (live reloading etc):
+To get started, run the following to download an example Zika dataset into the `data` folder:
+
+```
+curl http://data.nextstrain.org/zika.json --compressed -o data/zika.json
+```
+
+```
 ```bash
-npm run develop
+# This uses the `data` folder so you'll need a dataset.
+npm run dev
 ```
 
 #### (re-)build the static site

--- a/docs-src/README.md
+++ b/docs-src/README.md
@@ -29,16 +29,8 @@ npm install
 ```
 
 #### Developing (live reloading etc):
-To get started, run the following to download an example Zika dataset into the `data` folder:
-
-```
-curl http://data.nextstrain.org/zika.json --compressed -o data/zika.json
-```
-
-```
 ```bash
-# This uses the `data` folder so you'll need a dataset.
-npm run dev
+npm run develop
 ```
 
 #### (re-)build the static site


### PR DESCRIPTION
Explains `npm run dev` for a local setup.
Removes an unneeded/confusing `mkdir datasets` line (when the script already creates a `data` folder).
