### PR TITLE
test: text-based dataset smoke test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@ globals:
   browser: true
   context: true
   jestPuppeteer: true
+  BASE_URL: true
 rules:
   camelcase: off # require camel case names
   prefer-template: off

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
-      - run: npm install
+      - run: npm ci
       - run: npm test
   integration-test:
     runs-on: ubuntu-latest
@@ -28,10 +28,24 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm ci
       - run: npm run get-data
       - run: npm run get-narratives
       - run: npm run integration-test:ci
+  smoke-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run get-data
+      - run: npm run get-narratives
+      - run: npm run smoke-test:ci
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -16,11 +16,33 @@ Code contributions are welcomed! [Please see the main auspice docs](https://next
 Please comment on an open issue if you are working on it.
 For changes unrelated to an open issue, please make an issue outlining what you would like to change/add.
 
-Please ensure there are no **linting** errors by running `npm run lint` (which uses [eslint](https://eslint.org/)).
-In the future we will make this a requirement for PRs or commits. 
-
 Where possible, **please rebase** your work onto master rather than merging changes from master into your PR.
 
+### Make sure tests are passing
+
+When you submit a pull request to the auspice repository, a variety of integration and unit tests will need to pass before it can be merged.
+
+You will likely want to run these tests locally before submitting:
+
+First, install the dependencies with `npm i`, then:
+
+#### For unit tests:
+
+Run `npm test`.
+
+#### For linting:
+
+Run `npm run lint`. If there are issues run `npm run lint:fix`.
+
+#### For integration tests:
+
+1. Fetch the datasets with `npm run get-data` and `npm run get-narratives`.
+2. Ensure you are **not** currently running the site locally, then run `npm run integration-test:ci`.
+
+#### For smoke tests:
+
+1. Fetch the datasets with `npm run get-data` and `npm run get-narratives`.
+2. Ensure you are **not** currently running the site locally, then run `npm run smoke-test:ci`.
 
 ## Contributing to Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11626,6 +11626,15 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "quoted-printable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/quoted-printable/-/quoted-printable-1.0.1.tgz",
+      "integrity": "sha1-nuv16z0R7vAismT9LStrK7O4TMM=",
+      "dev": true,
+      "requires": {
+        "utf8": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13815,6 +13824,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "gzip-and-upload": "env bash ./scripts/gzip-and-upload.sh",
     "build-docs": "echo 'see ./docs-src/README.md'",
     "test": "jest test/*.js",
-    "integration-test": "NODE_ENV=test ENV=dev jest --config puppeteer.config.js",
+    "integration-test": "NODE_ENV=test ENV=dev jest ./test/integration/*.js --config puppeteer.config.js",
     "integration-test:ci": "start-server-and-test server http://localhost:4000 integration-test",
+    "smoke-test": "NODE_ENV=test ENV=dev jest ./test/smoke-test/urls.test.js --config puppeteer.config.js",
+    "smoke-test:ci": "start-server-and-test server http://localhost:4000 smoke-test",
     "diff-lang": "./scripts/diff-lang.js"
   },
   "dependencies": {
@@ -41,9 +43,9 @@
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/plugin-proposal-decorators": "^7.3.0",
     "@babel/plugin-transform-runtime": "^7.8.3",
-    "@babel/runtime": "^7.8.7",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.8.7",
     "argparse": "^1.0.10",
     "awesomplete": "^1.1.2",
     "babel-eslint": "^10.0.1",
@@ -137,6 +139,7 @@
     "jest": "^25.1.0",
     "jest-puppeteer": "^4.4.0",
     "puppeteer": "^2.1.1",
+    "quoted-printable": "^1.0.1",
     "start-server-and-test": "^1.11.0",
     "webpack-bundle-analyzer": "^3.3.2"
   }

--- a/test/smoke-test/urls.test.js
+++ b/test/smoke-test/urls.test.js
@@ -1,0 +1,49 @@
+const {readFileSync} = require('fs');
+const {decode} = require('quoted-printable');
+
+const testCases = [];
+
+// Load a suite of smoke tests from a simple text file. File is of the format:
+// [path], [comma separated text assertions]
+const text = readFileSync(require.resolve('./urls.txt'), 'utf8').trim();
+for (const line of text.split(/\r?\n/)) {
+  if (line.length === 0) continue; // allow for blank lines.
+  if (line.match(/^#/)) continue; // allow for comments.
+  const testCase = {assertions: []};
+  line.split(/,/).forEach((token, i) => {
+    if (i === 0) {
+      // The first token is the path that we wish to traverse the headless
+      // browser to:
+      testCase.path = token;
+    } else {
+      // The remaining tokens represent blocks of text in the rendered page
+      // we should check for:
+      testCase.assertions.push(token.trimLeft());
+    }
+  });
+  testCases.push(testCase);
+}
+
+describe("smoke test rendering of paths in urls.txt", () => {
+  for (const testCase of testCases) {
+    // eslint-disable-next-line no-loop-func
+    it(`it appropriately renders ${testCase.path}`, async () => {
+      const url = `${BASE_URL}${testCase.path}`;
+      const resp = await page.goto(url, { waitUntil: 'networkidle2' });
+      expect(resp.status()).toEqual(200);
+      // Create a Devtools session for fetching MIME HTML snapshot:
+      const client = await page.target().createCDPSession();
+      await client.send('Page.enable');
+      // Takes a MIME HTML snapshot of page, and makes sure it contains
+      // our smoke test text content:
+      const snapshotText = decode((await client.send('Page.captureSnapshot')).data);
+      for (const assertion of testCase.assertions) {
+        try {
+          expect(snapshotText).toEqual(expect.stringContaining(assertion), 'the erro');
+        } catch (_err) {
+          throw Error(`could not find text "${assertion}" on page ${testCase.path}`);
+        }
+      }
+    });
+  }
+});

--- a/test/smoke-test/urls.txt
+++ b/test/smoke-test/urls.txt
@@ -1,0 +1,10 @@
+# First token represents the path to access, remaining tokens are a
+# comma separated list of text assertions (text we expect to find in the
+# rendered page):
+/ncov, novel coronavirus, Phylogeny, Diversity, Filter by Location
+
+/zika, Zika virus evolution, rectangular
+/zika?c=region&l=clock&legend=open&m=div&r=region, Zika virus evolution, rectangular
+
+# any page that doesn't exist will do:
+/page-does-not-exist, an error has occured


### PR DESCRIPTION
### Description of proposed changes 

This pull request is an implementation of the work outlined in #1048. Given a list of URLs in `smoke-test/urls.txt`, it:

1. loads the page, and makes sure that a 200 response was received.
2. asserts that a list of target strings exist in the rendered text (it does this using chrome's `Page.captureSnapshot`, which is just a raw dump of all the text on page).

Step `2.`  is meant to be the most basic of smoke test, e.g., that `/ncov` has `novel coronavirus` in the body (compared to #917, which actually cares about page layout).

TODO:

- [x] write GitHub action that actually pulls down the datasets and runs this smoke test.
- [x] `smoke-test` directory should be skipped by `npm test`.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1048
Related to #917 

### Testing

I will submit a GitHub action shortly that will run `smoke-test`, If you're happy with this approach, would love help making sure we wire it up appropriately.

### Thank you for contributing to Nextstrain!
