### PR TITLE
[bugfix] allow `auspice view` to work with custom auspice clients

### DIFF
--- a/cli/view.js
+++ b/cli/view.js
@@ -82,7 +82,7 @@ const getAuspiceBuild = () => {
     cwd !== sourceDir &&
     fs.existsSync(path.join(cwd, "index.html")) &&
     fs.existsSync(path.join(cwd, "dist")) &&
-    fs.existsSync(path.join(cwd, "dist", "auspice.bundle.js"))
+    fs.readdirSync(path.join(cwd, "dist")).filter((fn) => fn.match(/^auspice.bundle.[a-z0-9]+.js$/)).length === 1
   ) {
     return {
       message: "Serving the auspice build which exists in this directory.",


### PR DESCRIPTION
When running `auspice view` there is some logic to ask if we have a customised client bundle present, which we should serve, or whether we should serve the vanilla (default) auspice client.

PR #1126 introduced hashes into the (client) JS bundle names, which resulted in this logic missing when there was a customised client present, so we would always fall back to the vanilla auspice client.

Note that we didn't observe this in nextstrain.org as we don't use `auspice view` directly. This bug was identified while trying to upgrade [auspice.us](github.com/nextstrain/auspice.us). 