### PR TITLE
Add opt-in genome download feature

### DIFF
--- a/cli/develop.js
+++ b/cli/develop.js
@@ -10,6 +10,7 @@ const version = require('../src/version').version;
 const chalk = require('chalk');
 const generateWebpackConfig = require("../webpack.config.js").default;
 const SUPPRESS = require('argparse').Const.SUPPRESS;
+const bodyParser = require('body-parser');
 
 const addParser = (parser) => {
   const description = `Launch auspice in development mode.
@@ -49,6 +50,11 @@ const run = (args) => {
   process.env.BABEL_INCLUDE_TIMING_FUNCTIONS = args.includeTiming;
   process.env.BABEL_ENV = "development";
   process.env.BABEL_EXTENSION_PATH = extensionPath;
+
+  // parse application/json
+  app.use(bodyParser.json({limit: '20mb'}));
+  // parse application/x-www-form-urlencoded
+  app.use(bodyParser.urlencoded({ extended: false }));
 
   /* Redirects / to webpack-generated index */
   app.use((req, res, next) => {

--- a/cli/server/handleGenomeDbs.js
+++ b/cli/server/handleGenomeDbs.js
@@ -1,0 +1,158 @@
+const fs = require('fs');
+const path = require("path");
+const through = require('through2');
+const {PassThrough} = require('stream');
+const Engine = require('nedb');
+const fasta = require('bionode-fasta');
+const bodyParser = require('body-parser');
+
+const { promisify } = require('util');
+
+const readdir = promisify(fs.readdir);
+
+/*
+  All NeDB database files are stored in the subdirectory 'genomeDbs'
+  at the same level where fasta file and auspice file is located.
+*/
+const getDbPath = (fastaPath) => {
+  const dbRoot = path.join(path.dirname(fastaPath), 'genomeDbs');
+  const dbPath = path.join(dbRoot,
+    path.basename(fastaPath).replace(".fasta", ".db"));
+  return dbPath;
+};
+
+/*
+  @param: ids: an array of fasta sequence ids
+  @param: dbPath: resolvable path to NeDB database of genome sequences
+*/
+const fetchRecords = (ids, dbPath) =>
+  new Promise((resolve, reject) => {
+    console.log("dbPath: " + dbPath);
+    const db = new Engine({filename: dbPath, autoload: true});
+    if (db) {
+      console.log("db connected");
+      db.find({id: {$in: ids}}, (err, docs) => {
+        if (err) {
+          console.log('EE');
+          reject(err);
+        } else if (docs.length == 0) {
+          console.log("No record found!");
+          resolve(docs);
+        } else {
+          console.log("records: " + docs.length);
+          resolve(docs);
+        }
+      });
+    }
+  });
+
+
+/**
+   return response to a POST of fetching genome sequences by an array of ids
+   @param {string} datasetPath same as datasetDir when staring auspice
+*/
+const getGenomeDB = (datasetsPath) => {
+  return async (req, res) => { // eslint-disable-line consistent-return
+    try {
+      let prefix = req.body.prefix
+          .replace(/^\//, '')
+          .replace(/\/$/, '')
+          .split("/")
+          .join("_");
+      const dbPath = datasetsPath + '/genomeDbs/' + prefix + '.db';
+      if (!req.body.ids || req.body.ids.length === 0) {
+        res.setHeader('Content-Type', 'application/json');
+        if (fs.existsSync(dbPath)) {
+          res.end(JSON.stringify({result: true}));
+        } else {
+          res.end(JSON.stringify({result: false}));
+        }
+        return;
+      }
+      res.setHeader('Content-Type', 'text/plain');
+      var db = await fetchRecords(req.body.ids, dbPath);
+      db.forEach(v=> {
+        const wrappedSeq = v.seq.match(/.{1,80}/g).join('\n') + '\n';
+        res.write('>' + v.id + '\n');
+        res.write(wrappedSeq);
+      });
+      res.end();
+    } catch (err) {
+      console.trace(err);
+    }
+  };
+};
+
+/**
+   @param {string} path Path to datasetDir so we can create database if corresponding fasta
+   files exists for aupsice input JSON file
+*/
+const prepareDbs = async (path) => {
+  try {
+    const files = await readdir(path);
+    const v2Files = files.filter((file) => (
+      file.endsWith(".fasta")
+    ));
+    v2Files.forEach((v) => {
+      makeDB(path, path + '/' + v);
+    });
+
+
+  } catch (err) {
+    // utils.warn(`Couldn't collect available dataset files (path searched: ${path})`);
+    // utils.verbose(err);
+  }
+};
+
+/**
+   @param {string} dbRoot Path to directory where genome database should be saved
+   @param {string} fastaPath Path to fasta file to use as input to create database
+
+   Database will overwrite existing database files to avoid duplicates.
+   TODO: Maybe do something else to prevent unexpected data loss
+*/
+const makeDB = (dbRoot, fastaPath) => new Promise((resolve, reject) => {
+
+  process.stdin.setEncoding('utf8');
+
+  if (!fs.existsSync(dbRoot)) {
+    fs.mkdirSync(dbRoot);
+  }
+  const dbPath = getDbPath(fastaPath);
+
+  if (fs.existsSync(dbPath)) {
+    fs.unlink(dbPath, () => { console.log(`Overwrote ${dbPath} with new data!`);});
+  }
+
+  const processRecord = new PassThrough();
+  const db = new Engine({filename: dbPath, autoload: true});
+  let rc = 0;
+
+  processRecord.on('data', (rec) => {
+    obj = JSON.parse(rec);
+    const outrec = {id: obj.id, seq: obj.seq, source: fastaPath};
+    db.insert(outrec);
+    rc++;
+  });
+
+  processRecord.on('end', () => {
+    console.log(`Total added: ${rc} seqs to ${dbPath}`);
+    if (fs.existsSync(dbPath)) {
+      resolve();
+    } else {
+      reject(`File: ${dbPath} was not created.`);
+    }
+  }
+  );
+  const rs = fs.createReadStream(fastaPath);
+  rs.pipe(fasta())
+    .pipe(processRecord);
+
+});
+module.exports = {
+  fetchRecords,
+  getDbPath,
+  makeDB,
+  prepareDbs,
+  getGenomeDB
+};

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "10.8.x",
-    "npm": "6.2.x"
+    "node": ">=10.8 <= 13.16",
+    "npm": ">=6.2.x"
   },
   "bin": {
     "auspice": "./auspice.js"
@@ -54,6 +54,8 @@
     "babel-plugin-strip-function-call": "^1.0.2",
     "babel-plugin-styled-components": "^1.10.0",
     "binomial": "^0.2.0",
+    "bionode-fasta": "^0.5.6",
+    "body-parser": "^1.19.0",
     "chalk": "^2.4.1",
     "clean-webpack-plugin": "^3.0.0",
     "compression": "^1.7.3",
@@ -92,9 +94,10 @@
     "lodash-webpack-plugin": "^0.11.5",
     "marked": "^0.7.0",
     "mousetrap": "^1.6.2",
+    "nedb": "^1.8.0",
     "node-fetch": "^2.1.2",
     "outer-product": "0.0.4",
-    "papaparse": "^4.3.5",
+    "papaparse": "^5.2.0",
     "prettyjson": "^1.2.1",
     "prop-types": "^15.6.0",
     "query-string": "^4.2.3",

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -43,6 +43,8 @@ export const getDefaultControlsState = () => {
     region: null,
     search: null,
     strain: null,
+    gridFiltered: null,
+    isGenomeAvailable: false,
     geneLength: {},
     mutType: defaultMutType,
     temporalConfidence: {exists: false, display: false, on: false},
@@ -249,6 +251,10 @@ const Controls = (state = getDefaultControlsState(), action) => {
       return Object.assign({}, state, {coloringsPresentOnTree: state.coloringsPresentOnTree});
     case types.TOGGLE_TRANSMISSION_LINES:
       return Object.assign({}, state, {showTransmissionLines: action.data});
+  case 'GRID_FILTERED':
+    return Object.assign({}, state, {gridFiltered: action.data});
+  case 'GENOME_AVAILBLE':
+    return Object.assign({}, state, {isGenomeAvailable: action.data});
     default:
       return state;
   }


### PR DESCRIPTION
### Description of proposed changes    
When a corresponding FASTA file is placed in the same directory with auspice's
JSON file, for example a `ncov_global.fasta` is placed in the same directory with
`ncov_global.json`: the genome database handling functionality will kick in and
generate a file-based NeDB database at server startup time. A "Selected
Genomes (Fasta)" download button also then appears in side the "Download Data"
popup window. For dataset that doesn't have a corresponding FASTA file, this
functionality is inactive.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1110 

### Testing
>What steps should be taken to test the changes you've proposed? 
 

1. Apply this feature to the code base
2. Installation again as normal. 
2. Place a FASTA file `ncov_global.fasta` to `datasetDir` (i.e. ./data) for testing with `ncov_global.json`. Start or restart `asupice`. Fasta record IDs inside the FASTA file and tree tip names should match for auspice to fetch the correct genome from the database. 

>If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

None.

### Note:
[Upgrading](https://github.com/biocyberman/auspice/blob/feature-download-genomes/package.json#L100)  `papaparse` to newer version is not required for this feature to function properly, but I upgraded that in response to [severe security warning](https://www.npmjs.com/advisories/1515) by `npm` during installation process. 

### Thank you for contributing to Nextstrain!
