### PR TITLE
make shell scripts conform to shellcheck standards

### DIFF
--- a/scripts/create-data-dir.sh
+++ b/scripts/create-data-dir.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if ! [ -d "data" ]; then
   echo "Creating empty data directory"
   mkdir data

--- a/scripts/get-data.sh
+++ b/scripts/get-data.sh
@@ -66,7 +66,7 @@ rm -rf data/
 mkdir -p data/
 for i in "${data_files[@]}"
 do
-  curl http://data.nextstrain.org/${i} --compressed -o data/${i}
+  curl http://data.nextstrain.org/"${i}" --compressed -o data/"${i}"
 done
 
 echo "The local data directory ./data now contains up-to-date datasets from http://data.nextstrain.org"

--- a/scripts/get-narratives.sh
+++ b/scripts/get-narratives.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function errorFound {
-  echo -e "\nScript Failed at step $step (Line $1)\n"
+  echo -e "\nScript Failed at line $1\n"
   exit 2
 }
 trap 'errorFound $LINENO' ERR

--- a/scripts/rebuild-docker-image.sh
+++ b/scripts/rebuild-docker-image.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 echo "Pinging Travis CI to rebuild Docker image"
 
 body='{


### PR DESCRIPTION
This basically just includes missing shebangs, some quoting and removing reference to a variable never assigned to.