### PR TITLE
fix: polyfill Promise to avoid crashes in old browsers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,7 +109,7 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
     plugins.push(new BundleAnalyzerPlugin());
   }
 
-  const entry = devMode ? ["webpack-hot-middleware/client", "./src/indexAsync"] : ["./src/indexAsync"];
+  const entry = devMode ? ["webpack-hot-middleware/client", "./src/indexAsync"] : ["core-js/es/promise", "./src/indexAsync"];
 
   /* Where do we want the output to be saved?
    * For development we use the (virtual) "devel" directory


### PR DESCRIPTION
### Description of proposed changes    
This adds `Promise` polyfill before async entrypoint.
This is "solution 2" in the linked issue. See there for more details.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #1213

### Testing

Tested in a some of the old browsers, as described in the issue

### Thank you for contributing to Nextstrain!
Always glad