### PR TITLE
Use response status code not status message for 204 responses

### DIFF
--- a/src/util/exceptions.js
+++ b/src/util/exceptions.js
@@ -1,0 +1,5 @@
+export class NoContentError extends Error {
+  constructor(...params) {
+    super(...params);
+  }
+}

--- a/src/util/serverInteraction.js
+++ b/src/util/serverInteraction.js
@@ -1,7 +1,12 @@
+import {NoContentError} from "./exceptions";
+
 export const fetchWithErrorHandling = async (path) => {
   const res = await fetch(path);
 
   if (res.status !== 200) {
+    if (res.status === 204) {
+      throw new NoContentError();
+    }
     throw new Error(`${await res.text()} (${res.statusText})`);
   }
   return res;


### PR DESCRIPTION
API requests for `getDataset` which return 204 (No content) responses are a special case which should "cause Auspice to show its splash page listing the available datasets & narratives" (see https://nextstrain.github.io/auspice/server/api#charon-getdataset)

Auspice previously looked at the response statusMessage to check if responses were 204, however this wasn't appropriate (see https://github.com/nextstrain/nextstrain.org/commit/ff810503b0de6d03fc07e25d9f626d0e25f9e429 for more).

Here I switch the code to specifically check the response status code. This restores the intended behavior.
