### PR TITLE
Add panels to display_defaults

### DIFF
--- a/docs-src/docs/advanced-functionality/view-settings.md
+++ b/docs-src/docs/advanced-functionality/view-settings.md
@@ -36,9 +36,10 @@ For instance, if you set `display_defaults.color_by` to `country`, but load the 
 | `map_triplicate`    | Should the map repeat, so that you can pan further in each direction? | Boolean |
 | `layout`            | Tree layout        | "rect", "radial", "clock" or "unrooted |
 | `branch_label`      | Which set of branch labels are to be displayed | "aa", "lineage" |
+| `panels`            | List of panels which (if available) are to be displayed  | ["tree", "map"] |
 
-Furthermore, a JSON property `meta.panels` lists which panels auspice displays.
-If this is not included, then auspice tries to display as many as possible.
+
+Note that `meta.display_defaults.panels` (optional) differs from `meta.panels` (required), where the latter lists the possible panels that auspice may display for the dataset.
 See the [JSON schema](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json) for more details.
 
 **See this in action:**

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -95,7 +95,11 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.TOGGLE_PANEL_DISPLAY: {
-      if (state.controls.panelsAvailable.length === action.panelsToDisplay.length) {
+      /* check this against the defaults set by the dataset (and this default is all available panels if not specifically set) */
+      if (
+        state.controls.defaults.panels.length===action.panelsToDisplay.length &&
+        state.controls.defaults.panels.filter((p) => !action.panelsToDisplay.includes(p)).length===0
+      ) {
         query.d = undefined;
       } else {
         query.d = action.panelsToDisplay.join(",");


### PR DESCRIPTION
Allows datasets to define which panels are shown by default. This is optional and overridable via URL queries.
