### PR TITLE
Enabled right to left text to be properly justified in narratives

### DIFF
--- a/src/components/narrative/MainDisplayMarkdown.js
+++ b/src/components/narrative/MainDisplayMarkdown.js
@@ -101,7 +101,7 @@ const EXPERIMENTAL_MainDisplayMarkdown = ({narrativeBlock, width, mobile}) => {
   const cleanHTML = mdToHtml(narrativeBlock.mainDisplayMarkdown);
   return (
     <Container width={width} mobile={mobile}>
-      <div dangerouslySetInnerHTML={{ __html: cleanHTML }}/>
+      <div dir="auto" dangerouslySetInnerHTML={{ __html: cleanHTML }}/>
     </Container>
   );
 };

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -146,6 +146,7 @@ class Narrative extends React.Component {
 
       return (
         <div
+          dir="auto"
           id={`NarrativeBlock_${i}`}
           key={i}
           style={{


### PR DESCRIPTION
This pull request should close #954.

The `dir="auto"` property was added to each narrative block, and to the `MainDisplayMarkdown` container.