### PR TITLE
Fix #973 (Legend ordering)

### DIFF
--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -8,6 +8,7 @@ import { getExtraVals } from "./colorHelpers";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
 import { setGenotype, orderOfGenotypeAppearance } from "./setGenotype";
 import { getTraitFromNode } from "./treeMiscHelpers";
+import { sortedDomain } from "./sortedDomain";
 
 const unknownColor = "#AAAAAA";
 
@@ -39,13 +40,7 @@ const getDiscreteValuesFromTree = (nodes, nodesToo, attr) => {
       stateCount.set(state, currentCount+1);
     }
   }
-  const domain = Array.from(stateCount.keys()).filter((x) => isValueValid(x));
-  /* sorting technique depends on the colorBy */
-  if (attr === "clade_membership") {
-    domain.sort();
-  } else {
-    domain.sort((a, b) => stateCount[a] > stateCount[b] ? 1 : -1);
-  }
+  const domain = sortedDomain(Array.from(stateCount.keys()).filter((x) => isValueValid(x)), attr, stateCount);
   return domain;
 };
 

--- a/src/util/sortedDomain.js
+++ b/src/util/sortedDomain.js
@@ -1,0 +1,15 @@
+export const sortedDomain = (domain, attr, stateCount) => {
+  /* sorting technique depends on the colorBy */
+  const sorted = Array.from(domain);
+  if (attr === "clade_membership") {
+    sorted.sort();
+  } else {
+    sorted.sort(
+      (a, b) =>
+        stateCount.get(a) === stateCount.get(b)
+          ? a < b ? -1 : 1
+          : stateCount.get(a) > stateCount.get(b) ? -1 : 1
+    );
+  }
+  return sorted;
+};

--- a/test/sortedDomain.test.js
+++ b/test/sortedDomain.test.js
@@ -1,0 +1,67 @@
+import { sortedDomain } from "../src/util/sortedDomain";
+
+test("sortedDomain works correctly in normal case", () => {
+  const stateCount = new Map([
+    ["Italy", 8],
+    ["Lombardy", 9],
+    ["USA", 1],
+    ["Iran", 18],
+    ["Comunitat Valenciana", 1],
+    ["Hubei", 35],
+    ["China", 2],
+    ["Grand Princess", 2],
+    ["Hong Kong", 1],
+    ["South Korea", 1],
+    ["Europe", 1],
+    ["UK", 1]
+  ]);
+  const domain = stateCount.keys();
+  const sorted = sortedDomain(domain, "", stateCount);
+  expect(sorted).toMatchObject([
+    "Hubei",
+    "Iran",
+    "Lombardy",
+    "Italy",
+    "China",
+    "Grand Princess",
+    "Comunitat Valenciana",
+    "Europe",
+    "Hong Kong",
+    "South Korea",
+    "UK",
+    "USA"
+  ]);
+});
+
+test("sortedDomain works correctly in special case", () => {
+  const stateCount = new Map([
+    ["Italy", 8],
+    ["Lombardy", 9],
+    ["USA", 1],
+    ["Iran", 18],
+    ["Comunitat Valenciana", 1],
+    ["Hubei", 35],
+    ["China", 2],
+    ["Grand Princess", 2],
+    ["Hong Kong", 1],
+    ["South Korea", 1],
+    ["Europe", 1],
+    ["UK", 1]
+  ]);
+  const domain = stateCount.keys();
+  const sorted = sortedDomain(domain, "clade_membership", stateCount);
+  expect(sorted).toMatchObject([
+    "China",
+    "Comunitat Valenciana",
+    "Europe",
+    "Grand Princess",
+    "Hong Kong",
+    "Hubei",
+    "Iran",
+    "Italy",
+    "Lombardy",
+    "South Korea",
+    "UK",
+    "USA"
+  ]);
+});


### PR DESCRIPTION
### Description of proposed changes    

- The legend ordering code was treating `stateCount` as an object when it is actually a Map.
- Added code to sort items alphabetically if they have equal counts.
- Refactored this code into its own module for easier testing.
- Added unit tests.

### Related issue(s)  

Related to #973 

### Testing

Verified the changes locally, and added Jest tests.

### Thank you for contributing to Nextstrain!
