### PR TITLE
Strawman: VSCode dev container mode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# To fully customize the contents of this image, use the following Dockerfile instead:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/javascript-node-10/.devcontainer/Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-10
+RUN rm -rf /root/.npm
+
+# ** [Optional] Uncomment this section to install additional packages. **
+#
+# ENV DEBIAN_FRONTEND=noninteractive
+# RUN apt-get update \
+#    && apt-get -y install --no-install-recommends <your-package-list-here> \
+#    #
+#    # Clean up
+#    && apt-get autoremove -y \
+#    && apt-get clean -y \
+#    && rm -rf /var/lib/apt/lists/*
+# ENV DEBIAN_FRONTEND=dialog
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/javascript-node-10
+{
+	"name": "Node.js 10",
+	"dockerFile": "Dockerfile",
+	
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install --global .",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,39 @@ auspice develop --datasetDir data
 
 Run `auspice --help` or `auspice view --help` to see all the available command line options.
 
+### Visual Studio Code Development Container
+
+Auspice development can also occur in a VSCode development container. 
+
+System requirements:
+- VSCode on Windows, Mac, or Linux
+- Docker
+
+
+```bash
+git clone https://github.com/nextstrain/auspice.git
+cd auspice
+#Ensure the development containers extension is installed
+#This can be done via the GUI or through the below command:
+code --install-extension ms-vscode-remote.remote-containers
+
+#Open VSCode to the cloned directory.
+code .
+
+#Click the remote connection button in the lower left, and pick 'Remote-Container: Reopen in Container'
+
+#Click Terminal->New Terminal. This opens up a command shell inside the development container, then:
+#optional
+npm run get-data
+#optional
+npm run get-narratives
+
+#Show that the application functions normally. 
+#Run in develop mode and view results in browser (localhost:4000)
+auspice develop
+```
+
+
 ## Contributor Information
 
 > We have received a number of generous offers to contribute developer effort to nextstrain (and auspice) following our work on hCoV-19. We welcome contributions! To get started, please review these resources before submitting a pull request:


### PR DESCRIPTION
#762 
I have a proposal to sidestep the conda vs global auspice install entirely - support the use of VSCode development containers.

This wraps the global install for auspice to just the docker container, rather than the bare metal machine.

To test, please give the updated README.md notes a try. 