### PR TITLE
Leaflet gesture handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9033,9 +9033,14 @@
       }
     },
     "leaflet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
-      "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz",
+      "integrity": "sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ=="
+    },
+    "leaflet-gesture-handling": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/leaflet-gesture-handling/-/leaflet-gesture-handling-1.1.8.tgz",
+      "integrity": "sha512-QnKNAqZxaO4nzCsHA9l/vPazF15TILkSaYNoDqMtiVXrsWMWh6fWD4phRuftPC+kvY9OBzVKuTfKlLdhZ/2oIg=="
     },
     "leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "i18next-resource-store-loader": "^0.1.2",
     "json-loader": "^0.5.1",
     "leaflet": "^1.2.0",
+    "leaflet-gesture-handling": "^1.1.8",
     "linspace": "^1.0.0",
     "lodash": "^4.17.15",
     "marked": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "i18next": "^19.3.2",
     "i18next-resource-store-loader": "^0.1.2",
     "json-loader": "^0.5.1",
-    "leaflet": "^1.2.0",
+    "leaflet": "^1.6.0",
     "leaflet-gesture-handling": "^1.1.8",
     "linspace": "^1.0.0",
     "lodash": "^4.17.15",

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import leaflet from "leaflet";
+import { GestureHandling } from "leaflet-gesture-handling";
 import _min from "lodash/min";
 import _max from "lodash/max";
 import domtoimage from "dom-to-image";
@@ -466,10 +467,13 @@ class Map extends React.Component {
     GET LEAFLET IN THE DOM
     **************************************** */
 
+    L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);
+
     const map = L.map('map', {
       center: center,
       zoom: zoom,
       scrollWheelZoom: false,
+      gestureHandling: true,
       maxBounds: this.getInitialBounds(),
       minZoom: 1,
       maxZoom: 14,

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -472,28 +472,13 @@ class Map extends React.Component {
     const map = L.map('map', {
       center: center,
       zoom: zoom,
-      scrollWheelZoom: false,
       gestureHandling: true,
       maxBounds: this.getInitialBounds(),
       minZoom: 1,
       maxZoom: 14,
       zoomSnap: 0.5,
       zoomControl: false,
-      /* leaflet sleep see https://cliffcloud.github.io/Leaflet.Sleep/#summary */
-      // true by default, false if you want a wild map
-      sleep: false,
-      // time(ms) for the map to fall asleep upon mouseout
-      sleepTime: 750,
-      // time(ms) until map wakes on mouseover
-      wakeTime: 750,
-      // defines whether or not the user is prompted oh how to wake map
-      sleepNote: true,
-      // should hovering wake the map? (clicking always will)
-      hoverToWake: false,
-      // if mobile OR narrative mode, disable single finger dragging
-      dragging: (!L.Browser.mobile) && (!this.props.narrativeMode),
       doubleClickZoom: !this.props.narrativeMode,
-      tap: false
     });
 
     map.getRenderer(map).options.padding = 2;

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { initialiseGoogleAnalyticsIfRequired } from "./util/googleAnalytics";
 /* S T Y L E S H E E T S */
 import "font-awesome/css/font-awesome.css";
 import "leaflet/dist/leaflet.css";
+import "leaflet-gesture-handling/dist/leaflet-gesture-handling.css";
 import "./css/global.css";
 import "./css/browserCompatability.css";
 import "./css/bootstrapCustomized.css";


### PR DESCRIPTION
With this PR it is possible to use the mouse scroll wheel in combination with Ctrl/Cmd to zoom in/out the map. It fixes #260.

I've tested it on desktop browsers as well as on Android phone.

The [Leaflet.Sleep](https://github.com/CliffCloud/Leaflet.Sleep) code was inactive, because `src/util/leaflet-plugins.js` was removed with commit f972a8a.