### PR TITLE
Enable navigation to End-of-narrative page

### DIFF
--- a/src/components/narrative/MobileNarrativeDisplay.js
+++ b/src/components/narrative/MobileNarrativeDisplay.js
@@ -65,13 +65,7 @@ class MobileNarrativeDisplay extends React.Component {
     };
 
     this.goToNextPage = () => {
-      if (this.state.showingEndOfNarrativePage) return; // no-op
-
-      if (this.props.currentInFocusBlockIdx+1 === this.props.blocks.length) {
-        this.setState({showingEndOfNarrativePage: true});
-        return;
-      }
-
+      if (this.props.currentInFocusBlockIdx === this.props.blocks.length) return; // no-op
       this._goToPage(this.props.currentInFocusBlockIdx+1);
     };
 
@@ -80,7 +74,22 @@ class MobileNarrativeDisplay extends React.Component {
       this._goToPage(this.props.currentInFocusBlockIdx-1);
     };
 
+    this._goToEndOfNarrativePage = () => {
+      this.setState({showingEndOfNarrativePage: true});
+      this.props.dispatch(changePage({
+        changeDataset: false,
+        query: undefined,
+        queryToDisplay: {n: this.props.blocks.length},
+        push: true
+      }));
+    };
+
     this._goToPage = (idx) => {
+      if (idx === this.props.blocks.length) {
+        this._goToEndOfNarrativePage();
+        return;
+      }
+
       this.setState({ showingEndOfNarrativePage: false });
 
       // TODO: this `if` statement should be moved to the `changePage` function or similar
@@ -232,28 +241,33 @@ class MobileNarrativeDisplay extends React.Component {
   )
 
   renderProgress() {
+    const ret = this.props.blocks.map((b, i) => {
+      const d = (!this.state.showingEndOfNarrativePage) &&
+        this.props.currentInFocusBlockIdx === i ? "14px" : "6px";
+      return (<ProgressButton
+        key={i}
+        style={{width: d, height: d}}
+        onClick={() => this._goToPage(i)}
+      />);
+    });
+    const d = this.state.showingEndOfNarrativePage ? "14px" : "6px";
+    ret.push((<ProgressButton key={this.props.blocks.length}
+      style={{width: d, height: d}}
+      onClick={() => this._goToPage(this.props.blocks.length)}
+    />));
+
     return (
       <ProgressBar id="progress-bar"
         style={{height: `${progressHeight}px`}}
       >
-        {this.props.blocks.map((b, i) => {
-          const d = (!this.state.showingEndOfNarrativePage) &&
-            this.props.currentInFocusBlockIdx === i ?
-            "14px" : "6px";
-          return (
-            <ProgressButton
-              key={i}
-              style={{width: d, height: d}}
-              onClick={() => this._goToPage(i)}
-            />);
-        })}
+        {ret}
       </ProgressBar>
     );
   }
 
   render() {
 
-    if (this.state.showingEndOfNarrativePage) {
+    if (this.props.currentInFocusBlockIdx === this.props.blocks.length) {
       return this.renderEndOfNarrative();
 
     } else if (this.props.currentInFocusBlockIdx === 0) {

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -127,20 +127,18 @@ class Narrative extends React.Component {
   renderProgress() {
     const ret = this.props.blocks.map((b, i) => {
       const d = (!this.state.showingEndOfNarrativePage) &&
-            this.props.currentInFocusBlockIdx === i ?
-            "14px" : "6px";
+            this.props.currentInFocusBlockIdx === i ? "14px" : "6px";
       return (<ProgressButton
-              key={i}
-              style={{width: d, height: d}}
-              onClick={() => this.reactPageScroller.goToPage(i)}
-              />);
+        key={i}
+        style={{width: d, height: d}}
+        onClick={() => this.reactPageScroller.goToPage(i)}
+      />);
     });
     const d = this.state.showingEndOfNarrativePage ? "14px" : "6px";
-    ret.push((<ProgressButton
-              key={this.props.blocks.length}
-              style={{width: d, height: d}}
-              onClick={() => this.reactPageScroller.goToPage(this.props.blocks.length)}
-              />));
+    ret.push((<ProgressButton key={this.props.blocks.length}
+      style={{width: d, height: d}}
+      onClick={() => this.reactPageScroller.goToPage(this.props.blocks.length)}
+    />));
 
     return (
       <ProgressBar style={{height: `${progressHeight}px`}}

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -211,11 +211,13 @@ class Narrative extends React.Component {
     );
   }
   componentWillUnmount() {
-    this.props.dispatch({
-      type: CHANGE_URL_QUERY_BUT_NOT_REDUX_STATE,
-      pathname: this.props.blocks[this.props.currentInFocusBlockIdx].dataset,
-      query: queryString.parse(this.props.blocks[this.props.currentInFocusBlockIdx].url)
-    });
+    if (!this.state.showingEndOfNarrativePage) {
+      this.props.dispatch({
+        type: CHANGE_URL_QUERY_BUT_NOT_REDUX_STATE,
+        pathname: this.props.blocks[this.props.currentInFocusBlockIdx].dataset,
+        query: queryString.parse(this.props.blocks[this.props.currentInFocusBlockIdx].url)
+      });
+    }
     Mousetrap.unbind(['left', 'right', 'up', 'down']);
   }
 }


### PR DESCRIPTION
### Description of proposed changes    

This PR addresses part of issue #872. On the desktop (non-mobile) view of a narrative, the "End of Narrative" page now has a dot in the progress bar (the last one) and navigation to that page should be possible with a `?n=<last narrative block + 1>`

A PR for this change in the mobile view will follow.

### Related issue(s)  
Fixes part of #872 