### PR TITLE
Add placeholder license for visualizations / graphics. 

### DIFF
--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -191,7 +191,7 @@ class DownloadModal extends React.Component {
         (<MetaIcon width={iconWidth} selected />), () => helpers.authorTSV(this.props.dispatch, filePrefix, this.props.tree)]);
     }
     buttons.push(
-      ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format; CC-BY-SA licensed.",
+      ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format; CC-BY licensed.",
         (<PanelsGridIcon width={iconWidth} selected />), () => helpers.SVG(this.props.dispatch, filePrefix, this.props.panelsToDisplay, this.props.panelLayout, this.makeTextStringsForSVGExport())]
     );
     const buttonTextStyle = Object.assign({}, materialButton, {backgroundColor: "rgba(0,0,0,0)", paddingLeft: "10px", color: "white", minWidth: "300px", textAlign: "left" });

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -151,7 +151,7 @@ class DownloadModal extends React.Component {
     x.push(this.createSummaryWrapper());
     x.push("");
     x.push(`${this.props.t("Data usage part 1")} A full list of sequence authors is available via <a href="https://nextstrain.org">nextstrain.org</a>.`);
-    x.push(`License: CC-BY`);
+    x.push(`Visualizations are licensed under CC-BY.`);
     x.push(`Relevant publications:`);
     this.getRelevantPublications().forEach((pub) => {
       x.push(`<a href="${pub.href}">${pub.author}, ${pub.title}, ${pub.journal} (${pub.year})</a>`);

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -151,6 +151,7 @@ class DownloadModal extends React.Component {
     x.push(this.createSummaryWrapper());
     x.push("");
     x.push(`${this.props.t("Data usage part 1")} A full list of sequence authors is available via <a href="https://nextstrain.org">nextstrain.org</a>.`);
+    x.push(`License: CC-BY`);
     x.push(`Relevant publications:`);
     this.getRelevantPublications().forEach((pub) => {
       x.push(`<a href="${pub.href}">${pub.author}, ${pub.title}, ${pub.journal} (${pub.year})</a>`);

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -191,7 +191,7 @@ class DownloadModal extends React.Component {
         (<MetaIcon width={iconWidth} selected />), () => helpers.authorTSV(this.props.dispatch, filePrefix, this.props.tree)]);
     }
     buttons.push(
-      ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format.",
+      ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format; CC-BY-SA licensed.",
         (<PanelsGridIcon width={iconWidth} selected />), () => helpers.SVG(this.props.dispatch, filePrefix, this.props.panelsToDisplay, this.props.panelLayout, this.makeTextStringsForSVGExport())]
     );
     const buttonTextStyle = Object.assign({}, materialButton, {backgroundColor: "rgba(0,0,0,0)", paddingLeft: "10px", color: "white", minWidth: "300px", textAlign: "left" });


### PR DESCRIPTION
We get many requests to reuse / alter / publish / distribute the visualizations from Nextstrain. A license makes these conversations much easier and more consistent.

For now, I've put in a CC-BY-SA license as a placeholder to attempt to mirror the GNU Affero General Public License v3.0 used for this repository. 

I'd suggest moving to a CC-BY if the team is comfortable with this.