### PR TITLE
Add detailed JSON format descriptions from nextstrain.org docs

### DIFF
--- a/docs-src/docs/introduction/how-to-run.md
+++ b/docs-src/docs/introduction/how-to-run.md
@@ -72,47 +72,47 @@ Right now, `auspice view` will automatically convert "v1" JSONs into "v2" JSONs,
 
 ## Input File Formats
 
-> Auspice is agnostic about the data it visualises -- they don't have to be viral genomes, or real-time, or generated in Augur.
+Auspice is agnostic about the data it visualises -- they don't have to be viral genomes, or real-time, or generated in Augur.
 (They do, however have to be in a specific file format.)
 
-Auspice takes two different file types: datasets (the tree, map, etc.), which are defined as one or more JSON files and narratives, which are specified as a Markdown file.
-
-### Dataset JSONs
-
-For datasets, Auspice (v2.x) can currently load one of two formats:
-* [Auspice v1 JSONs](#auspice-v1-jsons) - _The zika dataset we download above is in this format._
-* [Auspice v2 JSONs](#auspice-v2-jsons)
-
-Currently we mainly use [Augur](https://github.com/nextstrain/augur) to create these datasets.
-See [the Nextstrain documentation](https://nextstrain.org/docs/bioinformatics/introduction-to-augur) for more details.
+Auspice takes two different file types: 
+* Datasets (the tree, map, etc.), which are defined as one or more JSON files.
+* Narratives, which are specified as a Markdown file.
 
 See the [Server API](server/api.md) for more details about the file formats an Auspice server (e.g. `auspice view`) sends to the client.
 
-See [the v2 release notes](releases/v2.md) for details and motivation for the v2 format.
+### Dataset JSONs
+
+Currently we mainly use [Augur](https://github.com/nextstrain/augur) to create these datasets.
+See [the Nextstrain documentation](https://nextstrain.org/docs/bioinformatics/introduction-to-augur) for more details on this process.
+
+Datasets JSONs include:
+* Auspice v2 JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json). It includes the following information:
+  * `tree`: The tree structure encoded as a deeply nested JSON object.
+    * Traits (such as country, divergence, collection date, attributions, etc.) are stored on each node. 
+    * The presence of a `children` property indicates that it's an internal node and contains the child objects. 
+  * `metadata`: Additional data to control and inform the visualization. 
+* Frequency JSON (optional) - [example here](http://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json)
+  * Generates the frequencies panel, e.g. on [nextstrain.org/flu](https://nextstrain.org/flu).
 
 > We are working on ways to make datasets in Newick / Nexus formats available. You can see an early prototype of this at [auspice-us.herokuapp.com](https://auspice-us.herokuapp.com/) where you can drop on Newick (and CSV) files.
 Using BEAST trees is possible, but you have to use Augur to convert them first.
 
-#### Auspice v1 JSONs
+> If you happen to maintain builds that rely on Auspice v1, don’t worry - Auspice v2 is backward compatible and accepts the v1 format as well. The v1 schema is also available below.
+See [the v2 release notes](releases/v2.md) for details and motivation for the v2 format.
+
+#### Auspice v1 JSONs (for backwards compatibility use only)
+
+Auspice works with the v1 format for backwards compatibility. _The zika dataset we download above is in this format._
 
 This format includes:
 * Tree JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-tree.json)
-  * The tree structure is encoded as a deeply nested JSON object, with traits (such as country, divergence, collection date, attributions, etc.) stored on each node. 
-  * The presence of a `children` property indicates that it's an internal node and contains the child objects. 
-  * The filename _must_ end with `_tree.json`.
+  * The same tree information as in the v2 JSON above in a separate file whose name _must_ end with `_tree.json`.
 * Metadata JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-meta.json)
-  * Additional data to control and inform the visualization is stored via the `metadata` property (key) at the top level of the JSON. 
-  * The filename _must_ end with `_meta.json` and have the same prefix as the tree JSON above. 
+  * The same metadata information as in the v2 JSON above in a separate file whose name _must_ end with `_meta.json` and have the same prefix as the tree JSON above. 
 * Frequency JSON (optional) - [example here](http://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json)
   * Generates the frequencies panel, e.g. on [nextstrain.org/flu](https://nextstrain.org/flu). 
 
-#### Auspice v2 JSONs
-
-This format includes:
-* Auspice v2 JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json)
-  * The single input format required for Auspice v2, including the same tree and meta info as v1 in one file.
-* Frequency JSON (optional) - [example here](http://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json)
-  * Generates the frequencies panel, e.g. on [nextstrain.org/flu](https://nextstrain.org/flu). 
 
 ### Narratives
 For narratives, please see [Writing a Narrative](narratives/how-to-write.md) for a description of the file format.

--- a/docs-src/docs/introduction/how-to-run.md
+++ b/docs-src/docs/introduction/how-to-run.md
@@ -79,19 +79,40 @@ Auspice takes two different file types: datasets (the tree, map, etc.), which ar
 
 ### Dataset JSONs
 
-For datasets, Auspice (v2.x) can currently load either
-* "Auspice v1" JSONs (metadata + tree JSONs) -- see the JSON schemas [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-meta.json) and [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-tree.json).
-_The zika dataset we download above is in this format_
-* "Auspice v2" JSONs. See the JSON schema [here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json).
-
-See the [Server API](server/api.md) for more details about the file formats an Auspice server (e.g. `auspice view`) sends to the client.
+For datasets, Auspice (v2.x) can currently load one of two formats:
+* [Auspice v1 JSONs](#auspice-v1-jsons) - _The zika dataset we download above is in this format._
+* [Auspice v2 JSONs](#auspice-v2-jsons)
 
 Currently we mainly use [Augur](https://github.com/nextstrain/augur) to create these datasets.
 See [the Nextstrain documentation](https://nextstrain.org/docs/bioinformatics/introduction-to-augur) for more details.
 
+See the [Server API](server/api.md) for more details about the file formats an Auspice server (e.g. `auspice view`) sends to the client.
+
+See [the v2 release notes](releases/v2.md) for details and motivation for the v2 format.
+
 > We are working on ways to make datasets in Newick / Nexus formats available. You can see an early prototype of this at [auspice-us.herokuapp.com](https://auspice-us.herokuapp.com/) where you can drop on Newick (and CSV) files.
 Using BEAST trees is possible, but you have to use Augur to convert them first.
 
+#### Auspice v1 JSONs
+
+This format includes:
+* Tree JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-tree.json)
+  * The tree structure is encoded as a deeply nested JSON object, with traits (such as country, divergence, collection date, attributions, etc.) stored on each node. 
+  * The presence of a `children` property indicates that it's an internal node and contains the child objects. 
+  * The filename _must_ end with `_tree.json`.
+* Metadata JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v1-meta.json)
+  * Additional data to control and inform the visualization is stored via the `metadata` property (key) at the top level of the JSON. 
+  * The filename _must_ end with `_meta.json` and have the same prefix as the tree JSON above. 
+* Frequency JSON (optional) - [example here](http://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json)
+  * Generates the frequencies panel, e.g. on [nextstrain.org/flu](https://nextstrain.org/flu). 
+
+#### Auspice v2 JSONs
+
+This format includes:
+* Auspice v2 JSON (required) - [schema here](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json)
+  * The single input format required for Auspice v2, including the same tree and meta info as v1 in one file.
+* Frequency JSON (optional) - [example here](http://data.nextstrain.org/flu_seasonal_h3n2_ha_2y_tip-frequencies.json)
+  * Generates the frequencies panel, e.g. on [nextstrain.org/flu](https://nextstrain.org/flu). 
 
 ### Narratives
 For narratives, please see [Writing a Narrative](narratives/how-to-write.md) for a description of the file format.


### PR DESCRIPTION
### Description of proposed changes    
Moving the detailed file descriptions from the [nextstrain.org page](https://nextstrain.org/docs/bioinformatics/data-formats) into the auspice docs. That way auspice docs host the detailed info on file formats and it can be linked in / injected into nextstrain.org docs as necessary and they don't get out of sync.
 
### Related issue(s) 
https://github.com/nextstrain/nextstrain.org/pull/164
https://github.com/nextstrain/nextstrain.org/pull/168

### Testing
Tested links work locally with docusaurus.

### Thank you for contributing to Nextstrain!
