### PR TITLE
color value was in quotes, was bad syntax. tested by making it #3f3 b…

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -2,7 +2,7 @@
 html, p, div, input, button {
   font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-weight: 400;
-  color: #333;
+  color: #010101;
 }
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -2,7 +2,6 @@
 html, p, div, input, button {
   font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-weight: 400;
-  color: #010101;
 }
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -2,7 +2,7 @@
 html, p, div, input, button {
   font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif";
   font-weight: 400;
-  color: "#333";
+  color: #333;
 }
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 


### PR DESCRIPTION
…right lime green temporarily.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?
Fix invalid CSS detected by a linter. My goal is mainly to clean all the minor lint warnings so the linter becomes useful again.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1081 
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
I tested by setting the color value to 3f3 bright lime green temporarily. It only affects the entropy scale lines and the text 'This work is made possible by the open...'. It would probably have historically colored most of the text in the UI. When it was not working someone corrected the color by creating 'darkgrey' or similar.

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  
No change to the tests but I can do if you would like me to.
### Thank you for contributing to Nextstrain!
