### PR TITLE
Add license/copyright field to narratives

### DIFF
--- a/cli/server/parseNarrative.js
+++ b/cli/server/parseNarrative.js
@@ -30,7 +30,7 @@ const makeFrontMatterBlock = (frontMatter) => {
   const markdown = [];
   markdown.push(`## ${frontMatter.title}`);
   if (frontMatter.authors) {
-    const authors = parseContributors(frontMatter, "authors", "authorLinks");
+    const authors = parseAttributions(frontMatter, "authors", "authorLinks");
     if (authors) {
       markdown.push(`### Author: ${authors}`);
       if (frontMatter.affiliations && typeof frontMatter.affiliations === "string") {
@@ -40,7 +40,7 @@ const makeFrontMatterBlock = (frontMatter) => {
     }
   }
   if (frontMatter.translators) {
-    const translators = parseContributors(frontMatter, "translators", "translatorLinks");
+    const translators = parseAttributions(frontMatter, "translators", "translatorLinks");
     if (translators) {
       markdown.push(`### Translators: ${translators}`);
     }
@@ -54,60 +54,66 @@ const makeFrontMatterBlock = (frontMatter) => {
   if (frontMatter.updated && typeof frontMatter.updated === "string") {
     markdown.push(`#### Updated: ${frontMatter.updated}`);
   }
-
+  if (frontMatter.license) {
+    const license = parseAttributions(frontMatter, "license", "licenseLink");
+    if (license) {
+      markdown.push(`#### License: ${license}`);
+    }
+  }
+  
   const block = new Proxy({}, blockProxyHandler);
   block.url = frontMatter.dataset;
   block.contents = markdown.join("\n");
   return block;
 };
 
-function parseContributors(frontMatter, contributorsKey, contributorLinksKey) {
-  const contributors = frontMatter[contributorsKey];
-  const contributorLinks = frontMatter[contributorLinksKey];
+function parseAttributions(frontMatter, attributionsKey, attributionLinksKey) {
+  const attributions = frontMatter[attributionsKey];
+  const attributionLinks = frontMatter[attributionLinksKey];
 
-  if (Array.isArray(contributors)) {
-    return parseContributorsArray(contributors, contributorLinks, contributorsKey, contributorLinksKey);
-  } else if (typeof contributors === 'string') {
-    return parseContributorsString(contributors, contributorLinks, contributorsKey, contributorLinksKey);
+  if (Array.isArray(attributions)) {
+    return parseAttributionsArray(attributions, attributionLinks, attributionsKey, attributionLinksKey);
+  } else if (typeof attributions === 'string') {
+    return parseAttributionsString(attributions, attributionLinks, attributionsKey, attributionLinksKey);
   }
   return undefined;
 }
 
-function parseContributorsArray(contributors, contributorLinks, contributorsKey, contributorLinksKey) {
+function parseAttributionsArray(attributions, attributionLinks, attributionsKey, attributionLinksKey) {
   // validate links
-  if (contributorLinks) {
-    if (!Array.isArray(contributorLinks)) {
-      utils.warn(`Narrative parsing - if ${contributorsKey} is an array, then ${contributorLinksKey} must also be an array. Skipping links.`);
-      contributorLinks = undefined;
-    } else if (contributorLinks.length !== contributors.length) {
-      utils.warn(`Narrative parsing - the length of ${contributorsKey} and ${contributorLinksKey} did not match. Skipping links.`);
-      contributorLinks = undefined;
+  if (attributionLinks) {
+    if (!Array.isArray(attributionLinks)) {
+      utils.warn(`Narrative parsing - if ${attributionsKey} is an array, then ${attributionLinksKey} must also be an array. Skipping links.`);
+      attributionLinks = undefined;
+    } else if (attributionLinks.length !== attributions.length) {
+      utils.warn(`Narrative parsing - the length of ${attributionsKey} and ${attributionLinksKey} did not match. Skipping links.`);
+      attributionLinks = undefined;
     }
   }
-  if (contributorLinks) {
-    contributors = contributors.map((contributor, idx) => {
-      return contributorLink(contributor, contributorLinks[idx]);
+  if (attributionLinks) {
+    attributions = attributions.map((attribution, idx) => {
+      return attributionLink(attribution, attributionLinks[idx]);
     });
   }
-  return contributors.join(", ");
+  return attributions.join(", ");
 }
 
-function parseContributorsString(contributors, contributorLinks, contributorsKey, contributorLinksKey) {
+function parseAttributionsString(attributions, attributionLinks, attributionsKey, attributionLinksKey) {
   // validate links
-  if (contributorLinks) {
-    if (typeof contributorLinks !== "string") {
-      utils.warn(`Narrative parsing - if ${contributorsKey} is a string, then ${contributorLinksKey} must also be a string. Skipping links.`);
-      contributorLinks = undefined;
+  if (attributionLinks) {
+    if (typeof attributionLinks !== "string") {
+      utils.warn(`Narrative parsing - if ${attributionsKey} is a string, then ${attributionLinksKey} must also be a string. Skipping links.`);
+      attributionLinks = undefined;
     }
   }
-  return contributorLink(contributors, contributorLinks);
+  return attributionLink(attributions, attributionLinks);
 }
 
-function contributorLink(contributor, contributorLinkValue) {
-  if (contributorLink) {
-    return `[${contributor}](${contributorLinkValue})`;
+function attributionLink(attribution, attributionLinkValue) {
+  if (attributionLink) {
+    return `[${attribution}](${attributionLinkValue})`;
   }
-  return contributor;
+  return attribution;
 }
 
 /**


### PR DESCRIPTION
### Description of proposed changes    
Adds a field for a license, copyright, etc. This uses the same function as the previous `parseContributors`, renamed to `parseAttributions` to be a bit more generic. This will probably be used for a single string +/- link most of the time, but allowing arrays enables adding both a license and a copyright.

### Testing
Usage:
```
license: "CC-BY"  
licenseLink: "https://creativecommons.org/licenses/by/4.0/"
```

Yields:
![image](https://user-images.githubusercontent.com/12618847/79173501-94a66080-7dac-11ea-944e-36500be46f21.png)

