### PR TITLE
fix #915: correctly determine tip counts based on visibility

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -13,8 +13,11 @@ export const updateTipLabels = function updateTipLabels(dt) {
   const yPad = this.params.tipLabelPadY;
   const inViewTerminalNodes = this.nodes
     .filter((d) => d.terminal)
-    .filter((d) => d.inView);
+    .filter((d) => d.inView)
+    .filter((d) => d.visibility == NODE_VISIBLE);
+
   // console.log(`there are ${inViewTerminalNodes.length} nodes in view`)
+  
   if (inViewTerminalNodes.length < this.params.tipLabelBreakL1) {
 
     let fontSize = this.params.tipLabelFontSizeL1;

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -14,7 +14,7 @@ export const updateTipLabels = function updateTipLabels(dt) {
   const inViewTerminalNodes = this.nodes
     .filter((d) => d.terminal)
     .filter((d) => d.inView)
-    .filter((d) => d.visibility == NODE_VISIBLE);
+    .filter((d) => d.visibility === NODE_VISIBLE);
 
   // console.log(`there are ${inViewTerminalNodes.length} nodes in view`)
   


### PR DESCRIPTION
### Description
Correctly determines whether to show tips based on the number of in-view, fully visible nodes (as opposed to partially visible, unselected nodes), not based on the number of in-view nodes in total.

### Related issue(s)  
Fixes #915 
Related to #237 

### Testing
What steps should be taken to test the changes you've proposed?  
1. Load the ncov dataset (or any of sufficient density).
2. Filter to any specific strain (or anything that selects only one node).
3. The tip for that strain should appear next to it, even on the fully zoomed-out tree.