### PR TITLE
temporarily disable integration tests running on GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,22 +18,6 @@ jobs:
       - run: node --version
       - run: npm ci
       - run: npm test
-  integration-test:
-    runs-on: macos-10.15
-    strategy:
-      matrix:
-        node: [10]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          lfs: true
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - run: npm ci
-      - run: npm run get-data
-      - run: npm run get-narratives
-      - run: npm run integration-test:ci
   smoke-test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
These are problematic due to subtle differences in fonts across
OSs (and maybe other reasons). There are solutions forthcoming
which I hope we can implement shortly. However for now it's simpler
to disable these from GitHub CI. This commit should be reverted
in a feature branch to bring these important tests back.

cc @bcoe @tihuan -- you've both done great work here and have suggested
solutions to the problem which I simply haven't had time to get around to addressing.
