### PR TITLE
Improve parsing of auspice URLs with a colon character

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -63,15 +63,18 @@ const getDataset = hasExtension("hardcodedDataPaths") ? getHardcodedData : getDa
  *                  [1] {string | undefined} secondTreeUrl, if applicable
  */
 export const collectDatasetFetchUrls = (url) => {
-  let secondTreeUrl;
-  if (url.includes(":")) {
-    const parts = url.replace(/^\//, '')
-      .replace(/\/$/, '')
-      .split(":");
-    url = parts[0]; // eslint-disable-line no-param-reassign
-    secondTreeUrl = parts[1];
+  // dual trees are defined via <pathA>:<pathB>. Note that pathA (and/or pathB) should be allowed
+  // to include http[s]:// (i.e. the colon there shouldn't split the string)
+  const re = /(?<!http[s]?):(?!\/\/)/;
+  if (url.search(re) !== -1) {
+    const treeUrls = url
+      .replace(/^\//, '') // strip leading forward slash
+      .replace(/\/$/, '') // strip trailing forward slash
+      .split(re);         // split on the `:` character
+    if (treeUrls.length > 2) console.warn("Splitting of the requested dataset URL resulted in more than 2 datasets!");
+    return treeUrls.splice(0, 2);
   }
-  return [url, secondTreeUrl];
+  return [url, undefined];
 };
 
 /**


### PR DESCRIPTION
In preparation for new nextstrain.org functionality to allow
users to specify custom JSON locations as a URL within the
nextstrain.org URL (see https://github.com/nextstrain/nextstrain.org/pull/216)
we need to improve the logic auspice uses to identify dual trees.

dual trees are defined via <pathA>:<pathB> but we wish to allow a `:` character
to appear within pathA (and/or pathB) in the form of "http://" or "https://"
and not interpret this as requesting two trees.
