### PR TITLE
Update to PR #897 fixing rotation issues

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -322,7 +322,8 @@ export const change = function change({
     elemsToUpdate.add(".vaccineCross").add(".vaccineDottedLine").add(".conf");
     elemsToUpdate.add('.branchLabel').add('.tipLabel');
     elemsToUpdate.add(".grid").add(".regression");
-    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity").add("visibility");
+    svgPropsToUpdate.add("cx").add("cy").add("d").add("opacity")
+.add("visibility");
   }
 
   /* change the requested properties on the nodes */

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -3,7 +3,7 @@ import { calcConfidenceWidth } from "./confidence";
 import { applyToChildren } from "./helpers";
 import { timerStart, timerEnd } from "../../../util/perf";
 import { NODE_VISIBLE } from "../../../util/globals";
-import { getBranchVisibility } from "./renderers";
+import { getBranchVisibility, strokeForBranch } from "./renderers";
 
 /* loop through the nodes and update each provided prop with the new value
  * additionally, set d.update -> whether or not the node props changed
@@ -56,11 +56,17 @@ const svgSetters = {
       stroke: (d) => d.branchStroke,
       "stroke-width": calcConfidenceWidth
     },
+    // only allow stroke to be set on individual branches
     ".branch": {
-      stroke: (d) => d.branchStroke,
       "stroke-width": (d) => d["stroke-width"] + "px", // style - as per drawBranches()
       cursor: (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default",
       visibility: getBranchVisibility
+    },
+    ".branch.S": {
+      stroke: (d) => strokeForBranch(d, "S")
+    },
+    ".branch.T": {
+      stroke: (d) => strokeForBranch(d, "T")
     }
   }
 };
@@ -116,7 +122,6 @@ const genericSelectAndModify = (svg, treeElem, updateCall, transitionTime) => {
 export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, transitionTime, extras) {
   let updateCall;
   const classesToPotentiallyUpdate = [".tip", ".vaccineDottedLine", ".vaccineCross", ".branch"]; /* order is respected */
-  // console.log("modifying these elems", elemsToUpdate)
 
   /* treat stem / branch specially, but use these to replace a normal .branch call if that's also to be applied */
   if (elemsToUpdate.has(".branch.S") || elemsToUpdate.has(".branch.T")) {
@@ -130,9 +135,17 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
             createUpdateCall(".branch", svgPropsToUpdate)(selection); /* the "normal" branch changes to apply */
             selection.attr("d", (d) => d.branch[STidx]); /* change the path (differs between .S and .T) */
           };
+        } else if (svgPropsToUpdate.has("stroke")) { /* we seed to set stroke differently on T and S branches */
+          updateCall = (selection) => {
+            createUpdateCall(`.branch${x}`, svgPropsToUpdate)(selection);
+            selection.attr("d", (d) => d.branch[STidx]);
+          };
         } else {
-          updateCall = (selection) => {selection.attr("d", (d) => d.branch[STidx]);};
+          updateCall = (selection) => {
+            selection.attr("d", (d) => d.branch[STidx]);
+          };
         }
+
         genericSelectAndModify(this.svg, `.branch${x}`, updateCall, transitionTime);
       }
     });
@@ -281,7 +294,7 @@ export const change = function change({
   and what SVG elements, node properties, svg props we actually change */
   if (changeColorBy) {
     /* check that fill & stroke are defined */
-    elemsToUpdate.add(".branch").add(".tip").add(".conf");
+    elemsToUpdate.add(".branch.S").add(".branch.T").add(".tip").add(".conf");
     svgPropsToUpdate.add("stroke").add("fill");
     nodePropsToModify.branchStroke = branchStroke;
     nodePropsToModify.tipStroke = tipStroke;
@@ -315,6 +328,10 @@ export const change = function change({
   /* change the requested properties on the nodes */
   updateNodesWithNewData(this.nodes, nodePropsToModify);
 
+  // recalculate gradients here?
+  if (changeColorBy) {
+    this.updateColorBy();
+  }
   /* some things need to update d.inView and/or d.update. This should be centralised */
   /* TODO: list all functions which modify these */
   if (zoomIntoClade) { /* must happen below updateNodesWithNewData */
@@ -348,7 +365,7 @@ export const change = function change({
   }
 
   /* Finally, actually change the SVG elements themselves */
-  const extras = {removeConfidences, showConfidences, newBranchLabellingKey};
+  const extras = { removeConfidences, showConfidences, newBranchLabellingKey };
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   extras.hideTipLabels = animationInProgress;
   if (useModifySVGInStages) {

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -359,9 +359,9 @@ export const mapToScreen = function mapToScreen() {
     d.yTip = this.yScale(d.y);
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
-    
-    d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI ;
-    
+
+    d.rot = Math.atan2(d.yTip-d.yBase, d.xTip-d.xBase) * 180/Math.PI;
+
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
@@ -399,15 +399,15 @@ export const mapToScreen = function mapToScreen() {
     this.nodes.forEach((d) => {d.cBarEnd = this.yScale(d.yRange[1]);});
     this.nodes.forEach((d, i) => {
       d.branch =[
-        " M "+(d.xBase-stem_offset_radial[i]*Math.sin(d.angle)).toString()
-        + " "+(d.yBase-stem_offset_radial[i]*Math.cos(d.angle)).toString()
-        + " L "+d.xTip.toString()+" "+d.yTip.toString(), ""
+        " M "+(d.xBase-stem_offset_radial[i]*Math.sin(d.angle)).toString() +
+        " "+(d.yBase-stem_offset_radial[i]*Math.cos(d.angle)).toString() +
+        " L "+d.xTip.toString()+" "+d.yTip.toString(), ""
       ];
       if (!d.terminal) {
         d.branch[1] =[" M "+this.xScale(d.xCBarStart).toString()+" "+this.yScale(d.yCBarStart).toString()+
-        " A "+(this.xScale(d.depth)-this.xScale(offset)).toString()+" "
-        +(this.yScale(d.depth)-this.yScale(offset)).toString()
-        +" 0 "+(d.smallBigArc?"1 ":"0 ") +" 1 "+
+        " A "+(this.xScale(d.depth)-this.xScale(offset)).toString()+" "+
+        (this.yScale(d.depth)-this.yScale(offset)).toString()+
+        " 0 "+(d.smallBigArc?"1 ":"0 ") +" 1 "+
         " "+this.xScale(d.xCBarEnd).toString()+","+this.yScale(d.yCBarEnd).toString()];
       }
     });

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -359,9 +359,9 @@ export const mapToScreen = function mapToScreen() {
     d.yTip = this.yScale(d.y);
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
-    if (this.layout !=="rectangular"){
-      d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI ;
-    }
+    
+    d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI ;
+    
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -360,7 +360,7 @@ export const mapToScreen = function mapToScreen() {
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
     if (this.layout !=="rectangular"){
-      d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI;
+      d.rot = (Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI + 360)%360;
     }
   });
   if (this.vaccines) {

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -359,6 +359,9 @@ export const mapToScreen = function mapToScreen() {
     d.yTip = this.yScale(d.y);
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
+    if (this.layout !=="rectangular"){
+      d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI;
+    }
   });
   if (this.vaccines) {
     this.vaccines.forEach((d) => {
@@ -378,7 +381,13 @@ export const mapToScreen = function mapToScreen() {
     this.nodes.forEach((d) => {
       const stem_offset = 0.5*(d.parent["stroke-width"] - d["stroke-width"]) || 0.0;
       const childrenY = [this.yScale(d.yRange[0]), this.yScale(d.yRange[1])];
-      d.branch =[` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip} M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`];
+      // Note that a branch cannot be perfectly horizontal and also have a (linear) gradient applied to it
+      // So we add a tiny amount of jitter (e.g 1/1000px) to the horizontal line (d.branch[0])
+      // see https://stackoverflow.com/questions/13223636/svg-gradient-for-perfectly-horizontal-path
+      d.branch =[
+        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip+0.001}`],
+        [` M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`]
+      ];
       if (this.params.confidence) {
         d.confLine =` M ${this.xScale(d.conf[0])},${d.yBase} L ${this.xScale(d.conf[1])},${d.yTip}`;
       }

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -360,7 +360,7 @@ export const mapToScreen = function mapToScreen() {
     d.xBase = this.xScale(d.px);
     d.yBase = this.yScale(d.py);
     if (this.layout !=="rectangular"){
-      d.rot = (Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI + 360)%360;
+      d.rot = Math.atan2(d.yTip-d.yBase,d.xTip-d.xBase) * 180/Math.PI ;
     }
   });
   if (this.vaccines) {

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -63,6 +63,7 @@ PhyloTree.prototype.drawBranches = renderers.drawBranches;
 PhyloTree.prototype.drawVaccines = renderers.drawVaccines;
 PhyloTree.prototype.drawRegression = renderers.drawRegression;
 PhyloTree.prototype.removeRegression = renderers.removeRegression;
+PhyloTree.prototype.makeLinearGradient = renderers.makeLinearGradient;
 
 /* C A L C U L A T E    G E O M E T R I E S  E T C   ( M O D I F I E S    N O D E S ,    N O T    S V G ) */
 PhyloTree.prototype.setDistance = layouts.setDistance;

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -63,7 +63,7 @@ PhyloTree.prototype.drawBranches = renderers.drawBranches;
 PhyloTree.prototype.drawVaccines = renderers.drawVaccines;
 PhyloTree.prototype.drawRegression = renderers.drawRegression;
 PhyloTree.prototype.removeRegression = renderers.removeRegression;
-PhyloTree.prototype.makeLinearGradient = renderers.makeLinearGradient;
+PhyloTree.prototype.updateColorBy = renderers.updateColorBy;
 
 /* C A L C U L A T E    G E O M E T R I E S  E T C   ( M O D I F I E S    N O D E S ,    N O T    S V G ) */
 PhyloTree.prototype.setDistance = layouts.setDistance;

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -141,6 +141,16 @@ export const getBranchVisibility = (d) => {
   return "visible";
 };
 
+export const strokeForBranch = (d, b) => {
+  const id = `T${d.that.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
+  // console.log(id + " " +  b);
+  if (d.branchStroke === d.parent.branchStroke || b === "T") {
+    // console.log("stroking " + id + " " + d.branchStroke);
+    return d.branchStroke;
+  }
+  return `url(#${id})`;
+};
+
 /**
  * adds all branches to the svg, these are paths with class branch, which comprise two groups
  * @return {null}
@@ -198,7 +208,7 @@ export const drawBranches = function drawBranches() {
     .attr("d", (d) => d.branch[0])
     .style("stroke", (d) => {
       if (!d.branchStroke) return params.branchStroke;
-      return strokeForBranch(d,"S");
+      return strokeForBranch(d, "S");
     })
     .style("stroke-linecap", "round")
     .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
@@ -262,8 +272,8 @@ export const clearSVG = function clearSVG() {
 };
 
 
-export const updateColorBy = function() {
-    //console.log("updating colorBy")
+export const updateColorBy = function () {
+  // console.log("updating colorBy")
   this.nodes.forEach((d) => {
     const a = d.parent.branchStroke;
     const b = d.branchStroke;
@@ -296,31 +306,11 @@ export const updateColorBy = function() {
   });
 };
 
-export const strokeForBranch = function(d, b) {
+const handleHoverColor = (d, c1, c2) => {
+  if (!d) { return; }
+
   const id = `T${d.that.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
-  //console.log(id + " " +  b);
-  if (d.branchStroke === d.parent.branchStroke || b === "T") {
-    //console.log("stroking " + id + " " + d.branchStroke);
-    return d.branchStroke;
-  }
-  return `url(#${id})`;
-};
 
-export const branchStrokeForLeave = function(d) {
-  if (!d) { return; }
-  handleHoverColor(d, d.parent.branchStroke,d.branchStroke);
-};
-
-export const branchStrokeForHover = function(d) {
-  if (!d) { return; }
-  handleHoverColor(d, getEmphasizedColor(d.parent.branchStroke),getEmphasizedColor(d.branchStroke));
-};
-
-const handleHoverColor = function(d, c1, c2){
-  if (!d) { return; }
-  
-  const id = `T${d.that.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
- 
   /* We want to emphasize the colour of the branch. How we do this depends on how the branch was rendered in the first place! */
   const tel = d.that.svg.select(getDomId("#branchT", d.n.name));
 
@@ -329,10 +319,10 @@ const handleHoverColor = function(d, c1, c2){
   }
   const sel = d.that.svg.select(getDomId("#branchS", d.n.name));
   if (!sel.empty()) {
-    if (d.branchStroke === d.parent.branchStroke){
-        sel.style("stroke", c2);
-      } else {
-      //console.log("going to gradient " + el.attr("id"));
+    if (d.branchStroke === d.parent.branchStroke) {
+      sel.style("stroke", c2);
+    } else {
+      // console.log("going to gradient " + el.attr("id"));
       const begin = d.that.svg.select(`#${id}_begin`);
       if (begin) {
         begin.attr("stop-color", c1);
@@ -343,15 +333,27 @@ const handleHoverColor = function(d, c1, c2){
       }
     }
   }
-}
-  function getRateEstimate(regression, maxDivergence) {
-    /* Prior to Jan 2020, the divergence measure was always "subs per site per year"
+};
+
+export const branchStrokeForLeave = function (d) {
+  if (!d) { return; }
+  handleHoverColor(d, d.parent.branchStroke, d.branchStroke);
+};
+
+export const branchStrokeForHover = function (d) {
+  if (!d) { return; }
+  handleHoverColor(d, getEmphasizedColor(d.parent.branchStroke), getEmphasizedColor(d.branchStroke));
+};
+
+
+function getRateEstimate(regression, maxDivergence) {
+  /* Prior to Jan 2020, the divergence measure was always "subs per site per year"
     however certain datasets chaged this to "subs per year" across entire sequence.
     This distinction is not set in the JSON, so in order to correctly display the rate
     we will "guess" this here. A future augur update will export this in a JSON key,
     removing the need to guess */
-    if (maxDivergence > 5) {
-      return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
-    }
-    return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
-  };
+  if (maxDivergence > 5) {
+    return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
+  }
+  return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
+}

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -1,6 +1,7 @@
 import { timerStart, timerEnd } from "../../../util/perf";
 import { NODE_VISIBLE } from "../../../util/globals";
 import { getDomId, formatDivergence } from "./helpers";
+import { getEmphasizedColor } from "../../../util/colorHelpers";
 /**
  * @param {d3 selection} svg      -- the svg into which the tree is drawn
  * @param {string} layout         -- the layout to be used, e.g. "rect"
@@ -72,17 +73,17 @@ export const drawVaccines = function drawVaccines() {
     .selectAll(".vaccineCross")
     .data(this.vaccines)
     .enter()
-      .append("path")
-        .attr("class", "vaccineCross")
-        .attr("d", (d) => d.vaccineCross)
-        .style("stroke", "#333")
-        .style("stroke-width", 2 * this.params.branchStrokeWidth)
-        .style("fill", "none")
-        .style("cursor", "pointer")
-        .style("pointer-events", "auto")
-        .on("mouseover", this.callbacks.onTipHover)
-        .on("mouseout", this.callbacks.onTipLeave)
-        .on("click", this.callbacks.onTipClick);
+    .append("path")
+    .attr("class", "vaccineCross")
+    .attr("d", (d) => d.vaccineCross)
+    .style("stroke", "#333")
+    .style("stroke-width", 2 * this.params.branchStrokeWidth)
+    .style("fill", "none")
+    .style("cursor", "pointer")
+    .style("pointer-events", "auto")
+    .on("mouseover", this.callbacks.onTipHover)
+    .on("mouseout", this.callbacks.onTipLeave)
+    .on("click", this.callbacks.onTipClick);
 };
 
 
@@ -101,21 +102,21 @@ export const drawTips = function drawTips() {
     .selectAll(".tip")
     .data(this.nodes.filter((d) => d.terminal))
     .enter()
-      .append("circle")
-        .attr("class", "tip")
-        .attr("id", (d) => getDomId("tip", d.n.name))
-        .attr("cx", (d) => d.xTip)
-        .attr("cy", (d) => d.yTip)
-        .attr("r", (d) => d.r)
-        .on("mouseover", this.callbacks.onTipHover)
-        .on("mouseout", this.callbacks.onTipLeave)
-        .on("click", this.callbacks.onTipClick)
-        .style("pointer-events", "auto")
-        .style("visibility", (d) => d.visibility === NODE_VISIBLE ? "visible" : "hidden")
-        .style("fill", (d) => d.fill || params.tipFill)
-        .style("stroke", (d) => d.tipStroke || params.tipStroke)
-        .style("stroke-width", () => params.tipStrokeWidth) /* don't want branch thicknesses applied */
-        .style("cursor", "pointer");
+    .append("circle")
+    .attr("class", "tip")
+    .attr("id", (d) => getDomId("tip", d.n.name))
+    .attr("cx", (d) => d.xTip)
+    .attr("cy", (d) => d.yTip)
+    .attr("r", (d) => d.r)
+    .on("mouseover", this.callbacks.onTipHover)
+    .on("mouseout", this.callbacks.onTipLeave)
+    .on("click", this.callbacks.onTipClick)
+    .style("pointer-events", "auto")
+    .style("visibility", (d) => d.visibility === NODE_VISIBLE ? "visible" : "hidden")
+    .style("fill", (d) => d.fill || params.tipFill)
+    .style("stroke", (d) => d.tipStroke || params.tipStroke)
+    .style("stroke-width", () => params.tipStrokeWidth) /* don't want branch thicknesses applied */
+    .style("cursor", "pointer");
 
   timerEnd("drawTips");
 };
@@ -160,14 +161,17 @@ export const drawBranches = function drawBranches() {
       .selectAll('.branch')
       .data(this.nodes.filter((d) => !d.terminal))
       .enter()
-        .append("path")
-          .attr("class", "branch T")
-          .attr("id", (d) => getDomId("branchT", d.n.name))
-          .attr("d", (d) => d.branch[1])
-          .style("stroke", (d) => d.branchStroke || params.branchStroke)
-          .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
-          .style("fill", "none")
-          .style("pointer-events", "auto");
+      .append("path")
+      .attr("class", "branch T")
+      .attr("id", (d) => getDomId("branchT", d.n.name))
+      .attr("d", (d) => d.branch[1])
+      .style("stroke", (d) => d.branchStroke || params.branchStroke)
+      .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
+      .style("fill", "none")
+      .style("pointer-events", "auto")
+      .on("mouseover", this.callbacks.onBranchHover)
+      .on("mouseout", this.callbacks.onBranchLeave)
+      .on("click", this.callbacks.onBranchClick);
   }
 
   /* PART 2: draw the branch stems (i.e. the actual branches) */
@@ -179,15 +183,7 @@ export const drawBranches = function drawBranches() {
   }
   this.groups.branchGradientDefs.selectAll("*").remove();
   // TODO -- explore if duplicate <def> elements (e.g. same colours on each end) slow things down
-  
-  this.nodes.forEach((d) => {
-    const a = d.parent.branchStroke;
-    const b = d.branchStroke;
-    if (a===b) return;
-    this.makeLinearGradient(`${d.parent.n.arrayIdx}:${d.n.arrayIdx}`, [[0, a], [100, b]], d.rot);
-  });
-  
-
+  this.updateColorBy();
   /* PART 2b: Draw the stems */
   if (!("branchStem" in this.groups)) {
     this.groups.branchStem = this.svg.append("g").attr("id", "branchStem");
@@ -196,25 +192,22 @@ export const drawBranches = function drawBranches() {
     .selectAll('.branch')
     .data(this.nodes)
     .enter()
-      .append("path")
-        .attr("class", "branch S")
-        .attr("id", (d) => getDomId("branchS", d.n.name))
-        .attr("d", (d) => d.branch[0])
-        .style("stroke", (d) => {
-          if (!d.branchStroke) return params.branchStroke;
-          if (d.branchStroke === d.parent.branchStroke) {
-            return d.branchStroke;
-          }
-          return `url(#${d.parent.n.arrayIdx}:${d.n.arrayIdx})`;
-        })
-        .style("stroke-linecap", "round")
-        .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
-        .style("visibility", getBranchVisibility)
-        .style("cursor", (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default")
-        .style("pointer-events", "auto")
-        .on("mouseover", this.callbacks.onBranchHover)
-        .on("mouseout", this.callbacks.onBranchLeave)
-        .on("click", this.callbacks.onBranchClick);
+    .append("path")
+    .attr("class", "branch S")
+    .attr("id", (d) => getDomId("branchS", d.n.name))
+    .attr("d", (d) => d.branch[0])
+    .style("stroke", (d) => {
+      if (!d.branchStroke) return params.branchStroke;
+      return strokeForBranch(d,"S");
+    })
+    .style("stroke-linecap", "round")
+    .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
+    .style("visibility", getBranchVisibility)
+    .style("cursor", (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default")
+    .style("pointer-events", "auto")
+    .on("mouseover", this.callbacks.onBranchHover)
+    .on("mouseout", this.callbacks.onBranchLeave)
+    .on("click", this.callbacks.onBranchClick);
 
   timerEnd("drawBranches");
 };
@@ -268,33 +261,97 @@ export const clearSVG = function clearSVG() {
   this.svg.selectAll("*").remove();
 };
 
-export const makeLinearGradient = function makeLinearGradient(id, stops, rot) {
-	
-  const linearGradient = this.groups.branchGradientDefs.append("linearGradient")
-    .attr("id", id);
-    if( rot && typeof rot === "number") { // skip 0 rotation
-      linearGradient.attr("gradientTransform","translate(.5,.5) rotate("+rot+") translate(-.5,-.5)");
+
+export const updateColorBy = function() {
+    //console.log("updating colorBy")
+  this.nodes.forEach((d) => {
+    const a = d.parent.branchStroke;
+    const b = d.branchStroke;
+    const id = `T${this.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
+    if (a === b) { // not a gradient // color can be computed from d alone
+      this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
+      return;
     }
-   // .attr("x1", "0%") // TODO -- customise these via args, will be needed for non horizontal lines
-  //  .attr("x2", "100%") // these are the default values for linear gradient, so are not needed to be added
-   // .attr("y1", "0%")
-  //  .attr("y2", "0%");
-  stops.forEach((stop) => {
-    linearGradient.append("stop")
-    .attr("offset", `${stop[0]}%`)
-    .attr("stop-color", stop[1]);
-    
+    if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
+      // console.log("adjusting " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
+      this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);
+      this.svg.select(`#${id}_end`).attr("stop-color", d.branchStroke);
+
+    } else { // otherwise create a new gradient
+      //  console.log("new gradient " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
+      const linearGradient = this.svg.select("defs").append("linearGradient")
+        .attr("id", id);
+      if (d.rot && typeof d.rot === "number") {
+        linearGradient.attr("gradientTransform", "translate(.5,.5) rotate(" + d.rot + ") translate(-.5,-.5)");
+      }
+      linearGradient.append("stop")
+        .attr("id", id + "_begin")
+        .attr("offset", "0")
+        .attr("stop-color", d.parent.branchStroke);
+      linearGradient.append("stop")
+        .attr("id", id + "_end")
+        .attr("offset", "1")
+        .attr("stop-color", d.branchStroke);
+    }
   });
 };
 
-function getRateEstimate(regression, maxDivergence) {
-  /* Prior to Jan 2020, the divergence measure was always "subs per site per year"
-  however certain datasets chaged this to "subs per year" across entire sequence.
-  This distinction is not set in the JSON, so in order to correctly display the rate
-  we will "guess" this here. A future augur update will export this in a JSON key,
-  removing the need to guess */
-  if (maxDivergence > 5) {
-    return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
+export const strokeForBranch = function(d, b) {
+  const id = `T${d.that.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
+  //console.log(id + " " +  b);
+  if (d.branchStroke === d.parent.branchStroke || b === "T") {
+    //console.log("stroking " + id + " " + d.branchStroke);
+    return d.branchStroke;
   }
-  return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
+  return `url(#${id})`;
+};
+
+export const branchStrokeForLeave = function(d) {
+  if (!d) { return; }
+  handleHoverColor(d, d.parent.branchStroke,d.branchStroke);
+};
+
+export const branchStrokeForHover = function(d) {
+  if (!d) { return; }
+  handleHoverColor(d, getEmphasizedColor(d.parent.branchStroke),getEmphasizedColor(d.branchStroke));
+};
+
+const handleHoverColor = function(d, c1, c2){
+  if (!d) { return; }
+  
+  const id = `T${d.that.debugId}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
+ 
+  /* We want to emphasize the colour of the branch. How we do this depends on how the branch was rendered in the first place! */
+  const tel = d.that.svg.select(getDomId("#branchT", d.n.name));
+
+  if (!tel.empty()) { // Some displays don't have S & T parts of the branch
+    tel.style("stroke", c2);
+  }
+  const sel = d.that.svg.select(getDomId("#branchS", d.n.name));
+  if (!sel.empty()) {
+    if (d.branchStroke === d.parent.branchStroke){
+        sel.style("stroke", c2);
+      } else {
+      //console.log("going to gradient " + el.attr("id"));
+      const begin = d.that.svg.select(`#${id}_begin`);
+      if (begin) {
+        begin.attr("stop-color", c1);
+      }
+      const end = d.that.svg.select(`#${id}_end`);
+      if (end) {
+        end.attr("stop-color", c2);
+      }
+    }
+  }
 }
+  function getRateEstimate(regression, maxDivergence) {
+    /* Prior to Jan 2020, the divergence measure was always "subs per site per year"
+    however certain datasets chaged this to "subs per year" across entire sequence.
+    This distinction is not set in the JSON, so in order to correctly display the rate
+    we will "guess" this here. A future augur update will export this in a JSON key,
+    removing the need to guess */
+    if (maxDivergence > 5) {
+      return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
+    }
+    return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
+  };

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -271,18 +271,19 @@ export const clearSVG = function clearSVG() {
 export const makeLinearGradient = function makeLinearGradient(id, stops, rot) {
 	
   const linearGradient = this.groups.branchGradientDefs.append("linearGradient")
-    .attr("id", id)
-    .attr("x1", "0%") // TODO -- customise these via args, will be needed for non horizontal lines
-    .attr("x2", "100%")
-    .attr("y1", "0%")
-    .attr("y2", "0%");
+    .attr("id", id);
+    if( rot && typeof rot === "number") { // skip 0 rotation
+      linearGradient.attr("gradientTransform","translate(.5,.5) rotate("+rot+") translate(-.5,-.5)");
+    }
+   // .attr("x1", "0%") // TODO -- customise these via args, will be needed for non horizontal lines
+  //  .attr("x2", "100%") // these are the default values for linear gradient, so are not needed to be added
+   // .attr("y1", "0%")
+  //  .attr("y2", "0%");
   stops.forEach((stop) => {
     linearGradient.append("stop")
     .attr("offset", `${stop[0]}%`)
     .attr("stop-color", stop[1]);
-    if( rot ) {
-      linearGradient.attr("gradientTransform","rotate("+rot+")");
-    }
+    
   });
 };
 

--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -36,7 +36,7 @@ export const onTipClick = function onTipClick(d) {
 export const onBranchHover = function onBranchHover(d) {
   if (d.visibility !== NODE_VISIBLE) return;
 
-    branchStrokeForHover(d);
+  branchStrokeForHover(d);
 
   /* if temporal confidence bounds are defined for this branch, then display them on hover */
   if (this.props.temporalConfidence.exists && this.props.temporalConfidence.display && !this.props.temporalConfidence.on) {

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -1,4 +1,4 @@
-import { rgb } from "d3-color";
+import { rgb, hsl } from "d3-color";
 import { interpolateRgb } from "d3-interpolate";
 import { scalePow } from "d3-scale";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
@@ -76,10 +76,11 @@ export const calcNodeColor = (tree, colorScale) => {
 // scale entropy such that higher entropy maps to a grayer less-certain branch
 const branchInterpolateColour = "#BBB";
 const branchOpacityConstant = 0.6;
+const branchOpacityLowerBound = 0.4;
 export const branchOpacityFunction = scalePow()
-  .exponent([0.6])
-  .domain([0, 2.0])
-  .range([0.4, 1])
+  .exponent([0.3])
+  .domain([0, 1])
+  .range([branchOpacityLowerBound, 1])
   .clamp(true);
 // entropy calculation precomputed in augur
 // export const calcEntropyOfValues = (vals) =>
@@ -103,4 +104,15 @@ export const calcBranchStrokeCols = (tree, confidence, colorBy) => {
   return tree.nodeColors.map((col) => {
     return rgb(interpolateRgb(col, branchInterpolateColour)(branchOpacityConstant)).toString();
   });
+};
+
+
+/**
+ * Return an emphasized color
+ */
+export const getEmphasizedColor = (color) => {
+  const hslColor = hsl(color);
+  hslColor.s *= 1.8; // more saturation
+  hslColor.l /= 1.2; // less luminance
+  return rgb(hslColor).toString();
 };


### PR DESCRIPTION
This should be PR #897 with an addition of a rotation added to the gradient definition to account for layouts other than rectangular.
Showing reversed gradient:
![Pre](https://user-images.githubusercontent.com/1314245/76662109-53ffc100-653a-11ea-8f1a-f5643f59a6c7.png)

Showing rotated gradient:
![Post](https://user-images.githubusercontent.com/1314245/76662159-7265bc80-653a-11ea-90d6-a94ca300245e.png)
