### PR TITLE
catch EADDRINUSE and ENOTFOUND on dev/view script

### DIFF
--- a/cli/develop.js
+++ b/cli/develop.js
@@ -80,11 +80,27 @@ const run = (args) => {
     utils.log(`Serving auspice version ${version}${args.extend ? " with extensions" : ""}.`);
     utils.log(handlerMsg);
     utils.log("---------------------------------------------------\n\n");
+  }).on('error', (error) => {
+    if (error.code === 'EADDRINUSE') {
+      utils.error(`Port ${app.get('port')} is currently in use by another program.
+      You must either close that program or specify a different port by setting the shell variable "$PORT". Note that on MacOS / Linux ${chalk.yellow(`lsof -n -i :${app.get('port')} | grep LISTEN`)} should identify the process currently using the port.`);
+    }
+
+    if (error.code === 'ENOTFOUND') {
+      utils.error(`Host ${app.get('host')} is not a valid address. The server could not be started. If you did not provide a HOST environment variable when starting the app you may have HOST already set in your system. You can either change that variable, or override HOST when starting the app.
+
+      Example commands to fix:
+        ${chalk.yellow('HOST="localhost" auspice develop')}
+        ${chalk.yellow('HOST="localhost" npm run develop')}`);
+    }
+
+    utils.error(`Uncaught error in app.listen(). Code: ${error.code}`);
   });
+
 
 };
 
 module.exports = {
   addParser,
-  run,
+  run
 };

--- a/cli/view.js
+++ b/cli/view.js
@@ -136,14 +136,21 @@ const run = (args) => {
     utils.log(auspiceBuild.message);
     utils.log(handlerMsg);
     utils.log("---------------------------------------------------\n\n");
-  }).on('error', (err) => {
-    if (err.code === 'EADDRINUSE') {
-      utils.error(`Port ${app.get('port')} is currently in use by another program. 
-      You must either close that program or specify a different port by setting the shell variable
-      "$PORT". Note that on MacOS / Linux, "lsof -n -i :${app.get('port')} | grep LISTEN" should
-      identify the process currently using the port.`);
+  }).on('error', (error) => {
+    if (error.code === 'EADDRINUSE') {
+      utils.error(`Port ${app.get('port')} is currently in use by another program.
+      You must either close that program or specify a different port by setting the shell variable "$PORT". Note that on MacOS / Linux ${chalk.yellow(`lsof -n -i :${app.get('port')} | grep LISTEN`)} should identify the process currently using the port.`);
     }
-    utils.error(`Uncaught error in app.listen(). Code: ${err.code}`);
+
+    if (error.code === 'ENOTFOUND') {
+      utils.error(`Host ${app.get('host')} is not a valid address. The server could not be started. If you did not provide a HOST environment variable when starting the app you may have HOST already set in your system. You can either change that variable, or override HOST when starting the app.
+
+      Example commands to fix:
+        ${chalk.yellow('HOST="localhost" auspice view')}
+        ${chalk.yellow('HOST="localhost" npm run view')}`);
+    }
+
+    utils.error(`Uncaught error in app.listen(). Code: ${error.code}`);
   });
 
 };


### PR DESCRIPTION
Catches both these events when starting the server on develop and view scripts, displays error to user.

### Description of proposed changes    
As per the issue, when a HOST environment variable is set that is not a valid address, the app would fail to start the server and provide an unhelpful message. This change will catch that error and log a more descriptive message to the user as well as provide a command to potentially fix the issue.

### Related issue(s)  
Fixes #1086

### Testing
Set the HOST variable to an invalid address when running the app, such as with the following command:
`HOST='x86_64-apple-darwin13.4.0' auspice develop` or
`HOST='x86_64-apple-darwin13.4.0' auspice view`
This should cause it to fail and display the message.

### Thank you for contributing to Nextstrain!
