### PR TITLE
Improve appearance of sidebar headers

### DIFF
--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -37,6 +37,7 @@ export const HeaderIconContainer = styled.span`
   padding-top: 4px;
   padding-right: 3px;
   cursor: help;
+  color: #888;
 `;
 
 export const SidebarButton = styled.button`

--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -27,6 +27,7 @@ export const HeaderContainer = styled.div`
   font-family: ${(props) => props.theme["font-family"]};
   font-size: 16px;
   line-height: 28px;
+  min-height: 28px; /* needed for safari, else the div height is 0 */
   margin-top: 15px;
   margin-bottom: 5px;
   font-weight: 500;


### PR DESCRIPTION
Using medium gray so it's less prominent on both Auspice's dark sidebar and Nextstrain's light sidebar. We only have a single text color in `globalStyles.js` and so I hard coded this to the component rather than borrowing something from `globalStyles.js`.