### PR TITLE
fix: ensure generated svg ids are escaped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5324,6 +5324,11 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "core-js": "^3.6.5",
     "create-react-class": "^15.6.0",
     "css-loader": "^2.1.1",
+    "css.escape": "^1.5.1",
     "d3-array": "^1.2.0",
     "d3-axis": "^1.0.6",
     "d3-brush": "^1.0.4",

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -5,8 +5,9 @@ import {getTraitFromNode, getDivFromNode} from "../../../util/treeMiscHelpers";
  * Note that this cannot have any "special" characters
  */
 export const getDomId = (type, strain) => {
-  const name = typeof strain === "string" ? strain.replace(/[/_.;,~|[\]-]/g, '') : strain;
-  return `${type}_${name}`;
+  // Replace non-alphanumeric characters with dashes (probably unnecessary)
+  const name = `${type}_${strain}`.replace(/(\W+)/g, '-');
+  return CSS.escape(name);
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 import "whatwg-fetch"; // eslint-disable-line
 import "core-js";
 import "regenerator-runtime";
+import "css.escape";
 /* L I B R A R I E S */
 import "react-hot-loader";
 import React from "react";


### PR DESCRIPTION
### Description of proposed changes    
This ensures that runtime-generated HTML `id` properties are correctly sanitized, in particular, that invalid characters are removed or escaped.

Added dependencies:

`css.escape` as a polyfill for `CSS.escape()` (not available in IE)

There might be more places requiring sanitizaton.

### Related issue(s)  
Contributes to #1208 

### Testing
See linked issue.  
