### PR TITLE
fix bug of gmax&gmin query earse on any other entropy brush

### DIFF
--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -442,12 +442,20 @@ EntropyChart.prototype._addBrush = function _addBrush() {
   this.brushFinished = function brushFinished() {
     this.brushed();
     /* if the brushes were moved by box, click drag, handle, or click, then update zoom coords */
-    if (d3event.sourceEvent instanceof MouseEvent && (!d3event.selection || d3event.sourceEvent.target.id === "d3entropyParent" ||
-        d3event.sourceEvent.target.id === "")) {
-      this.props.dispatch(changeZoom(this.zoomCoordinates));
-    } else {
-      /* If selected gene or clicked on entropy, hide zoom coords */
-      this.props.dispatch(changeZoom([undefined, undefined]));
+    if (d3event.sourceEvent instanceof MouseEvent) {
+      if(
+        !d3event.selection ||
+        d3event.sourceEvent.target.id === "d3entropyParent" ||
+        d3event.sourceEvent.target.id === ""
+      ) {
+        this.props.dispatch(changeZoom(this.zoomCoordinates));
+      } else if (
+        d3event.sourceEvent.target.id.match(/^prot/) ||
+        d3event.sourceEvent.target.id.match(/^nt/)
+      ) {
+        /* If selected gene or clicked on entropy, hide zoom coords */
+        this.props.dispatch(changeZoom([undefined, undefined]));
+      }
     }
   };
 

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -443,7 +443,7 @@ EntropyChart.prototype._addBrush = function _addBrush() {
     this.brushed();
     /* if the brushes were moved by box, click drag, handle, or click, then update zoom coords */
     if (d3event.sourceEvent instanceof MouseEvent) {
-      if(
+      if (
         !d3event.selection ||
         d3event.sourceEvent.target.id === "d3entropyParent" ||
         d3event.sourceEvent.target.id === ""


### PR DESCRIPTION
### Description of proposed changes    
Fix for disappearing gmin&gmax query on URL for entropy zoom level in initial or any other rendering other than zoom changes. The new conditional will only erase zoom level when brush trigger by click on entropy or gene, as the original code comment intended.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1145 
Related to #  

### Testing
Tested by changing zoom level, copy the url and paste into a new window. With the new code, the gmin&gmax query remain after load. Clicking on entropy or gene will hide the zoom queries, as intended.

### Thank you for contributing to Nextstrain!
