### PR TITLE
Improve performance when transmission lines are not drawn

### DIFF
--- a/docs-src/docs/advanced-functionality/view-settings.md
+++ b/docs-src/docs/advanced-functionality/view-settings.md
@@ -37,6 +37,7 @@ For instance, if you set `display_defaults.color_by` to `country`, but load the 
 | `layout`            | Tree layout        | "rect", "radial", "clock" or "unrooted |
 | `branch_label`      | Which set of branch labels are to be displayed | "aa", "lineage" |
 | `panels`            | List of panels which (if available) are to be displayed  | ["tree", "map"] |
+| `transmission_lines`| Should transmission lines (if available) be rendered on the map?  | Boolean |
 
 
 Note that `meta.display_defaults.panels` (optional) differs from `meta.panels` (required), where the latter lists the possible panels that auspice may display for the dataset.

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -192,11 +192,11 @@ const modifyStateViaMetadata = (state, metadata) => {
     console.warn("JSON did not include any filters");
   }
   if (metadata.displayDefaults) {
-    const keysToCheckFor = ["geoResolution", "colorBy", "distanceMeasure", "layout", "mapTriplicate", "selectedBranchLabel", 'sidebar'];
-    const expectedTypes =  ["string",        "string",  "string",          "string", "boolean",       "string",              'string']; // eslint-disable-line no-multi-spaces
+    const keysToCheckFor = ["geoResolution", "colorBy", "distanceMeasure", "layout", "mapTriplicate", "selectedBranchLabel", 'sidebar', "showTransmissionLines"];
+    const expectedTypes =  ["string",        "string",  "string",          "string", "boolean",       "string",              'string',  "boolean"              ]; // eslint-disable-line
 
     for (let i = 0; i < keysToCheckFor.length; i += 1) {
-      if (metadata.displayDefaults[keysToCheckFor[i]]) {
+      if (Object.hasOwnProperty.call(metadata.displayDefaults, keysToCheckFor[i])) {
         if (typeof metadata.displayDefaults[keysToCheckFor[i]] === expectedTypes[i]) { // eslint-disable-line valid-typeof
           if (keysToCheckFor[i] === "sidebar") {
             if (metadata.displayDefaults[keysToCheckFor[i]] === "open") {
@@ -631,10 +631,11 @@ const createMetadataStateFromJSON = (json) => {
       map_triplicate: "mapTriplicate",
       layout: "layout",
       sidebar: "sidebar",
-      panels: "panels"
+      panels: "panels",
+      transmission_lines: "showTransmissionLines"
     };
     for (const [jsonKey, auspiceKey] of Object.entries(jsonKeyToAuspiceKey)) {
-      if (json.meta.display_defaults[jsonKey]) {
+      if (Object.prototype.hasOwnProperty.call(json.meta.display_defaults, jsonKey)) {
         metadata.displayDefaults[auspiceKey] = json.meta.display_defaults[jsonKey];
       }
     }

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -220,6 +220,7 @@ class Map extends React.Component {
         this.props.pieChart,
         this.props.legendValues,
         this.props.colorBy,
+        this.props.showTransmissionLines,
         this.props.dispatch
       );
 
@@ -385,6 +386,7 @@ class Map extends React.Component {
         nextProps.pieChart,
         nextProps.legendValues,
         nextProps.colorBy,
+        nextProps.showTransmissionLines,
         nextProps.dispatch
       );
       const d3elems = drawDemesAndTransmissions(
@@ -397,8 +399,7 @@ class Map extends React.Component {
         nextProps.dateMaxNumeric,
         nextProps.pieChart,
         nextProps.geoResolution,
-        nextProps.dispatch,
-        nextProps.showTransmissionLines
+        nextProps.dispatch
       );
       this.setState({
         d3elems,

--- a/src/components/map/mapHelpers.js
+++ b/src/components/map/mapHelpers.js
@@ -137,8 +137,7 @@ export const drawDemesAndTransmissions = (
   numDateMax,
   pieChart, /* bool */
   geoResolution,
-  dispatch,
-  showTransmissionLines
+  dispatch
 ) => {
 
   // add transmission lines
@@ -165,7 +164,7 @@ export const drawDemesAndTransmissions = (
     .attr("stroke-opacity", 0.6)
     .attr("stroke-linecap", "round")
     .attr("stroke", (d) => { return d.color; })
-    .attr("stroke-width", showTransmissionLines ? 1 : 0);
+    .attr("stroke-width", 1);
 
   const visibleTips = nodes[0].tipCount;
   const demeMultiplier =

--- a/src/components/map/mapHelpersLatLong.js
+++ b/src/components/map/mapHelpersLatLong.js
@@ -399,6 +399,7 @@ export const createDemeAndTransmissionData = (
   pieChart,
   legendValues,
   colorBy,
+  showTransmissionLines,
   dispatch
 ) => {
   /*
@@ -414,16 +415,21 @@ export const createDemeAndTransmissionData = (
     demeIndices
   } = setupDemeData(nodes, visibility, geoResolution, nodeColors, triplicate, metadata, map, pieChart, legendValues, colorBy);
 
-  /* second time so that we can get Bezier */
-  const { transmissionData, transmissionIndices, demesMissingLatLongs } = setupTransmissionData(
-    nodes,
-    visibility,
-    geoResolution,
-    nodeColors,
-    triplicate,
-    metadata,
-    map
-  );
+  let transmissionData = [];
+  let transmissionIndices = {};
+  let demesMissingLatLongs = new Set(); // TODO: this won't be filled in if we're not showing transmission lines...
+  if (showTransmissionLines) {
+    /* second time so that we can get Bezier */
+    ({ transmissionData, transmissionIndices, demesMissingLatLongs } = setupTransmissionData(
+      nodes,
+      visibility,
+      geoResolution,
+      nodeColors,
+      triplicate,
+      metadata,
+      map
+    ));
+  }
 
   const filteredDemesMissingLatLongs = [...demesMissingLatLongs].filter((value) => {
     return value.toLowerCase() !== "unknown";


### PR DESCRIPTION
#1147 implemented a toggle for transmission lines. This works by [setting the stroke-width for the lines to 0](https://github.com/nextstrain/auspice/pull/1147/files#diff-6f2756004c3173752c364d433f1a7b58R168), so they are still calculated and placed in the DOM.  There is significant overhead to both the calculation and the DOM manipulation for these lines, especially noticeable during animation. 

This PR skips the creation of `transmissionData` and `transmissionIndices` when we are not displaying transmission lines, and the corresponding DOM elements are never created.

Performance testing (locally using Firefox dev-tools, displaying only the map panel, using a nCoV dataset with 4.3k tips) shows a ~50% increase in framerate (8.8 -> 12.7fps).

This PR is a single commit (a9ef44b) on top of PR #1152