### PR TITLE
Relax requirement for nodejs 10.8. Closes #1161.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The following are helpful when beginning to use Auspice:
 ### Installation
 
 Install auspice for use as a global command.
-This requires nodejs 10+. We recommend using a conda environment, but this is not the only way.
+This requires nodejs.
+We recommend using a conda environment, but this is not the only way.
 (See [here](https://nextstrain.github.io/auspice/introduction/install) for more installation methods & help).
 
 #### Install with conda (Recommended)
@@ -40,7 +41,7 @@ This requires nodejs 10+. We recommend using a conda environment, but this is no
 Create and activate a [conda](https://docs.conda.io) environment:
 
 ```bash
-conda create --name auspice nodejs=10
+conda create --name auspice nodejs=12
 conda activate auspice
 ```
 

--- a/docs-src/docs/introduction/install.md
+++ b/docs-src/docs/introduction/install.md
@@ -4,7 +4,7 @@ title: Install Auspice
 
 ## Prerequisites
 Auspice is a JavaScript program, and requires [Node.js](https://nodejs.org/) to be installed on your system.
-For best results, please use Node.js version 10.
+We've had success running a range of different node versions between 10.8 and 13.
 
 We highly recommend using [Conda](https://conda.io/docs/) to manage environments, i.e. use Conda to create an environment with Node.js installed where you can use Auspice.
 It's possible to use other methods, but this documentation presupposes that you have Conda installed.
@@ -16,7 +16,7 @@ You can also use the Windows Subsystem Linux for a fuller Linux environment.
 
 ## Create a Conda Environment
 ```bash
-conda create --name auspice nodejs=10
+conda create --name auspice nodejs=12
 conda activate auspice
 ```
 

--- a/docs-src/docs/narratives/create-pdf.md
+++ b/docs-src/docs/narratives/create-pdf.md
@@ -14,7 +14,7 @@ If you've followed the [auspice install instructions](../introduction/install) a
 If not, you can create the necessary conda environment via:
 
 ```bash
-conda create --name auspice nodejs=10
+conda create --name auspice nodejs=12
 ```
 
 Install Decktape via:

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "10.8.x",
-    "npm": "6.2.x"
+    "node": ">=10.8.0 <=13.14",
+    "npm": ">=6.2"
   },
   "bin": {
     "auspice": "./auspice.js"


### PR DESCRIPTION
Auspice should work on a wide range of nodejs versions. Here I specified
between 10.8 and 13.14 as they are the versions I've personally run
auspice on without trouble.