### PR TITLE
Fix the shift/option + mouseWheel zoom bug in entropy panel

### DIFF
--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -456,8 +456,15 @@ EntropyChart.prototype._addBrush = function _addBrush() {
         /* If selected gene or clicked on entropy, hide zoom coords */
         this.props.dispatch(changeZoom([undefined, undefined]));
       }
+    } else if (_isZoomEvent(d3event)) {
+      this.props.dispatch(changeZoom(this.zoomCoordinates));
     }
   };
+
+  /* ZoomEvent is emitted by d3-zoom when shift/option + mouseWheel on the entropy panel. */
+  function _isZoomEvent(d3Event) {
+    return d3Event && d3Event.sourceEvent && d3Event.sourceEvent.type === 'zoom';
+  }
 
   /* zooms in by modifing the domain of xMain scale */
   this._zoom = function _zoom(start, end) {


### PR DESCRIPTION
### Description of proposed changes    

Fix the issue that shift/option + mouseWheel on the entropy panel doesn't update the query strings `gmax` and `gmin`.

The root cause of the issue is that the `brushFinished` method doesn't dispatch `changeZoom(this.zoomCoordinates)` for the ZoomEvent(ZoomEvent is the event emitted by shift/option + mouseWheel). Added the logic to dispatch `changeZoom(this.zoomCoordinates)` for ZoomEvent.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1179 
Related to #  

### Testing
Manually tested the following 3 cases.
1. shift + mouseWheel on the entropy panel, observed the query strings `gmax` and `gmin` get in the URL.
1. option + mouseWheel on the entropy panel, observed the query strings `gmax` and `gmin` get in the URL.
1. click + drag the up arrow works as before.
