### PR TITLE
Fix some broken links in documentation

### DIFF
--- a/docs-src/docs/customise-client/api.md
+++ b/docs-src/docs/customise-client/api.md
@@ -21,7 +21,7 @@ auspice build --extend <JSON>
 
 ## Available Customisations
 The following are definable as top-level keys of the JSON file.
-A useful reference may be the [customisation JSON file](https://github.com/nextstrain/nextstrain.org/blob/master/auspice/client/config.json) used by nextstrain.org.
+A useful reference may be the [customisation JSON file](https://github.com/nextstrain/nextstrain.org/blob/master/auspice-client/customisations/config.json) used by nextstrain.org.
 
 * `sidebarTheme` allows modifications to the aesthetics of the sidebar. See below.
 * `navbarComponent` a (relative) path to a JS file exporting a React component to be rendered as the nav bar. See below.

--- a/docs-src/docs/customise-client/introduction.md
+++ b/docs-src/docs/customise-client/introduction.md
@@ -16,7 +16,7 @@ This is achieved by providing a JSON at build time to Auspice which defines the 
 auspice build --extend <JSON>
 ```
 
-[Here's](https://github.com/nextstrain/nextstrain.org/blob/master/auspice/client/config.json) the file used by nextstrain.org to change the appearance of Auspice in the above image.
+[Here's](https://github.com/nextstrain/nextstrain.org/blob/master/auspice-client/customisations/config.json) the file used by nextstrain.org to change the appearance of Auspice in the above image.
 
 
 See the [client customisation API](customise-client/api.md) for the available options.

--- a/docs-src/docs/introduction/how-to-run.md
+++ b/docs-src/docs/introduction/how-to-run.md
@@ -80,9 +80,9 @@ Auspice takes two different file types: datasets (the tree, map, etc.), which ar
 ### Dataset JSONs
 
 For datasets, Auspice (v2.x) can currently load either
-* "Auspice v1" JSONs (metadata + tree JSONs) -- see the JSON schemas [here](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v1-meta.json) and [here](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v1-tree.json).
+* "Auspice v1" JSONs (metadata + tree JSONs) -- see the JSON schemas [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-meta.json) and [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-tree.json).
 _The zika dataset we download above is in this format_
-* "Auspice v2" JSONs. See the JSON schema [here](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v2.json).
+* "Auspice v2" JSONs. See the JSON schema [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json).
 
 See the [Server API](server/api.md) for more details about the file formats an Auspice server (e.g. `auspice view`) sends to the client.
 

--- a/docs-src/docs/releases/v2.md
+++ b/docs-src/docs/releases/v2.md
@@ -55,9 +55,9 @@ We've settled on a new single "v2" JSON, containing pretty similar information t
 
 | file | schema | auspice versions | description |
 | ---- | ---- | ---- | ---- |
-|"tree" JSON | [Link](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v1-tree.json) | v1, v2 | Decorated phylogenetic tree |
-|"meta" JSON | [Link](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v1-meta.json) | v1, v2 | The "metadata" associated with a phylogenetic tree |
-|"v2" JSON | [Link](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v2.json) | v2 | The single input format required for Auspice v2 |
+|"tree" JSON | [Link](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-tree.json) | v1, v2 | Decorated phylogenetic tree |
+|"meta" JSON | [Link](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-meta.json) | v1, v2 | The "metadata" associated with a phylogenetic tree |
+|"v2" JSON | [Link](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json) | v2 | The single input format required for Auspice v2 |
 
 If you use Augur to construct your JSONs, then the next version of Augur (v6) will give you the option to produce "v1" or "v2" JSONs.
 If you have specific queries, the JSON schemas (above) should help you out, but here is a list of the main changes (with links to PRs where relevent, if you're _really_ keen!):

--- a/docs-src/docs/server/api.md
+++ b/docs-src/docs/server/api.md
@@ -55,7 +55,7 @@ Failure to return a valid JSON will result in a warning notification shown in Au
 
 The JSON response depends on the file-type being requested.
 
-If the type is not specified, i.e. we're requesting the "main" dataset JSON then [see this JSON schema](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v2.json).
+If the type is not specified, i.e. we're requesting the "main" dataset JSON then [see this JSON schema](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json).
 Note that the Auspice client _cannot_ process v1 (meta / tree) JSONs -- [see below](server/api.md#importing-code-from-auspice) for how to convert these.
 
 Alternative file type reponses are to be documented.
@@ -100,7 +100,7 @@ The provided JavaScript file must export three functions, each of which handles 
 
 For information about the `req` and `res` arguments see the express documentation for the [request object](https://expressjs.com/en/api.html#req) and [response object](https://expressjs.com/en/api.html#res), respectively.
 
-You can see [nextstrain.org](https://nextstrain.org)'s implementation of these handlers [here](https://github.com/nextstrain/nextstrain.org/blob/master/auspice/server/index.js).
+You can see [nextstrain.org](https://nextstrain.org)'s implementation of these handlers [here](https://github.com/nextstrain/nextstrain.org/blob/master/server.js).
 
 Here's a pseudocode example of an implementation for the `getAvailable` handler which may help understanding:
 
@@ -141,7 +141,7 @@ where `tree` is the v1 tree JSON, and `meta` the v1 meta JSON.
 
 **Returns:**
 
-An object representing the v2 JSON [defined by this schema](https://github.com/nextstrain/augur/blob/v6/augur/data/schema-export-v2.json).
+An object representing the v2 JSON [defined by this schema](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json).
 
 
 


### PR DESCRIPTION
These links were pointing to GitHub resources which have since moved slightly.