### PR TITLE
add url query for transmission

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -127,6 +127,13 @@ const modifyStateViaURLQuery = (state, query) => {
   if ("onlyPanels" in query) {
     state.showOnlyPanels = true;
   }
+  if (query.transmissions) {
+    if (query.transmissions === "show") {
+      state.showTransmissionLines = true;
+    } else if (query.transmissions === "hide") {
+      state.showTransmissionLines = false;
+    }
+  }
 
   return state;
 };

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -75,6 +75,11 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       query.r = action.data === state.controls.defaults.geoResolution ? undefined : action.data;
       break;
     }
+    case types.TOGGLE_TRANSMISSION_LINES: {
+      if (action.data === state.controls.defaults.showTransmissionLines) query.transmissions = undefined;
+      else query.transmissions = action.data ? 'show' : 'hide';
+      break;
+    }
     case types.CHANGE_LANGUAGE: {
       query.lang = action.data === state.general.defaults.language ? undefined : action.data;
       break;

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -21,7 +21,8 @@ export const getDefaultControlsState = () => {
     geoResolution: defaultGeoResolution,
     filters: {},
     colorBy: defaultColorBy,
-    selectedBranchLabel: "none"
+    selectedBranchLabel: "none",
+    showTransmissionLines: true
   };
   // a default sidebarOpen status is only set via JSON, URL query
   // _or_ if certain URL keywords are triggered


### PR DESCRIPTION
### Description of proposed changes    
toggling showTransmissionsLine will update url query and vice versa.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1155   
Related to #  

### Testing
Tested out with dev. ?transmission=hide when toggled off and no query when toggled on.
Test suite also passed.

### Thank you for contributing to Nextstrain!
