### PR TITLE
Caching settings

### DIFF
--- a/cli/view.js
+++ b/cli/view.js
@@ -114,7 +114,6 @@ const run = (args) => {
   utils.verbose(`Serving built javascript from     "${auspiceBuild.distDir}"`);
   app.get("/favicon.png", (req, res) => {res.sendFile(path.join(auspiceBuild.baseDir, "favicon.png"));});
   app.use("/dist", expressStaticGzip(auspiceBuild.distDir));
-  app.use(express.static(auspiceBuild.distDir));
 
   let handlerMsg = "";
   if (args.gh_pages) {

--- a/cli/view.js
+++ b/cli/view.js
@@ -113,7 +113,7 @@ const run = (args) => {
   utils.verbose(`Serving index / favicon etc from  "${auspiceBuild.baseDir}"`);
   utils.verbose(`Serving built javascript from     "${auspiceBuild.distDir}"`);
   app.get("/favicon.png", (req, res) => {res.sendFile(path.join(auspiceBuild.baseDir, "favicon.png"));});
-  app.use("/dist", expressStaticGzip(auspiceBuild.distDir));
+  app.use("/dist", expressStaticGzip(auspiceBuild.distDir, {maxAge: '30d'}));
 
   let handlerMsg = "";
   if (args.gh_pages) {
@@ -124,7 +124,7 @@ const run = (args) => {
 
   /* this must be the last "get" handler, else the "*" swallows all other requests */
   app.get("*", (req, res) => {
-    res.sendFile(path.join(auspiceBuild.baseDir, "dist/index.html"));
+    res.sendFile(path.join(auspiceBuild.baseDir, "dist/index.html"), {headers: {"Cache-Control": "no-cache, no-store, must-revalidate"}});
   });
 
   const server = app.listen(app.get('port'), app.get('host'), () => {


### PR DESCRIPTION
This PR builds on #1126 and enforces that `index.html` is never cached, as it gets recreated when auspice rebuilds and the src for the main JS bundle changes accordingly. This may not be strictly necessary, as the max-age was 0 and the ETag changes as the file changes, but setting this explicitly is good practice.

JS bundles, which use hashes to facilitate cache busting, are served with a 30d cache lifetime. Note that this is not enough to _force_ browsers to not revalidate within the 30d (i.e. 304 response) -- see [this post](https://stackoverflow.com/questions/26166433/how-to-prevent-request-that-returns-304/26339940#26339940) for context. Re-validation during the 30d lifetime will return a 304 which is no worse than the current situation we have.

@salvatore-fxpig would you mind double checking this?