### PR TITLE
Improve redux state recalc on narrative slide changes. Closes #1191

### DIFF
--- a/narratives/test_confidence-intervals.md
+++ b/narratives/test_confidence-intervals.md
@@ -1,0 +1,28 @@
+---
+title: Exploring the narrative functionality using the ongoing mumps epidemic in North America
+authors: "James Hadfield"
+authorLinks: "https://twitter.com/hamesjadfield"
+affiliations: "Fred Hutch, Seattle, USA"
+date: "August 2018"
+dataset: "https://nextstrain.org/mumps/na?d=tree"
+abstract: "This content is here to test the potential of the nextstrain (auspice) narrative functionality. It uses the Publicly available North American mumps dataset [here](https://www.nextstrain.org/mumps/na) to explore what's possible using narratives."
+---
+
+
+# [Confidence](https://nextstrain.org/mumps/na?d=tree&p=full&ci)
+
+Toggle on confidence
+
+# [Confidence with change in tree](https://nextstrain.org/mumps/na?d=tree&p=full&ci&f_division=Washington)
+
+Confidence should remain while we filter the tree
+
+
+# [Toggle off confidence](https://nextstrain.org/mumps/na?d=tree&p=full&f_division=Washington)
+
+Toggle off confidence (filtering doesn't change)
+
+
+# [Radial tree with CIs](https://nextstrain.org/mumps/na?d=tree&p=full&ci&l=radial)
+
+The narrative asks for CIs on a radial tree which is invalid, but shouldn't result in a non-functional app state.

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -1,4 +1,5 @@
 import queryString from "query-string";
+import { cloneDeep } from 'lodash';
 import { numericToCalendar, calendarToNumeric } from "../util/dateHelpers";
 import { reallySmallNumber, twoColumnBreakpoint, defaultColorBy, defaultGeoResolution, defaultDateRange, nucleotide_gene } from "../util/globals";
 import { calcBrowserDimensionsInitialState } from "../reducers/browserDimensions";
@@ -696,8 +697,9 @@ export const createStateFromQueryOrJSONs = ({
     controls["absoluteZoomMin"] = 0;
     controls["absoluteZoomMax"] = entropy.lengthSequence;
   } else if (oldState) {
-    /* revisit this - but it helps prevent bugs */
-    controls = {...oldState.controls};
+    /* creating deep copies avoids references to (nested) objects remaining the same which
+    can affect props comparisons. Due to the size of some of the state, we only do this selectively */
+    controls = cloneDeep(oldState.controls);
     entropy = {...oldState.entropy};
     tree = {...oldState.tree};
     treeToo = {...oldState.treeToo};

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -57,15 +57,13 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
   }
 
 
-  /* confidence intervals (on means in the SVG, display means shown in the sidebar)
-  This block used to include comparisons of oldProps to newProps. See:
-  https://github.com/nextstrain/auspice/commit/0713e69b0707c92df806a575796e7205f08332ff
-  for an explanation of why it no longer does. */
-  if (newProps.temporalConfidence.display === false) {
+  /* show / remove confidence intervals across the tree */
+  if (
+    (oldProps.temporalConfidence.display === true && newProps.temporalConfidence.display === false) ||
+    (oldProps.temporalConfidence.on === true && newProps.temporalConfidence.on === false)
+  ) {
     args.removeConfidences = true;
-  } else if (newProps.temporalConfidence.on === false) {
-    args.removeConfidences = true;
-  } else if (newProps.temporalConfidence.display === true && newProps.temporalConfidence.on === true) {
+  } else if (newProps.temporalConfidence.display === true && oldProps.temporalConfidence.on === false && newProps.temporalConfidence.on === true) {
     args.showConfidences = true;
   }
 


### PR DESCRIPTION
This commit improves the creation of new state during narrative slide-changes which has a number of beneficial side-effects.

Previously we made a shallow-copy of the (redux) controls state when we changed slides, which resulted in props-comparison of nested state (i.e. objects within the controls state) being hard to reason with. This was problematic with the `temporalConfidence` object, which explains the approach employed in 0713e69b0707c92df806a575796e7205f08332ff to allow narrative slides to update CIs.

We now deep clone the controls state, allowing valid props comparison and allowing us to use this technique to decide when to render / remove CIs. (This is essentially a reversion of 0713e69b0707c92df806a575796e7205f08332ff, which was implemented as props comparisons were found to be unreliable).

This commit was motivated by, and fixes #1191. That bug was a result of the previous logic indicating that CIs should be removed on each branch-hover event. This meant that any subsequent tree-manipulation (such as clicking a branch to zoom) would be likely to be considered "in quick succession" to a previous manipulation and thus not employ an animation.

A test narrative is added.

@eharkins would you mind looking at this? It explains why the props-comparison wasn't working when you implemented the URL query for CIs! 