### PR TITLE
webpack updates

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,19 +21,7 @@ module.exports = function babelConfig(api) {
     "lodash"
   ];
   if (api.env("development")) {
-    if (process.env.BABEL_EXTENSION_PATH && !process.env.BABEL_EXTENSION_PATH.includes(__dirname)) {
-      utils.verbose("Not using react-hot-loader/babel plugin with auspice extensions as this produces an error. TO FIX.");
-      /* with extensions from a dir not within the main auspice directory we get the error:
-       * Module not found: Error: Can't resolve 'react-hot-loader' in ...extension directory...
-       * Which I can't fix. Tried:
-       * require.resolve("react-hot-loader/babel")
-       * setting babelrcRoots
-       * but google seems to have failed me.
-       * It may be a bug with "react-hot-loader/babel" as the other plugins work just fine!
-       */
-    } else {
-      plugins.push("react-hot-loader/babel");
-    }
+    plugins.push("react-hot-loader/babel");
   }
   if (process.env.BABEL_INCLUDE_TIMING_FUNCTIONS === "false") {
     plugins.push(["strip-function-call", {strip: ["timerStart", "timerEnd"]}]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1056,6 +1056,28 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.13.0.tgz",
+      "integrity": "sha512-lJZrmkucz2MrQJTQtJobx5MICXcfQvKihszqv655p557HPi0hMOWxrNpiHv3DWD8ugNWjtWcVWqRnFvwsHq1mQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.8.7",
+    "@hot-loader/react-dom": "^16.13.0",
     "argparse": "^1.0.10",
     "awesomplete": "^1.1.2",
     "babel-eslint": "^10.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
   const coreDeps = [
     "react",
     "react-hot-loader",
-    "react-dom:@hot-loader/react-dom"
+    "react-dom"
   ];
 
   // Actively searches for the "good" root starting from auspice dir and going backwards
@@ -88,9 +88,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
     plugins.push(new BundleAnalyzerPlugin());
   }
 
-  const entry =
-    (devMode ? ["react-hot-loader/patch", "webpack-hot-middleware/client"] : [])
-      .concat(["babel-polyfill", "./src/index"]);
+  const entry = [...(devMode ? ["webpack-hot-middleware/client"] : []), "babel-polyfill", "./src/index"];
 
   /* Where do we want the output to be saved?
    * For development we use the (virtual) "devel" directory


### PR DESCRIPTION
### Description of proposed changes    
This pull request changes some elements in webpack config, namely:
- Forces aliasing of `react` and react utilities to allow better compatibility with out-of-root-folder extensions
- Normalizes use of `react-hot-loader`
- Forces resolution of modules to pre-transpiled code where available (which is almost everywhere), hopefully alleviating the problem with non-transpiled code appearing in the final bundle and breaking compatibility with old browser
- Moves to `eval-source-map` because why not go with the best quality if it's only for debugging (note: I tried debugging performance using `cheap-module-source-map` and it was utterly impossible, everything was mapped to the bundles xD)

### Related issue(s)  
https://github.com/nextstrain/auspice/issues/902

### Testing
A general smoke test should suffice probably... !

### Thank you for contributing to Nextstrain!
