### PR TITLE
Padding bottom

### DIFF
--- a/src/components/narrative/ReactPageScroller.js
+++ b/src/components/narrative/ReactPageScroller.js
@@ -172,7 +172,7 @@ export default class ReactPageScroller extends React.Component {
           <div
             key={this.state.componentIndex}
             ref={c => this["container_" + this.state.componentIndex] = c}
-            style={{height: "calc(100% - 20px)", width: "100%", "padding-bottom": "20px"}}
+            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}
           >
             {this.props.children[this.state.componentIndex]}
           </div>
@@ -181,7 +181,7 @@ export default class ReactPageScroller extends React.Component {
         componentsToRender.push(
           <div
             ref={c => this["container_" + this.state.componentIndex] = c}
-            style={{height: "calc(100% - 20px)", width: "100%", "padding-bottom": "20px"}}
+            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}
           >
             {this.props.children}
           </div>
@@ -224,7 +224,7 @@ export default class ReactPageScroller extends React.Component {
                 componentsToRender.push(
                     <div key={number + 1}
                             ref={c => this["container_" + (number + 1)] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "padding-bottom": "20px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
                         {children[number + 1]}
                     </div>
                 );
@@ -244,7 +244,7 @@ export default class ReactPageScroller extends React.Component {
                 componentsToRender.push(
                     <div key={i}
                             ref={c => this["container_" + i] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "padding-bottom": "20px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
                         {children[i]}
                     </div>
                 );
@@ -254,7 +254,7 @@ export default class ReactPageScroller extends React.Component {
                 componentsToRender.push(
                     <div key={number + 1}
                             ref={c => this["container_" + (number + 1)] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "padding-bottom": "20px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
                         {children[number + 1]}
                     </div>
                 );

--- a/src/components/narrative/ReactPageScroller.js
+++ b/src/components/narrative/ReactPageScroller.js
@@ -240,7 +240,6 @@ export default class ReactPageScroller extends React.Component {
 
             const componentsLength = componentsToRender.length;
 
-            // all 1-5 of the scroll pages
             for (let i = componentsLength; i <= number; i++) {
                 componentsToRender.push(
                     <div key={i}
@@ -250,7 +249,6 @@ export default class ReactPageScroller extends React.Component {
                     </div>
                 );
             }
-            // the sixth scroll page (the remaining pages after this are not done
             if (!_.isNil(children[number + 1])) {
                 componentsToRender.push(
                     <div key={number + 1}

--- a/src/components/narrative/ReactPageScroller.js
+++ b/src/components/narrative/ReactPageScroller.js
@@ -172,7 +172,7 @@ export default class ReactPageScroller extends React.Component {
           <div
             key={this.state.componentIndex}
             ref={c => this["container_" + this.state.componentIndex] = c}
-            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}
+            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "20px"}}
           >
             {this.props.children[this.state.componentIndex]}
           </div>
@@ -181,7 +181,7 @@ export default class ReactPageScroller extends React.Component {
         componentsToRender.push(
           <div
             ref={c => this["container_" + this.state.componentIndex] = c}
-            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}
+            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "20px"}}
           >
             {this.props.children}
           </div>
@@ -224,7 +224,7 @@ export default class ReactPageScroller extends React.Component {
                 componentsToRender.push(
                     <div key={number + 1}
                             ref={c => this["container_" + (number + 1)] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "20px"}}>
                         {children[number + 1]}
                     </div>
                 );
@@ -240,21 +240,22 @@ export default class ReactPageScroller extends React.Component {
 
             const componentsLength = componentsToRender.length;
 
+            // all 1-5 of the scroll pages
             for (let i = componentsLength; i <= number; i++) {
                 componentsToRender.push(
                     <div key={i}
                             ref={c => this["container_" + i] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "20px"}}>
                         {children[i]}
                     </div>
                 );
             }
-
+            // the sixth scroll page (the remaining pages after this are not done
             if (!_.isNil(children[number + 1])) {
                 componentsToRender.push(
                     <div key={number + 1}
                             ref={c => this["container_" + (number + 1)] = c}
-                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "2px"}}>
+                            style={{height: "calc(100% - 20px)", width: "100%", "paddingBottom": "20px"}}>
                         {children[number + 1]}
                     </div>
                 );


### PR DESCRIPTION
### Description of proposed changes    
Fix #1091

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  1091
Related to #  

### Testing
I ran the changed code in devel mode with the 'inspect' console tab open. The previous warnings no longer appear.
I changed the value of paddingBottom and verified that it changed the layout. I left the value at the original 20px though that could be incorrect. We should test this on mobile, but I am not set up to do that. 
I ran Deepscan again, and the warnings are gone.

### Thank you for contributing to Nextstrain!
Feel free to ignore this PR, as the problem is just a warning and the testing is partial!
thanks
Rick