### PR TITLE
Allow displayed diversity data to be downloaded

### DIFF
--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -53,6 +53,8 @@ export const publications = {
   show: state.controls.showDownload,
   colorBy: state.controls.colorBy,
   metadata: state.metadata,
+  entropy: state.entropy,
+  mutType: state.controls.mutType,
   tree: state.tree,
   nodes: state.tree.nodes,
   visibleStateCounts: state.tree.visibleStateCounts,
@@ -189,6 +191,20 @@ class DownloadModal extends React.Component {
     if (helpers.areAuthorsPresent(this.props.tree)) {
       buttons.push(["Author Metadata (TSV)", `Metadata for all samples in the dataset (n = ${this.props.metadata.mainTreeNumTips}) grouped by their ${uniqueAuthorCount} authors.`,
         (<MetaIcon width={iconWidth} selected />), () => helpers.authorTSV(this.props.dispatch, filePrefix, this.props.tree)]);
+    }
+    if (this.props.entropy.loaded) {
+      let msg = `The data behind the diversity panel`;
+      msg += ` showing ${this.props.entropy.showCounts ? `a count of changes across the tree` : `normalised shannon entropy`}`;
+      msg += this.props.mutType === "nuc" ? " per nucleotide." : " per codon.";
+      if (selectedTipsCount !== this.props.metadata.mainTreeNumTips) {
+        msg += ` Restricted to strains which are currently displayed (n = ${selectedTipsCount}/${this.props.metadata.mainTreeNumTips}).`;
+      }
+      buttons.push([
+        "Genetic diversity data (TSV)",
+        msg,
+        (<MetaIcon width={iconWidth} selected />),
+        () => helpers.entropyTSV(this.props.dispatch, filePrefix, this.props.entropy, this.props.mutType)
+      ]);
     }
     buttons.push(
       ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format.",

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -416,3 +416,19 @@ export const SVG = (dispatch, filePrefix, panelsInDOM, panelLayout, textStrings)
     writeSVGPossiblyIncludingMap(dispatch, filePrefix, panelsInDOM, panelLayout, textStrings, undefined);
   }
 };
+
+export const entropyTSV = (dispatch, filePrefix, entropy, mutType) => {
+  const lines = mutType === "nuc" ? ["base"] : ["gene\tposition"];
+  lines[0] += entropy.showCounts ? "\tevents" : "\tentropy";
+  entropy.bars.forEach((bar) => {
+    if (mutType === "nuc") {
+      lines.push(`${bar.x}\t${bar.y}`);
+    } else {
+      lines.push(`${bar.prot}\t${bar.codon}\t${bar.y}`);
+    }
+  });
+  /* write out information we've collected */
+  const filename = `${filePrefix}_diversity.tsv`;
+  write(filename, MIME.tsv, lines.join("\n"));
+  dispatch(infoNotification({message: `Diversity data exported to ${filename}`}));
+};


### PR DESCRIPTION
We frequently get requests to share the data displayed in the
diversity panel. Here we address this by allowing download of
the data behind the graph. This is the simplest implementation,
as to download all data together ({events,entropy}U{nt,aa})
would require recalculations within the download logic as these
data are not stored by auspice when not being displayed.

closes #1143
