### PR TITLE
genotype color-by not shown in sidebar dropdown on page load

### DIFF
--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -32,9 +32,21 @@ class ColorBy extends React.Component {
       positionSelected: ""
     };
 
-    this.state = this.newState({
-      colorBySelected: props.colorBy
-    });
+    if (isColorByGenotype(props.colorBy)) {
+      const genotype = decodeColorByGenotype(props.colorBy);
+
+      if (genotype) {
+        this.state = this.newState({
+          colorBySelected: "gt",
+          geneSelected: genotype.gene,
+          positionSelected: genotype.positions.join(",")
+        });
+      }
+    } else {
+      this.state = this.newState({
+        colorBySelected: props.colorBy
+      });
+    }
   }
   static propTypes = {
     colorBy: PropTypes.string.isRequired,


### PR DESCRIPTION
### Description of proposed changes    
The goal of this pull request is to enable the color-by component to initialize from a URL parameter (c) when it denotes a genotype (for other categories the initialization has worked). From this PR, the redux store in color-by.js is initialized appropriately on page load. 

### Related issue(s)  
#738 

### Testing
In dev mode, the color-by genotype can be specified like this:
http://localhost:4000/ncov/north-america?c=gt-ORF1b_1000
Expected: 3 input fields are initialized with "genotype" (in color-by field), "ORF1b", and "1000". Any genotype with a position in the range should yield a similar result. 

### Thank you for contributing to Nextstrain!
