### PR TITLE
Tidy up the narratives front matter

### DIFF
--- a/cli/server/parseNarrative.js
+++ b/cli/server/parseNarrative.js
@@ -28,14 +28,14 @@ const makeFrontMatterBlock = (frontMatter) => {
   }
   /* create markdown to represent the title page */
   const markdown = [];
-  markdown.push(`# ${frontMatter.title}`);
+  markdown.push(`## ${frontMatter.title}`);
   if (frontMatter.authors) {
     const authors = parseContributors(frontMatter, "authors", "authorLinks");
     if (authors) {
       markdown.push(`### Author: ${authors}`);
       if (frontMatter.affiliations && typeof frontMatter.affiliations === "string") {
         markdown[markdown.length-1] += " <sup> 1 </sup>";
-        markdown.push(`<sup> 1 </sup> ${frontMatter.affiliations}`);
+        markdown.push(`<sub><sup> 1 </sup> ${frontMatter.affiliations}</sub>`);
       }
     }
   }
@@ -45,14 +45,14 @@ const makeFrontMatterBlock = (frontMatter) => {
       markdown.push(`### Translators: ${translators}`);
     }
   }
+  if (frontMatter.abstract && typeof frontMatter.abstract === "string") {
+    markdown.push(`### ${frontMatter.abstract}`);
+  }
   if (frontMatter.date && typeof frontMatter.date === "string") {
-    markdown.push(`### Created: ${frontMatter.date}`);
+    markdown.push(`#### Created: ${frontMatter.date}`);
   }
   if (frontMatter.updated && typeof frontMatter.updated === "string") {
-    markdown.push(`### Updated: ${frontMatter.updated}`);
-  }
-  if (frontMatter.abstract && typeof frontMatter.abstract === "string") {
-    markdown.push(`#### ${frontMatter.abstract}`);
+    markdown.push(`#### Updated: ${frontMatter.updated}`);
   }
 
   const block = new Proxy({}, blockProxyHandler);

--- a/src/components/narrative/index.js
+++ b/src/components/narrative/index.js
@@ -22,8 +22,7 @@ const progressHeight = 25;
 
 const explanationParagraph=`
   <p class="explanation">
-  Explore the content by scrolling the left hand side (or click on the arrows), and the data visualizations will change accordingly.
-  Clicking "explore the data yourself" (top right of page) will replace this narrative with a set of controls so that you may interact with the data.
+  Explore the narrative by scrolling on the left panel, or click "explore the data yourself" in the top right to interact with the data.
   </p>
 `;
 


### PR DESCRIPTION
### Description of proposed changes    
The current format of the narratives cover slide leaves very little room for an abstract, and has unclear information hierarchy due to font size variation. I've shortened the explanatory text to hopefully make a bit more room, and altered some of the sizing to emphasize the title, authors and abstract. Open to suggestions.

![image](https://user-images.githubusercontent.com/12618847/79173175-a1768480-7dab-11ea-9f97-cd09851c5e56.png)
