### PR TITLE
Place tip labels below tips

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -219,8 +219,8 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     this.drawBranches();
     if (this.params.showGrid) this.addGrid();
     this.svg.selectAll(".tip").remove();
-    this.drawTips();
     this.updateTipLabels();
+    this.drawTips();
     if (this.vaccines) this.drawVaccines();
     this.showTemporalSlice();
     if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -47,13 +47,13 @@ export const render = function render(svg, layout, distance, parameters, callbac
     this.showTemporalSlice();
   }
   this.drawBranches();
+  this.updateTipLabels();
   this.drawTips();
   if (this.params.branchLabelKey) this.drawBranchLabels(this.params.branchLabelKey);
   if (this.vaccines) this.drawVaccines();
   if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
   this.confidencesInSVG = false;
   if (drawConfidence) this.drawConfidence();
-  this.updateTipLabels();
 
   this.timeLastRenderRequested = Date.now();
   timerEnd("phyloTree render()");


### PR DESCRIPTION
This changes the render order so that the SVG group holding tips is before (below) the tips, thus preventing labels being drawn on top of tips and preventing the on-hover behavior.

A better long-term solution for the problems with drawing tip labels on big trees may be found, but this will require different rendering behavior or different logic around which tip labels to draw.

Closes #1082.
