### PR TITLE
Increase line endpoint offset to .01 For Windows/Firefox SVG gradient rendering

### DIFF
--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -385,7 +385,7 @@ export const mapToScreen = function mapToScreen() {
       // So we add a tiny amount of jitter (e.g 1/1000px) to the horizontal line (d.branch[0])
       // see https://stackoverflow.com/questions/13223636/svg-gradient-for-perfectly-horizontal-path
       d.branch =[
-        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip+0.001}`],
+        [` M ${d.xBase - stem_offset},${d.yBase} L ${d.xTip},${d.yTip+0.01}`],
         [` M ${d.xTip},${childrenY[0]} L ${d.xTip},${childrenY[1]}`]
       ];
       if (this.params.confidence) {

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -191,7 +191,10 @@ export const drawBranches = function drawBranches() {
 
   /* PART 2a: Create linear gradient definitions which can be applied to branch stems for which
   the start & end stroke colour is different */
- 
+  if (!this.groups.branchGradientDefs) {
+    this.groups.branchGradientDefs = this.svg.append("defs");
+  }
+  this.groups.branchGradientDefs.selectAll("*").remove();
   // TODO -- explore if duplicate <def> elements (e.g. same colours on each end) slow things down
   this.updateColorBy();
   /* PART 2b: Draw the stems */
@@ -273,25 +276,21 @@ export const clearSVG = function clearSVG() {
 
 
 export const updateColorBy = function updateColorBy() {
-   if (!this.groups.branchGradientDefs) {
-    this.groups.branchGradientDefs = this.svg.append("defs");
-  }
-  this.groups.branchGradientDefs.selectAll("*").remove();
   // console.log("updating colorBy")
   this.nodes.forEach((d) => {
-    //const a = d.parent.branchStroke;
-    //const b = d.branchStroke;
+    const a = d.parent.branchStroke;
+    const b = d.branchStroke;
     const id = `T${this.id}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
-   // if (a === b) { // not a gradient // color can be computed from d alone
-  //    this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
-   //   return;
- //   }
-  //  if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
+    if (a === b) { // not a gradient // color can be computed from d alone
+      this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
+      return;
+    }
+    if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
       // console.log("adjusting " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
-  //    this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);
-  //    this.svg.select(`#${id}_end`).attr("stop-color", d.branchStroke);
+      this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);
+      this.svg.select(`#${id}_end`).attr("stop-color", d.branchStroke);
 
-  //  } else { // otherwise create a new gradient
+    } else { // otherwise create a new gradient
       //  console.log("new gradient " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
       const linearGradient = this.svg.select("defs").append("linearGradient")
         .attr("id", id);
@@ -306,7 +305,7 @@ export const updateColorBy = function updateColorBy() {
         .attr("id", id + "_end")
         .attr("offset", "1")
         .attr("stop-color", d.branchStroke);
-   // }
+    }
   });
 };
 

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -191,10 +191,7 @@ export const drawBranches = function drawBranches() {
 
   /* PART 2a: Create linear gradient definitions which can be applied to branch stems for which
   the start & end stroke colour is different */
-  if (!this.groups.branchGradientDefs) {
-    this.groups.branchGradientDefs = this.svg.append("defs");
-  }
-  this.groups.branchGradientDefs.selectAll("*").remove();
+ 
   // TODO -- explore if duplicate <def> elements (e.g. same colours on each end) slow things down
   this.updateColorBy();
   /* PART 2b: Draw the stems */
@@ -276,15 +273,19 @@ export const clearSVG = function clearSVG() {
 
 
 export const updateColorBy = function updateColorBy() {
+   if (!this.groups.branchGradientDefs) {
+    this.groups.branchGradientDefs = this.svg.append("defs");
+  }
+  this.groups.branchGradientDefs.selectAll("*").remove();
   // console.log("updating colorBy")
   this.nodes.forEach((d) => {
-    const a = d.parent.branchStroke;
-    const b = d.branchStroke;
+    //const a = d.parent.branchStroke;
+    //const b = d.branchStroke;
     const id = `T${this.id}_${d.parent.n.arrayIdx}_${d.n.arrayIdx}`;
-    if (a === b) { // not a gradient // color can be computed from d alone
-      this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
-      return;
-    }
+   // if (a === b) { // not a gradient // color can be computed from d alone
+  //    this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
+   //   return;
+ //   }
     if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
       // console.log("adjusting " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
       this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -286,12 +286,12 @@ export const updateColorBy = function updateColorBy() {
   //    this.svg.select(`#${id}`).remove(); // remove an existing gradient for this node
    //   return;
  //   }
-    if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
+  //  if (!this.svg.select(`#${id}`).empty()) { // there an existing gradient // update its colors
       // console.log("adjusting " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
-      this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);
-      this.svg.select(`#${id}_end`).attr("stop-color", d.branchStroke);
+  //    this.svg.select(`#${id}_begin`).attr("stop-color", d.parent.branchStroke);
+  //    this.svg.select(`#${id}_end`).attr("stop-color", d.branchStroke);
 
-    } else { // otherwise create a new gradient
+  //  } else { // otherwise create a new gradient
       //  console.log("new gradient " + id + " " + d.parent.branchStroke + "=>" + d.branchStroke);
       const linearGradient = this.svg.select("defs").append("linearGradient")
         .attr("id", id);
@@ -306,7 +306,7 @@ export const updateColorBy = function updateColorBy() {
         .attr("id", id + "_end")
         .attr("offset", "1")
         .attr("stop-color", d.branchStroke);
-    }
+   // }
   });
 };
 


### PR DESCRIPTION
### Description of proposed changes    
First guess at fixing missing gradients on Windows 10/Firefox. I noticed a similar issue when developing the initial gradient coloring fix. This seems to be related to how updates to the DOM are handled by change.js. (React?) 

The current code updates existing gradients by changing their stop values, adds new gradients if needed and removes gradients that are not needed. 

This code clears all gradient definitions and creates new where needed.

Need PR to allow deployment on heroku for external testing. (I don't have a local Windows 10 machine)

Also noted: there are two hits to change.js for one change of the colorBy menu item. (not because of this update) This causes a lot of work in unneeded traversal of the nodes and recalculation of the gradients. May need a separate issue.

### Related issue(s)  

Fixes # 1005
Related to #897 #947 
 

### Thank you for contributing to Nextstrain!
