### PR TITLE
Cast all branch labels to strings

### DIFF
--- a/src/util/treeJsonProcessing.js
+++ b/src/util/treeJsonProcessing.js
@@ -46,7 +46,11 @@ const processBranchLabelsInPlace = (nodes) => {
   nodes.forEach((n) => {
     if (n.branch_attrs && n.branch_attrs.labels) {
       Object.keys(n.branch_attrs.labels)
-        .forEach((labelName) => availableBranchLabels.add(labelName));
+        .forEach((labelName) => {
+          availableBranchLabels.add(labelName);
+          /* cast all branch label values to strings */
+          n.branch_attrs.labels[labelName] = String(n.branch_attrs.labels[labelName]);
+        });
     }
   });
   return ["none", ...availableBranchLabels];


### PR DESCRIPTION
This addresses a long-standing bug in auspice and closes #888. Casting branch labels to strings doesn't change how the labels render, but does allow restoration of zoom state via URL queries which always use strings.

### Testing

Compare the behavior of this PR vs nextstrain.org for the flu/seasonal/h1n1pdm/ha/12y dataset which has numeric branch label values. 

Additionally to this, as per https://github.com/nextstrain/auspice/issues/888#issuecomment-634214223, the augur schema should be updated to indicate that string label values should be used. 
