### PR TITLE
fix 1176 (Drag and drop tsv metadata not adding color by option to dropdown)

### DIFF
--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -116,10 +116,11 @@ class ColorBy extends React.Component {
   /**
    * Avoids double invocation of change() method
    */
-  shouldComponentUpdate(_, nextState) {
+  shouldComponentUpdate(nextProps, nextState) {
     if (this.state.colorBySelected === nextState.colorBySelected &&
         this.state.geneSelected === nextState.geneSelected &&
-        this.state.positionSelected === nextState.positionSelected) {
+        this.state.positionSelected === nextState.positionSelected &&
+        this.props.colorings === nextProps.colorings) {
       return false;
     }
     return true;


### PR DESCRIPTION
see https://github.com/nextstrain/auspice/issues/1176#issuecomment-649097216

### Description of proposed changes    
Adds a clause to fix this particular issue, but if we are concerned that shouldComponentUpdate might preventing other needed updates in the name of performance improvements (the implementation of that function seemed to make an [important performance improvement](https://github.com/nextstrain/auspice/pull/1075)), maybe there is a way we could get the best of both worlds. For example, by [PureComponent to make a shallow comparison of props and state](https://reactjs.org/docs/react-component.html#shouldcomponentupdate). 

### Related issue(s)  
#1176 
#1035 

### Testing
see #1176 for testing steps to reproduce the bug. Doing this should now achieve the desired behavior in the original issue.

### Thank you for contributing to Nextstrain!
