### PR TITLE
Issue 999

### DIFF
--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -70,7 +70,7 @@ export const createSummary = (mainTreeNumTips, nodes, filters, visibility, visib
   let summary = ""; /* text returned from this function */
 
   /* Number of genomes & their date range */
-  if (branchLengthsToDisplay !== "divOnly") {
+  if (branchLengthsToDisplay !== "divOnly" && nSelectedSamples > 0) {
     summary += t(
       "Showing {{x}} of {{y}} genomes sampled between {{from}} and {{to}}.",
       {

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -7,9 +7,7 @@ export const getVisibleDateRange = (nodes, visibility) => nodes
   .filter((node, idx) => (visibility[idx] === NODE_VISIBLE && !node.hasChildren))
   .reduce((acc, node) => {
     const nodeDate = getTraitFromNode(node, "num_date");
-    if (nodeDate && nodeDate < acc[0]) return [nodeDate, acc[1]];
-    if (nodeDate && nodeDate > acc[1]) return [acc[0], nodeDate];
-    return acc;
+    return nodeDate ? [Math.min(nodeDate, acc[0]), Math.max(nodeDate, acc[1])] : acc;
   }, [100000, -100000]);
 
 export const strainNameToIdx = (nodes, name) => {


### PR DESCRIPTION
### Description of proposed changes    
Fixes issue: https://github.com/nextstrain/auspice/issues/999 (Incorrect dates in the header info display when no tip nodes are in the date selection)

Fixed the description so it doesn't present date range when there is no nodes present (because 0 nodes have never been sampled).
Also fixed `getVisibleDateRange` function so it would handle single element list nicely.
### Testing
Tested manually.

 