### PR TITLE
Enable a narrative to source multiple builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5116,6 +5116,16 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -7046,6 +7056,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -11122,6 +11143,15 @@
             "supports-color": "^2.0.0"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -12892,6 +12922,16 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -14391,6 +14431,14 @@
             "read-pkg": "^3.0.0"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -15139,6 +15187,15 @@
           "requires": {
             "mime-db": "1.43.0"
           }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -15783,9 +15840,9 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
         "glob": "^7.1.3"
       }
@@ -17062,6 +17119,14 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "source-map": {

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -70,7 +70,7 @@ export const changePage = ({
   }
 
   /* the path (dataset) remains the same... but the state may be modulated by the query */
-  const newState = createStateFromQueryOrJSONs({oldState, query, dispatch});
+  const newState = createStateFromQueryOrJSONs({ oldState, query: { ...queryToDisplay, ...query }, dispatch, changePage: true });
   dispatch({
     type: URL_QUERY_CHANGE_WITH_COMPUTED_STATE,
     ...newState,

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -583,7 +583,7 @@ const modifyControlsViaTreeToo = (controls, name) => {
 const convertColoringsListToDict = (coloringsList) => {
   const colorings = {};
   coloringsList.forEach((coloring) => {
-    colorings[coloring.key] = coloring;
+    colorings[coloring.key] = { ...coloring };
     delete colorings[coloring.key].key;
   });
   return colorings;
@@ -657,6 +657,7 @@ export const createStateFromQueryOrJSONs = ({
   oldState = false, /* existing redux state (instead of jsons) */
   narrativeBlocks = false,
   mainTreeName = false,
+  changePage = false,
   secondTreeName = false,
   query,
   dispatch
@@ -688,6 +689,12 @@ export const createStateFromQueryOrJSONs = ({
     controls["absoluteZoomMin"] = 0;
     controls["absoluteZoomMax"] = entropy.lengthSequence;
   } else if (oldState) {
+    if (changePage) { // Reload Saved State if you can
+      const baseState = window[`allBaseStates.${query.n || 0}`];
+      if (baseState) {
+        return baseState;
+      }
+    }
     /* revisit this - but it helps prevent bugs */
     controls = {...oldState.controls};
     entropy = {...oldState.entropy};
@@ -705,7 +712,7 @@ export const createStateFromQueryOrJSONs = ({
   only displaying the page number (e.g. ?n=3), but we can look up what (hidden)
   URL query this page defines via this information */
   if (narrativeBlocks) {
-    addEndOfNarrativeBlock(narrativeBlocks);
+    if (!query.n) addEndOfNarrativeBlock(narrativeBlocks);
     narrative = narrativeBlocks;
     let n = parseInt(query.n, 10) || 0;
     /* If the query has defined a block which doesn't exist then default to n=0 */
@@ -788,6 +795,10 @@ export const createStateFromQueryOrJSONs = ({
       controls.colorScale,
       controls.colorBy
     );
+  }
+
+  if (narrativeBlocks) { // Save state if it's a created-from-scratch state
+    window[`allBaseStates.${query.n}`] = { tree, treeToo, metadata, entropy, controls, narrative, frequencies, query };
   }
 
   return {tree, treeToo, metadata, entropy, controls, narrative, frequencies, query};

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -38,6 +38,7 @@ import "../../css/mapbox.css";
     absoluteDateMax: state.controls.absoluteDateMax,
     treeVersion: state.tree.version,
     treeLoaded: state.tree.loaded,
+    treeName: state.tree.name,
     nodes: state.tree.nodes,
     nodeColors: state.tree.nodeColors,
     visibility: state.tree.visibility,
@@ -275,7 +276,8 @@ class Map extends React.Component {
     const transmissionLinesToggleChanged = this.props.showTransmissionLines !== nextProps.showTransmissionLines;
     const dataChanged = (!nextProps.treeLoaded || this.props.treeVersion !== nextProps.treeVersion);
     const colorByChanged = (nextProps.colorScaleVersion !== this.props.colorScaleVersion);
-    if (mapIsDrawn && (geoResolutionChanged || dataChanged || colorByChanged || transmissionLinesToggleChanged)) {
+    const treeNameChanged = (nextProps.treeName !== this.props.treeName);
+    if (mapIsDrawn && (geoResolutionChanged || dataChanged || colorByChanged || transmissionLinesToggleChanged || treeNameChanged)) {
       this.state.d3DOMNode.selectAll("*").remove();
       this.setState({
         d3elems: null,

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -92,6 +92,17 @@ class Tree extends React.Component {
       this.tangleRef.drawLines();
     }
     if (Object.keys(newState).length) this.setState(newState);
+
+    if (this.props.tree.name !== prevProps.tree.name) {
+      newState = {};
+      this.state.tree.clearSVG();
+      newState.tree = new PhyloTree(this.props.tree.nodes, "LEFT");
+      renderTree(this, true, newState.tree, this.props);
+      if (this.props.showTreeToo) {
+        this.setUpAndRenderTreeToo(this.props, newState); /* modifies newState in place */
+      }
+      this.setState(newState);
+    }
   }
 
   getStyles = () => {

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -16,8 +16,9 @@ const Metadata = (state = {
       return Object.assign({}, state, {
         loaded: false
       });
+    case types.URL_QUERY_CHANGE_WITH_COMPUTED_STATE:
     case types.CLEAN_START:
-      return action.metadata;
+      return action.metadata || state.metadata;
     case types.ADD_COLOR_BYS:
       const colorings = Object.assign({}, state.colorings, action.newColorings);
       return Object.assign({}, state, {colorings});


### PR DESCRIPTION
### Description of proposed changes    
WIP trying to address https://github.com/nextstrain/auspice/issues/1050
Requires test cases, comments, more work

Added a new script to pull narratives and data as well, and enabled local serve to serve .json data directly (as opposed to .md data).

To run the example case, run
```
npm install -g 
npm run get-data-new
```

Then launch dev or prod server as normal and browse to narrative `narratives/ncov/sit-rep/2020-04-10`

### Related issue(s)  
Fixes #  https://github.com/nextstrain/auspice/issues/1050
Related to #  

### Testing
It requires a plethora of test cases as I'm virtually positive that I've missed a fair bit of functionality in there, in fact I'm not even 100% sure how this is supposed to look like, my knowledge of genomics stops at "DNA is helix"

### Thank you for contributing to Nextstrain!
