### PR TITLE
Hover on map deme will highlight tree tips

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -204,7 +204,7 @@ export const changeDateFilter = ({newMin = false, newMax = false, quickdraw = fa
  * @return {null} side-effects: a single action
  */
 export const updateTipRadii = (
-  {tipSelectedIdx = false, selectedLegendItem = false, searchNodes = false} = {}
+  {tipSelectedIdx = false, selectedLegendItem = false, geoFilter = false, searchNodes = false} = {}
 ) => {
   return (dispatch, getState) => {
     const { controls, tree, treeToo } = getState();
@@ -219,15 +219,9 @@ export const updateTipRadii = (
         const idx = strainNameToIdx(treeToo.nodes, tree.nodes[tipSelectedIdx].name);
         d.dataToo = calcTipRadii({idx, colorScale, tree: treeToo});
       }
-    } else if (selectedLegendItem !== false) {
-      d.data = calcTipRadii({selectedLegendItem, colorScale, tree});
-      if (tt) d.dataToo = calcTipRadii({selectedLegendItem, colorScale, tree: treeToo});
-    } else if (searchNodes !== false) {
-      d.data = calcTipRadii({searchNodes, colorScale, tree});
-      if (tt) d.dataToo = calcTipRadii({searchNodes, colorScale, tree: treeToo});
     } else {
-      d.data = calcTipRadii({colorScale, tree});
-      if (tt) d.dataToo = calcTipRadii({colorScale, tree: treeToo});
+      d.data = calcTipRadii({selectedLegendItem, geoFilter, searchNodes, colorScale, tree});
+      if (tt) d.dataToo = calcTipRadii({selectedLegendItem, geoFilter, searchNodes, colorScale, tree: treeToo});
     }
     dispatch(d);
   };

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -232,7 +232,8 @@ class Map extends React.Component {
         this.props.nodes,
         this.props.dateMinNumeric,
         this.props.dateMaxNumeric,
-        this.props.pieChart
+        this.props.pieChart,
+        this.props.dispatch
       );
 
       // don't redraw on every rerender - need to seperately handle virus change redraw

--- a/src/components/map/mapHelpers.js
+++ b/src/components/map/mapHelpers.js
@@ -190,9 +190,13 @@ export const drawDemesAndTransmissions = (
       .style("fill", (d) => { return d.color; })
       .style("stroke-opacity", 0.85)
       .style("stroke", (d) => { return d.color; })
+      .style("cursor", "pointer")
+      .style("pointer-events", "all")
       .attr("transform", (d) =>
         "translate(" + demeData[d.demeDataIdx].coords.x + "," + demeData[d.demeDataIdx].coords.y + ")"
-      );
+      )
+      .on("mouseover", (d) => { dispatch(updateTipRadii({geoFilter: demeData[d.demeDataIdx].name})) })
+      .on("mouseout", (d) => { dispatch(updateTipRadii()) });
   } else {
     demes = g.selectAll("demes") // add deme circles to this selection
       .data(demeData)
@@ -207,7 +211,7 @@ export const drawDemesAndTransmissions = (
       .style("cursor", "pointer")
       .style("pointer-events", "all")
       .attr("transform", (d) => "translate(" + d.coords.x + "," + d.coords.y + ")")
-      .on("mouseover", (d) => { dispatch(updateTipRadii({selectedLegendItem: d.name})) })
+      .on("mouseover", (d) => { dispatch(updateTipRadii({geoFilter: d.name})) })
       .on("mouseout", (d) => { dispatch(updateTipRadii()) });
   }
 

--- a/src/components/map/mapHelpers.js
+++ b/src/components/map/mapHelpers.js
@@ -4,6 +4,7 @@ import _max from "lodash/max";
 import { line, curveBasis, arc } from "d3-shape";
 import { easeLinear } from "d3-ease";
 import { demeCountMultiplier, demeCountMinimum } from "../../util/globals";
+import { updateTipRadii } from "../../actions/tree";
 
 /* util */
 
@@ -134,7 +135,8 @@ export const drawDemesAndTransmissions = (
   nodes,
   numDateMin,
   numDateMax,
-  pieChart /* bool */
+  pieChart, /* bool */
+  dispatch
 ) => {
 
   // add transmission lines
@@ -202,7 +204,11 @@ export const drawDemesAndTransmissions = (
       .style("fill", (d) => { return d.color; })
       .style("stroke-opacity", 0.85)
       .style("stroke", (d) => { return d.color; })
-      .attr("transform", (d) => "translate(" + d.coords.x + "," + d.coords.y + ")");
+      .style("cursor", "pointer")
+      .style("pointer-events", "all")
+      .attr("transform", (d) => "translate(" + d.coords.x + "," + d.coords.y + ")")
+      .on("mouseover", (d) => { dispatch(updateTipRadii({selectedLegendItem: d.name})) })
+      .on("mouseout", (d) => { dispatch(updateTipRadii()) });
   }
 
   return {

--- a/src/util/tipRadiusHelpers.js
+++ b/src/util/tipRadiusHelpers.js
@@ -21,6 +21,24 @@ const determineLegendMatch = (selectedLegendItem, node, colorScale) => {
 };
 
 /**
+* equates a single tip and a legend element
+* exact match on node's location attribute and geoFilter
+* @param geoFilter - value of the selected tip location attribute
+* @param node - node (tip) in question
+* @param colorScale - used to get the value of the attribute being used for colouring
+* @returns bool
+*/
+const determineLocationMatch = (geoFilter, node, colorScale) => {
+  const nodeAttr = getTipColorAttribute(node, colorScale);
+  if (nodeAttr === geoFilter) {
+    return true;
+  } else {
+    let location = node.node_attrs.location || node.node_attrs.division || node.node_attrs.country;
+    return location && location.value === geoFilter;
+  }
+};
+
+/**
 * produces the array of tip radii - if nothing's selected this is the hardcoded tipRadius
 * if there's a selectedLegendItem, then values will be small (like normal) or big (for those tips selected)
 * @param selectedLegendItem - value of the selected tip attribute (numeric or string) OPTIONAL
@@ -29,9 +47,11 @@ const determineLegendMatch = (selectedLegendItem, node, colorScale) => {
 * @param tree
 * @returns null (if data not ready) or array of tip radii
 */
-export const calcTipRadii = ({tipSelectedIdx = false, selectedLegendItem = false, searchNodes = false, colorScale, tree}) => {
+export const calcTipRadii = ({tipSelectedIdx = false, selectedLegendItem = false, geoFilter = false, searchNodes = false, colorScale, tree}) => {
   if (selectedLegendItem !== false && tree && tree.nodes) {
     return tree.nodes.map((d) => determineLegendMatch(selectedLegendItem, d, colorScale) ? tipRadiusOnLegendMatch : tipRadius);
+  } else if (geoFilter !== false && tree && tree.nodes) {
+    return tree.nodes.map((d) => determineLocationMatch(geoFilter, d, colorScale) ? tipRadiusOnLegendMatch : tipRadius);
   } else if (searchNodes) {
     return tree.nodes.map((d) => d.name.toLowerCase().includes(searchNodes) ? tipRadiusOnLegendMatch : tipRadius);
   } else if (tipSelectedIdx) {


### PR DESCRIPTION
My attempt at fixing #264 

> mousing over map demes should act just like mousing over legend items

The first commit does this now!

> The map demes should always represent geographical filters

The second commit modifies the clade-filtering so if you click a node on the map, you will see only nodes matching the location, and their parent branches. I didn't find this mode to be as helpful as expected, because the context is hidden? But the good news is, it works on both zika and ncov datasets (country or location attribute)

![Screen Shot 2020-03-11 at 11 04 29 PM](https://user-images.githubusercontent.com/643918/76483229-d8442e00-63ec-11ea-8c0f-ed9344ccbcb8.png)
