### PR TITLE
Enlarge progress buttons when hovering

### DIFF
--- a/src/components/narrative/styles.js
+++ b/src/components/narrative/styles.js
@@ -163,11 +163,16 @@ export const ProgressButton = styled.div`
   background: #74a9cf;
   border-radius: 50%;
   cursor: pointer;
+  transition: transform .1s;
 
   // BEGIN: mitigate ie flexbug-15: https://github.com/philipwalton/flexbugs#flexbug-15
   align-self: center;
   margin: auto;
   // END mitigate ie flexbug-15
+
+  &:hover {
+    transform: scale(3);
+  }
 `;
 
 const baseBannerStyles = css`


### PR DESCRIPTION
This may fix one issue raised by https://github.com/nextstrain/auspice/issues/921. Progress buttons are small and hard to pinpoint and click, so this pull request adds a temporary enlargement on hovering.