### PR TITLE
Fix choose layout control

### DIFF
--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -29,11 +29,33 @@ class ChooseLayout extends React.Component {
     layout: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired
   }
+
+  handleChangeLayoutClicked(userSelectedLayout) {
+    const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
+    if (!loopRunning) {
+      if (userSelectedLayout === "rect") {
+        analyticsControlsEvent("change-layout-rectangular"); 
+      } else if (userSelectedLayout === "radial") {
+        analyticsControlsEvent("change-layout-radial");
+      } else if (userSelectedLayout === "unrooted") {
+        analyticsControlsEvent("change-layout-unrooted");
+      } else if (userSelectedLayout === "clock") {
+        analyticsControlsEvent("change-layout-clock"); 
+      } else {
+        console.warn("Odd... controls/choose-layout.js tried to set a layout we don't offer...");
+      }
+
+      this.props.dispatch({
+        type: CHANGE_LAYOUT,
+        data: userSelectedLayout
+      });
+    }
+  }
+
   render() {
     const { t } = this.props;
     if (this.props.showTreeToo) return null;
     const selected = this.props.layout;
-    const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
     return (
       <div style={{marginBottom: 15}}>
         <SidebarSubtitle>
@@ -43,7 +65,7 @@ class ChooseLayout extends React.Component {
           <RectangularTreeIcon width={25} selected={selected === "rect"}/>
           <SidebarButton
             selected={selected === "rect"}
-            onClick={() => {if (!loopRunning) {analyticsControlsEvent("change-layout-rectangular"); this.props.dispatch({ type: CHANGE_LAYOUT, data: "rect" });}}}
+            onClick={this.handleChangeLayoutClicked.bind(this, "rect")}
           >
             {t("sidebar:rectangular")}
           </SidebarButton>
@@ -52,7 +74,7 @@ class ChooseLayout extends React.Component {
           <RadialTreeIcon width={25} selected={selected === "radial"}/>
           <SidebarButton
             selected={selected === "radial"}
-            onClick={() => {if (!loopRunning) {analyticsControlsEvent("change-layout-radial"); this.props.dispatch({ type: CHANGE_LAYOUT, data: "radial" });}}}
+            onClick={this.handleChangeLayoutClicked.bind(this, "radial")}
           >
             {t("sidebar:radial")}
           </SidebarButton>
@@ -61,7 +83,7 @@ class ChooseLayout extends React.Component {
           <UnrootedTreeIcon width={25} selected={selected === "unrooted"}/>
           <SidebarButton
             selected={selected === "unrooted"}
-            onClick={() => {if (!loopRunning) {analyticsControlsEvent("change-layout-unrooted"); this.props.dispatch({ type: CHANGE_LAYOUT, data: "unrooted" });}}}
+            onClick={this.handleChangeLayoutClicked.bind(this, "unrooted")}
           >
             {t("sidebar:unrooted")}
           </SidebarButton>
@@ -73,7 +95,7 @@ class ChooseLayout extends React.Component {
                 <ClockIcon width={25} selected={selected === "clock"}/>
                 <SidebarButton
                   selected={selected === "clock"}
-                  onClick={() => {if (!loopRunning) {analyticsControlsEvent("change-layout-clock"); this.props.dispatch({ type: CHANGE_LAYOUT, data: "clock" });}}}
+                  onClick={this.handleChangeLayoutClicked.bind(this, "clock")}
                 >
                   {t("sidebar:clock")}
                 </SidebarButton>


### PR DESCRIPTION
### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?
- Allow user to change layout after the pause, but prevent the user from changing layout during the animation.

- Added handleChangeLayoutClicked.
Defined a helper function to replace the anonymous onClicks functions that are currently in place. This will make sure that the loopRunning constant is valid when the onClick event happens.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1047 
Related to #1047   

### Testing
What steps should be taken to test the changes you've proposed?  
1. Open localhost:4000/zika
2. Start the animation.
3. Try to change the tree layout (e.g. to radial). You shouldn't be able to.
4. Pause the animation before it finished.
5. Try to change the tree layout (e.g. to radial). You should be able to.

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  
I don't think there's a test for this behavior.

### Thank you for contributing to Nextstrain!
