### PR TITLE
fix #1035 - Color-by changes result in duplicate function calls

### DIFF
--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -104,7 +104,7 @@ class ColorBy extends React.Component {
   /**
    * Avoids double invocation of change() method
    */
-  shouldComponentUpdate( _,nextState) {
+  shouldComponentUpdate(_, nextState) {
     if (this.state.colorBySelected === nextState.colorBySelected &&
         this.state.geneSelected === nextState.geneSelected &&
         this.state.positionSelected === nextState.positionSelected) {

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -78,7 +78,7 @@ class ColorBy extends React.Component {
   }
 
   // Our internal state is published back to the outside world when it changes.
-  componentDidUpdate() {
+  componentDidUpdate() {    
     const colorBySelected = this.state.colorBySelected;
 
     if (colorBySelected === "gt") {
@@ -99,6 +99,20 @@ class ColorBy extends React.Component {
     } else {
       this.dispatchColorBy(colorBySelected);
     }
+  }
+
+  /**
+   * Avoids double invocation of change() method 
+   * due to dispatchColorBy.
+   */
+  shouldComponentUpdate( _, nextState){    
+    if (this.state.colorBySelected === nextState.colorBySelected &&
+        this.state.geneSelected === nextState.geneSelected &&
+        this.state.positionSelected === nextState.positionSelected)
+    {
+      return false;
+    }    
+    return true;
   }
 
   dispatchColorBy(colorBy, name = colorBy) {

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -78,7 +78,7 @@ class ColorBy extends React.Component {
   }
 
   // Our internal state is published back to the outside world when it changes.
-  componentDidUpdate() {    
+  componentDidUpdate() {
     const colorBySelected = this.state.colorBySelected;
 
     if (colorBySelected === "gt") {
@@ -102,16 +102,14 @@ class ColorBy extends React.Component {
   }
 
   /**
-   * Avoids double invocation of change() method 
-   * due to dispatchColorBy.
+   * Avoids double invocation of change() method
    */
-  shouldComponentUpdate( _, nextState){    
+  shouldComponentUpdate( _,nextState) {
     if (this.state.colorBySelected === nextState.colorBySelected &&
         this.state.geneSelected === nextState.geneSelected &&
-        this.state.positionSelected === nextState.positionSelected)
-    {
+        this.state.positionSelected === nextState.positionSelected) {
       return false;
-    }    
+    }
     return true;
   }
 


### PR DESCRIPTION
### Description of proposed changes    
Implement `shouldComponentUpdate()` method in the `ColorBy` component for avoid function calls duplication.

### Related issue(s)  
Fixes #1035


### Testing
Uncomment the `console.log` statement, inn [ change() inside change.js add ](https://github.com/nextstrain/auspice/blob/2e78b0eb3227b6bb5e6966f7eef70e14e50ddd05/src/components/tree/phyloTree/change.js#L279). And run the application, check in console for one invocation per color change.

