### PR TITLE
make deme size non linear to number of visible tips

### DIFF
--- a/src/components/map/mapHelpers.js
+++ b/src/components/map/mapHelpers.js
@@ -166,7 +166,10 @@ export const drawDemesAndTransmissions = (
     .attr("stroke", (d) => { return d.color; })
     .attr("stroke-width", 1);
 
-  const demeMultiplier = demeCountMultiplier / Math.sqrt(_max([nodes.length, demeCountMinimum]));
+  const visibleTips = nodes[0].tipCount;
+  const demeMultiplier =
+    demeCountMultiplier /
+    Math.sqrt(_max([Math.sqrt(visibleTips * nodes.length), demeCountMinimum]));
   let demes;
   // determine whether to draw pieChart or not (sensible for categorical data)
   if (pieChart) {
@@ -277,7 +280,10 @@ export const updateVisibility = (
     console.error("d3elems is not defined!");
     return;
   }
-  const demeMultiplier = demeCountMultiplier / Math.sqrt(_max([nodes.length, demeCountMinimum]));
+  const visibleTips = nodes[0].tipCount;
+  const demeMultiplier =
+    demeCountMultiplier /
+    Math.sqrt(_max([Math.sqrt(visibleTips * nodes.length), demeCountMinimum]));
 
   if (pieChart) {
     const individualArcs = createArcsFromDemes(demeData);


### PR DESCRIPTION
### Description of proposed changes    
Make demes on make better visible even if heavily filtered down

This changes the denominator in the radius scalefactor of demes. it used to be the number of total tips. This is now replaced by the square root of the product total and visible tips. This choice retains some scaling of  deme size with number of tips, but avoid demes essentially disappearing when only a few tips are visible (there is probably a more robust way to getting the number of visible tips.... 

before:
![image](https://user-images.githubusercontent.com/8379168/82592403-24f07600-9ba1-11ea-9392-2965a1f075fd.png)

after:
![image](https://user-images.githubusercontent.com/8379168/82592427-3043a180-9ba1-11ea-8e2a-d21af808de96.png)


### Thank you for contributing to Nextstrain!
