### PR TITLE
Make tables in narratives look acceptable

### DIFF
--- a/src/components/narrative/styles.js
+++ b/src/components/narrative/styles.js
@@ -15,7 +15,7 @@ export const NarrativeStyles = styled.div`
     line-height: 1.1;
   }
 
-  p,h1,h2,h3,h4,li {
+  p, h1, h2, h3, h4, li, table {
     color: ${(props) => props.theme.unselectedColor};
   }
 
@@ -64,6 +64,10 @@ export const NarrativeStyles = styled.div`
     margin: 10px 0px 10px 0px;
     font-weight: inherit;
     line-height: inherit;
+  }
+
+  table {
+    width: 100%;
   }
 
   strong {

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -38,16 +38,20 @@ a, .link {
   font-size: 94%;
 }
 
-/* from Bootstrap */
+/* Table styles: from Bootstrap and customized */
 table {
   border-collapse: collapse;
   border-spacing: 0;
 }
-td,
-th {
-  padding: 0;
+
+table, th, td {
+  border: 1px solid;
 }
-/* end bootstrap */
+
+td, th {
+  padding: 3px;
+}
+/* end table styles */
 
 .panel th {
   text-align: left;


### PR DESCRIPTION
Meant to address #887

Before:

![image](https://user-images.githubusercontent.com/28556218/77232818-901ecb80-6ba3-11ea-9522-9fea3112c5a1.png)

After: 

![image](https://user-images.githubusercontent.com/28556218/77232805-7f6e5580-6ba3-11ea-82b8-06c402480d45.png)
