### PR TITLE
Handle non-valid dataset paths

### DIFF
--- a/cli/server/getDataset.js
+++ b/cli/server/getDataset.js
@@ -6,7 +6,8 @@ const setUpGetDatasetHandler = ({datasetsPath}) => {
     try {
       const availableDatasets = await getAvailable.getAvailableDatasets(datasetsPath);
       const info = helpers.interpretRequest(req, datasetsPath);
-      if (!helpers.extendDataPathsToMatchAvailable(res, info, availableDatasets)) return;
+      const redirected = helpers.redirectIfDatapathMatchFound(res, info, availableDatasets);
+      if (redirected) return;
       helpers.makeFetchAddresses(info, datasetsPath, availableDatasets);
       await helpers.sendJson(res, info);
     } catch (err) {

--- a/cli/server/getDataset.js
+++ b/cli/server/getDataset.js
@@ -6,7 +6,7 @@ const setUpGetDatasetHandler = ({datasetsPath}) => {
     try {
       const availableDatasets = await getAvailable.getAvailableDatasets(datasetsPath);
       const info = helpers.interpretRequest(req, datasetsPath);
-      helpers.extendDataPathsToMatchAvailable(info, availableDatasets);
+      if (!helpers.extendDataPathsToMatchAvailable(res, info, availableDatasets)) return;
       helpers.makeFetchAddresses(info, datasetsPath, availableDatasets);
       await helpers.sendJson(res, info);
     } catch (err) {

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -46,9 +46,12 @@ const interpretRequest = (req) => {
 };
 
 /**
- * Given a request, does the dataset exist?
+ * Given a request, if the dataset does not exist then either
+ * (a) redirect to an appropriate dataset if possible & return `true`
+ * (b) throw.
+ * If the dataset existed then return `false` as no redirect necessary.
  */
-const extendDataPathsToMatchAvailable = (res, info, availableDatasets) => {
+const redirectIfDatapathMatchFound = (res, info, availableDatasets) => {
   let matchingDatasets = availableDatasets;
   let i;
   const matchDatasetRequest = (d) => d.request.split("/")[i] === info.parts[i];
@@ -63,9 +66,9 @@ const extendDataPathsToMatchAvailable = (res, info, availableDatasets) => {
   // If best match is not equal to path requested, redirect
   if (matchingDatasets[0].request !== info.parts.join("/")) {
     res.redirect(`./getDataset?prefix=/${matchingDatasets[0].request}`);
-    return false;
+    return true;
   }
-  return true;
+  return false;
 };
 
 /**
@@ -164,7 +167,7 @@ const findAvailableSecondTreeOptions = (currentDatasetUrl, availableDatasetUrls)
 
 module.exports = {
   interpretRequest,
-  extendDataPathsToMatchAvailable,
+  redirectIfDatapathMatchFound,
   makeFetchAddresses,
   handleError,
   sendJson,

--- a/src/components/controls/choose-dataset-select.js
+++ b/src/components/controls/choose-dataset-select.js
@@ -7,12 +7,6 @@ import { controlsWidth } from "../../util/globals";
 
 
 class ChooseDatasetSelect extends React.Component {
-  createDataPath(dataset) {
-    let p = (this.props.choice_tree.length > 0) ? "/" : "";
-    p += this.props.choice_tree.join("/") + "/" + dataset;
-    p = p.replace(/\/+/, "/");
-    return p;
-  }
   changeDataset(newPath) {
     // 0 analytics (optional)
     analyticsControlsEvent(`change-virus-to-${newPath.replace(/\//g, "")}`);
@@ -35,7 +29,7 @@ class ChooseDatasetSelect extends React.Component {
           multi={false}
           onChange={(opt) => {
             if (opt.value !== this.props.selected) {
-              this.changeDataset(this.createDataPath(opt.value));
+              this.changeDataset(`/${opt.value}`);
             }
           }}
         />

--- a/src/components/controls/choose-dataset-select.js
+++ b/src/components/controls/choose-dataset-select.js
@@ -24,18 +24,12 @@ class ChooseDatasetSelect extends React.Component {
     }
     this.props.dispatch(changePage({path: newPath}));
   }
-  getDatasetOptions() {
-    return this.props.options ?
-      this.props.options.map((opt) => typeof opt === "object" ? opt : ({ value: opt, label: opt })) :
-      {};
-  }
   render() {
-    const datasetOptions = this.getDatasetOptions();
     return (
       <div style={{width: controlsWidth, fontSize: 14}}>
         <Select
           value={this.props.selected}
-          options={datasetOptions}
+          options={this.props.options || []}
           clearable={false}
           searchable={false}
           multi={false}

--- a/src/components/controls/choose-dataset-select.js
+++ b/src/components/controls/choose-dataset-select.js
@@ -26,7 +26,7 @@ class ChooseDatasetSelect extends React.Component {
   }
   getDatasetOptions() {
     return this.props.options ?
-      this.props.options.map((opt) => ({value: opt, label: opt})) :
+      this.props.options.map((opt) => typeof opt === "object" ? opt : ({ value: opt, label: opt })) :
       {};
   }
   render() {
@@ -39,7 +39,11 @@ class ChooseDatasetSelect extends React.Component {
           clearable={false}
           searchable={false}
           multi={false}
-          onChange={(opt) => {this.changeDataset(this.createDataPath(opt.value));}}
+          onChange={(opt) => {
+            if (opt.value !== this.props.selected) {
+              this.changeDataset(this.createDataPath(opt.value));
+            }
+          }}
         />
       </div>
     );

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -38,11 +38,14 @@ class ChooseDataset extends React.Component {
       .replace(/\/$/, '')
       .split(":")[0];
     const displayedDataset = displayedDatasetString.split("/");
-    const options = [[displayedDataset[0]]];
+    const options = [
+      [
+        {value: displayedDataset[0], label: displayedDataset[0]}
+      ]
+    ];
 
     this.props.available.datasets.forEach((d) => {
       const firstField = d.request.split("/")[0];
-      if (firstField == displayedDataset[0]) return;
       if (!options[0].find((o) => o.label === firstField)) {
         options[0].push({value: d.request, label: firstField});
       }

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -38,11 +38,8 @@ class ChooseDataset extends React.Component {
       .replace(/\/$/, '')
       .split(":")[0];
     const displayedDataset = displayedDatasetString.split("/");
-    const options = [
-      [
-        {value: displayedDataset[0], label: displayedDataset[0]}
-      ]
-    ];
+    const options = displayedDataset
+      .map((pathFragment) => [{ value: pathFragment, label: pathFragment }]);
 
     this.props.available.datasets.forEach((d) => {
       const firstField = d.request.split("/")[0];
@@ -51,17 +48,15 @@ class ChooseDataset extends React.Component {
       }
     });
 
-
     for (let idx=1; idx<displayedDataset.length; idx++) {
       /* going through the fields which comprise the current dataset
       in order to create available alternatives for each field */
-      options[idx] = [];
       this.props.available.datasets.forEach((singleAvailableOption) => {
         /* if the parents (and their parents etc) of this choice match,
         then we add that as a valid option */
         const fields = singleAvailableOption.request.split("/");
-        if (checkEqualityOfArrays(fields, displayedDataset, idx) && options[idx].indexOf(fields[idx]) === -1) {
-          options[idx].push(fields[idx]);
+        if (checkEqualityOfArrays(fields, displayedDataset, idx) && !options[idx].find((o) => o.label === fields[idx])) {
+          options[idx].push({value: fields.slice(idx).join("/"), label: fields[idx]});
         }
       });
     }
@@ -71,7 +66,7 @@ class ChooseDataset extends React.Component {
         <SidebarHeader>{t("sidebar:Dataset")}</SidebarHeader>
         {options.map((option, optionIdx) => (
           <ChooseDatasetSelect
-            key={option}
+            key={displayedDataset[optionIdx]}
             dispatch={this.props.dispatch}
             choice_tree={displayedDataset.slice(0, optionIdx)}
             selected={displayedDataset[optionIdx]}

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -50,7 +50,7 @@ class ChooseDataset extends React.Component {
         label: opt
       }))
     );
-    
+
     return (
       <>
         <SidebarHeader>{t("sidebar:Dataset")}</SidebarHeader>

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -42,9 +42,10 @@ class ChooseDataset extends React.Component {
     const options = displayedDataset.map((_, i) =>
       Array.from(
         new Set(
-          this.props.available.datasets.filter((ds) =>
-            checkEqualityOfArrays(ds.request.split("/"), displayedDataset, i)
-          ).map((ds) => ds.request.split("/")[i]))
+          this.props.available.datasets
+            .filter((ds) => checkEqualityOfArrays(ds.request.split("/"), displayedDataset, i))
+            .map((ds) => ds.request.split("/")[i])
+        )
       ).map((opt) => ({
         value: displayedDataset.slice(0, i).concat(opt).join("/"),
         label: opt
@@ -58,7 +59,6 @@ class ChooseDataset extends React.Component {
           <ChooseDatasetSelect
             key={displayedDataset[optionIdx]}
             dispatch={this.props.dispatch}
-            choice_tree={displayedDataset.slice(0, optionIdx)}
             selected={displayedDataset.slice(0, optionIdx + 1).join("/")}
             options={option}
           />

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -38,12 +38,13 @@ class ChooseDataset extends React.Component {
       .replace(/\/$/, '')
       .split(":")[0];
     const displayedDataset = displayedDatasetString.split("/");
-    const options = [[]];
+    const options = [[displayedDataset[0]]];
 
     this.props.available.datasets.forEach((d) => {
       const firstField = d.request.split("/")[0];
-      if (!options[0].includes(firstField)) {
-        options[0].push(firstField);
+      if (firstField == displayedDataset[0]) return;
+      if (!options[0].find((o) => o.label === firstField)) {
+        options[0].push({value: d.request, label: firstField});
       }
     });
 

--- a/src/components/controls/choose-dataset.js
+++ b/src/components/controls/choose-dataset.js
@@ -38,29 +38,19 @@ class ChooseDataset extends React.Component {
       .replace(/\/$/, '')
       .split(":")[0];
     const displayedDataset = displayedDatasetString.split("/");
-    const options = displayedDataset
-      .map((pathFragment) => [{ value: pathFragment, label: pathFragment }]);
 
-    this.props.available.datasets.forEach((d) => {
-      const firstField = d.request.split("/")[0];
-      if (!options[0].find((o) => o.label === firstField)) {
-        options[0].push({value: d.request, label: firstField});
-      }
-    });
-
-    for (let idx=1; idx<displayedDataset.length; idx++) {
-      /* going through the fields which comprise the current dataset
-      in order to create available alternatives for each field */
-      this.props.available.datasets.forEach((singleAvailableOption) => {
-        /* if the parents (and their parents etc) of this choice match,
-        then we add that as a valid option */
-        const fields = singleAvailableOption.request.split("/");
-        if (checkEqualityOfArrays(fields, displayedDataset, idx) && !options[idx].find((o) => o.label === fields[idx])) {
-          options[idx].push({value: fields.slice(idx).join("/"), label: fields[idx]});
-        }
-      });
-    }
-
+    const options = displayedDataset.map((_, i) =>
+      Array.from(
+        new Set(
+          this.props.available.datasets.filter((ds) =>
+            checkEqualityOfArrays(ds.request.split("/"), displayedDataset, i)
+          ).map((ds) => ds.request.split("/")[i]))
+      ).map((opt) => ({
+        value: displayedDataset.slice(0, i).concat(opt).join("/"),
+        label: opt
+      }))
+    );
+    
     return (
       <>
         <SidebarHeader>{t("sidebar:Dataset")}</SidebarHeader>
@@ -69,7 +59,7 @@ class ChooseDataset extends React.Component {
             key={displayedDataset[optionIdx]}
             dispatch={this.props.dispatch}
             choice_tree={displayedDataset.slice(0, optionIdx)}
-            selected={displayedDataset[optionIdx]}
+            selected={displayedDataset.slice(0, optionIdx + 1).join("/")}
             options={option}
           />
         ))}


### PR DESCRIPTION
### Description of proposed changes    
Currently the dataset selector leads to invalid paths when used for example to switch to dengue, (because /dengue does not exist, /dengue/denv1 does, and /dengue/denv2 etc). 
On the current master build of auspice this is not handled, on nextstrain.org this is handled with a res.redirect on the getDataset endpoint.
Additionally the selector switches dataset even when same dataset is reselected (useless loading).

With this PR, the selector automatically loads fully valid paths, paths identical to the current path are not reloaded, and incomplete paths are handled by auspice's server directly.

### Testing
In dev mode, test for example 
http://localhost:4000/dengue
http://localhost:4000/zika/nothanksjeff
http://localhost:4000/VirusThatDontExist

Also try fiddling with Dataset Selector
![image](https://user-images.githubusercontent.com/23081988/82087301-1d882300-96f0-11ea-994a-6096a70a6c9f.png)


### Thank you for contributing to Nextstrain!
