### PR TITLE
Function 'recurse' defined at line 8 takes 2 arguments, but it was ca…

### DIFF
--- a/src/util/setGenotype.js
+++ b/src/util/setGenotype.js
@@ -37,7 +37,7 @@ export const setGenotype = (nodes, prot, positions) => {
       }
     }
   };
-  recurse(nodes[0], positions.map(() => undefined), positions);
+  recurse(nodes[0], positions.map(() => undefined));
   for (let j = 0; j < nPositions; j++) {
     for (const node of ancNodes[j]) {
       node.currentGt[j] = ancState[j];


### PR DESCRIPTION
Hi all
In src/util/setGenotype.js, function 'recurse' defined at line 8 takes 2 arguments, but it was called with 3 arguments at line 40.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?
  This PR is trivial, and fixes some invalid JavaScript. The problem is harmless (other than code readability), so please feel free to ignore this PR.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
   I ran a linter program to verify that the syntax and calling semantics are correct.

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  
   Yes, I would like help testing this. Sorry for submitting a PR without testing, please feel free to ignore this PR.  Thanks -- Rick

### Thank you for contributing to Nextstrain!
