### PR TITLE
Have Legends Dynamically Change to only Show Visible Options

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -6,6 +6,7 @@ import { updateFrequencyDataDebounced } from "./frequencies";
 import { calendarToNumeric } from "../util/dateHelpers";
 import { applyToChildren } from "../components/tree/phyloTree/helpers";
 import { constructVisibleTipLookupBetweenTrees } from "../util/treeTangleHelpers";
+import { createVisibleLegendValues } from "../util/colorScale";
 
 
 export const applyInViewNodesToTree = (idx, tree) => {
@@ -138,6 +139,15 @@ export const updateVisibleTipsAndBranchThicknesses = (
       }
       dispatch(dispatchRadii);
     }
+    /* Changes in visibility require a recomputation of which legend items we wish to display */
+    dispatchObj.visibleLegendValues = createVisibleLegendValues({
+      colorBy: controls.colorBy,
+      scaleType: controls.colorScale.type,
+      legendValues: controls.colorScale.legendValues,
+      legendBounds: controls.colorScale.legendBounds,
+      nodes: tree.nodes,
+      visibility: data.visibility
+    });
 
     /* D I S P A T C H */
     dispatch(dispatchObj);
@@ -187,6 +197,16 @@ export const changeDateFilter = ({newMin = false, newMax = false, quickdraw = fa
       dispatchObj.branchThicknessToo = dataToo.branchThickness;
       dispatchObj.branchThicknessVersionToo = dataToo.branchThicknessVersion;
     }
+
+    /* Changes in visibility require a recomputation of which legend items we wish to display */
+    dispatchObj.visibleLegendValues = createVisibleLegendValues({
+      colorBy: controls.colorBy,
+      scaleType: controls.colorScale.type,
+      legendValues: controls.colorScale.legendValues,
+      legendBounds: controls.colorScale.legendBounds,
+      nodes: tree.nodes,
+      visibility: data.visibility
+    });
 
     /* D I S P A T C H */
     dispatch(dispatchObj);

--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -139,14 +139,15 @@ export const updateVisibleTipsAndBranchThicknesses = (
       }
       dispatch(dispatchRadii);
     }
+
     /* Changes in visibility require a recomputation of which legend items we wish to display */
     dispatchObj.visibleLegendValues = createVisibleLegendValues({
       colorBy: controls.colorBy,
-      scaleType: controls.colorScale.type,
+      type: controls.colorScale.type,
       legendValues: controls.colorScale.legendValues,
-      legendBounds: controls.colorScale.legendBounds,
-      nodes: tree.nodes,
-      visibility: data.visibility
+      tree: tree,
+      treeToo: treeToo,
+      controls: controls
     });
 
     /* D I S P A T C H */
@@ -201,11 +202,11 @@ export const changeDateFilter = ({newMin = false, newMax = false, quickdraw = fa
     /* Changes in visibility require a recomputation of which legend items we wish to display */
     dispatchObj.visibleLegendValues = createVisibleLegendValues({
       colorBy: controls.colorBy,
-      scaleType: controls.colorScale.type,
+      type: controls.colorScale.type,
       legendValues: controls.colorScale.legendValues,
-      legendBounds: controls.colorScale.legendBounds,
-      nodes: tree.nodes,
-      visibility: data.visibility
+      tree: tree,
+      treeToo: treeToo,
+      controls: controls
     });
 
     /* D I S P A T C H */

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -34,7 +34,7 @@ class Legend extends React.Component {
     if (this.props.legendOpen !== undefined) { return this.props.legendOpen; }
 
     // Our default state changes based on the size of the window or the number of items in the legend.
-    if (this.props.width < 600 || this.props.colorScale.legendValues.length > 32) {
+    if (this.props.width < 600 || this.props.colorScale.visibleLegendValues.length > 32) {
       return false;
     }
     return true;
@@ -44,7 +44,7 @@ class Legend extends React.Component {
     if (!this.showLegend()) {
       return 18;
     }
-    const nItems = this.props.colorScale.legendValues.length;
+    const nItems = this.props.colorScale.visibleLegendValues.length;
     const titlePadding = 20;
     return Math.ceil(nItems / 2) *
       (legendRectSize + legendSpacing) + legendSpacing + titlePadding || 100;
@@ -58,7 +58,7 @@ class Legend extends React.Component {
   }
 
   getTransformationForLegendItem(i) {
-    const count = this.props.colorScale.legendValues.length;
+    const count = this.props.colorScale.visibleLegendValues.length;
     const stack = Math.ceil(count / 2);
     const fromRight = Math.floor(i / stack);
     const fromTop = (i % stack);
@@ -141,7 +141,7 @@ class Legend extends React.Component {
   styleLabelText(label) {
     /* depending on the colorBy, we display different labels! */
     if (this.props.colorBy === "num_date") {
-      const legendValues = this.props.colorScale.legendValues;
+      const legendValues = this.props.colorScale.visibleLegendValues;
       if (
         (legendValues[legendValues.length-1] - legendValues[0] > 10) && /* range spans more than 10 years */
         (legendValues[legendValues.length-1] - parseInt(label, 10) >= 10) /* current label (value) is more than 10 years from the most recent */
@@ -159,7 +159,7 @@ class Legend extends React.Component {
    * coordinate system from top,left of parent SVG
    */
   legendItems() {
-    const items = this.props.colorScale.legendValues
+    const items = this.props.colorScale.visibleLegendValues
       .filter((d) => d !== undefined)
       .map((d, i) => {
         return (

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -248,7 +248,8 @@ const Controls = (state = getDefaultControlsState(), action) => {
       }
       return Object.assign({}, state, {coloringsPresentOnTree: state.coloringsPresentOnTree});
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS:
-      return {...state, ...{colorScale: {...state.colorScale, visibleLegendValues: action.visibleLegendValues}}};
+      const colorScale = {...state.colorScale, visibleLegendValues: action.visibleLegendValues};
+      return {...state, colorScale};
     default:
       return state;
   }

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -142,7 +142,8 @@ const Controls = (state = getDefaultControlsState(), action) => {
         newDates.dateMax = action.dateMax;
         newDates.dateMaxNumeric = action.dateMaxNumeric;
       }
-      return Object.assign({}, state, newDates);
+      const colorScale = {...state.colorScale, visibleLegendValues: action.visibleLegendValues};
+      return {...state, ...newDates, colorScale};
     }
     case types.CHANGE_ABSOLUTE_DATE_MIN:
       return Object.assign({}, state, {
@@ -246,6 +247,8 @@ const Controls = (state = getDefaultControlsState(), action) => {
         state.coloringsPresentOnTree.add(colorBy);
       }
       return Object.assign({}, state, {coloringsPresentOnTree: state.coloringsPresentOnTree});
+    case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS:
+      return {...state, ...{colorScale: {...state.colorScale, visibleLegendValues: action.visibleLegendValues}}};
     default:
       return state;
   }

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -2,7 +2,7 @@ import { scaleLinear, scaleOrdinal } from "d3-scale";
 import { min, max, range as d3Range } from "d3-array";
 import { rgb } from "d3-color";
 import { interpolateHcl } from "d3-interpolate";
-import { genericDomain, colors, genotypeColors, isValueValid } from "./globals";
+import { genericDomain, colors, genotypeColors, isValueValid, NODE_VISIBLE } from "./globals";
 import { countTraitsAcrossTree } from "./treeCountingHelpers";
 import { getExtraVals } from "./colorHelpers";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
@@ -42,6 +42,28 @@ const getDiscreteValuesFromTree = (nodes, nodesToo, attr) => {
   }
   const domain = sortedDomain(Array.from(stateCount.keys()).filter((x) => isValueValid(x)), attr, stateCount);
   return domain;
+};
+
+export const createVisibleLegendValues = ({colorBy, scaleType, legendValues, legendBounds, nodes, visibility}) => {
+  console.log("createVisibleLegendValues", scaleType, legendValues, legendBounds, nodes, visibility);
+  // filter according to scaleType, e.g. continuous is different to categorical which is different to boolean
+  // filtering will involve looping over reduxState.tree.nodes and comparing with reduxState.tree.visibility
+
+  if (!visibility) {
+    console.warn("to debug - race condition on loading");
+    return legendValues.slice();
+  }
+
+  if (scaleType === "categorical") {
+    const legendValuesObserved = new Set(
+      nodes.filter((n, i) => (!n.hasChildren && visibility[i]===NODE_VISIBLE))
+        .map((n) => getTraitFromNode(n, colorBy))
+    );
+    return legendValues.filter((v) => legendValuesObserved.has(v));
+  }
+
+  // for testing non-categorical scales, i'm just filtering the list into odd entries
+  return legendValues.filter((x, i) => i%2);
 };
 
 const createDiscreteScale = (domain, type) => {
@@ -273,6 +295,9 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     colorScale = () => unknownColor;
   }
 
+  // Would make more sense to calculate earlier in the function
+  const scaleType = genotype ? "categorical" : colorings[colorBy].type;
+
   return {
     scale: colorScale,
     continuous: continuous,
@@ -280,6 +305,9 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     version: controls.colorScale === undefined ? 1 : controls.colorScale.version + 1,
     legendValues,
     legendBounds,
-    genotype
+    type: scaleType,
+    visibleLegendValues: createVisibleLegendValues({
+      colorBy, scaleType, legendValues, legendBounds, nodes: tree.nodes, visibility: tree.visibility
+    })
   };
 };


### PR DESCRIPTION
### Description of proposed changes    
Dynamically changes the visibility of legend values for categorical and ordinal scale types. 

Before

<img width="1434" alt="Screen Shot 2020-06-01 at 5 08 57 PM" src="https://user-images.githubusercontent.com/40753283/83459733-9692b480-a42a-11ea-8cff-d644aa9c6654.png">

After

<img width="1430" alt="Screen Shot 2020-06-01 at 5 08 33 PM" src="https://user-images.githubusercontent.com/40753283/83459714-8ed31000-a42a-11ea-9f8d-72033487d72d.png">

```/flu/seasonal/h3n2/ha/2y:flu/seasonal/h1n1pdm/ha/2y?dmax=2018-02-15&dmin=2015-11-05```

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->


Closes #1109 

### Testing

I tried to fix potential issues related to having a second tree, but there should be more rigorous testing to make sure it doesn't fail. 

### Thank you for contributing to Nextstrain!
