### PR TITLE
Function 'getMinMaxFromTree' defined at line 15 takes 3 arguments, bu…

### DIFF
--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -169,7 +169,7 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
       const allInteger = legendValues.every((x) => Number.isInteger(x));
 
       if (allInteger) {
-        minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy, colorings[colorBy]);
+        minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy);
         if (minMax[1]-minMax[0]<=colors.length) {
           continuous = false;
           legendValues = [];
@@ -208,7 +208,7 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
         case "num_date":
           break; /* minMax not needed for num_date */
         default:
-          minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy, colorings[colorBy]);
+          minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy);
       }
 
       /* make the continuous scale */


### PR DESCRIPTION
Hi all,
In src/util/colorScale.js, the function 'getMinMaxFromTree' defined at line 15 takes 3 arguments, but it was called with 4 arguments at two places.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?
  This trivial change fixes some invalid JavaScript. The problem was harmless (other than code readability) so please feel free to ignore this PR.
 
### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  
  Yes, I would like help with testing. I ran my linter program to check the syntax and calling semantics. Please feel free to ignore this PR due to a lack of testing.
Thanks -- Rick

### Thank you for contributing to Nextstrain!
