### PR TITLE
[bugfix] handle unknown values in color scales with provided scales

### DIFF
--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -3,6 +3,7 @@ import { interpolateRgb } from "d3-interpolate";
 import scalePow from "d3-scale/src/pow";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
 import { getTraitFromNode } from "./treeMiscHelpers";
+import { isValueValid } from "./globals";
 
 /**
  * Average over the visible colours for a given location
@@ -48,7 +49,9 @@ export const getExtraVals = (nodes, nodesToo, colorBy, providedVals) => {
     nodesToo.forEach((n) => valsInTree.push(getTraitFromNode(n, colorBy)));
   }
   valsInTree = [...new Set(valsInTree)];
-  return valsInTree.filter((x) => providedVals.indexOf(x) === -1);
+  return valsInTree
+    .filter((x) => providedVals.indexOf(x) === -1)
+    .filter((x) => isValueValid(x));
 };
 
 

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -145,17 +145,19 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
         error = true;
       } else {
         continuous = false; /* colorMaps can't (yet) be continuous */
+        const colorMap = new Map(scale);
         let domain = scale.map((x) => x[0]);
-        let range = scale.map((x) => x[1]);
+        /* create shades of grey for values in the tree which weren't defined in the provided scale */
         const extraVals = getExtraVals(tree.nodes, treeTooNodes, colorBy, domain);
-        if (extraVals.length) { // we must add these to the domain + provide a value in the range
+        if (extraVals.length) { // we must add these to the domain + provide a color value
           domain = domain.concat(extraVals);
-          range = range.concat(createListOfColors(extraVals.length, [rgb(192, 192, 192), rgb(32, 32, 32)]));
+          const extraColors = createListOfColors(extraVals.length, [rgb(192, 192, 192), rgb(32, 32, 32)]);
+          extraVals.forEach((val, idx) => {
+            colorMap.set(val, extraColors[idx]);
+          });
         }
-        colorScale = scaleOrdinal()
-          .domain(domain)
-          .range(range);
         legendValues = domain;
+        colorScale = (val) => (colorMap.get(val) || unknownColor);
       }
     } else if (colorings[colorBy].type === "categorical") {
       continuous = false;

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -13,69 +13,6 @@ import { sortedDomain } from "./sortedDomain";
 
 export const unknownColor = "#AAAAAA";
 
-const getMinMaxFromTree = (nodes, nodesToo, attr) => {
-  const arr = nodesToo ? nodes.concat(nodesToo) : nodes.slice();
-  const vals = arr.map((n) => getTraitFromNode(n, attr))
-    .filter((n) => n !== undefined)
-    .filter((item, i, ar) => ar.indexOf(item) === i)
-    .map((v) => +v); // coerce throw new Error(to numeric
-  return [min(vals), max(vals)];
-};
-
-/* this creates a (ramped) list of colours
-   this is necessary as ordinal scales can't interpololate colours.
-   range: [a,b], the colours to go between */
-const createListOfColors = (n, range) => {
-  const scale = scaleLinear().domain([0, n])
-    .interpolate(interpolateHcl)
-    .range(range);
-  return d3Range(0, n).map(scale);
-};
-
-const getDiscreteValuesFromTree = (nodes, nodesToo, attr) => {
-  const stateCount = countTraitsAcrossTree(nodes, [attr], false, false)[attr];
-  if (nodesToo) {
-    const stateCountSecondTree = countTraitsAcrossTree(nodesToo, [attr], false, false)[attr];
-    for (const state of stateCountSecondTree.keys()) {
-      const currentCount = stateCount.get(state) || 0;
-      stateCount.set(state, currentCount+1);
-    }
-  }
-  const domain = sortedDomain(Array.from(stateCount.keys()).filter((x) => isValueValid(x)), attr, stateCount);
-  return domain;
-};
-
-const createDiscreteScale = (domain, type) => {
-  // note: colors[n] has n colors
-  let colorList;
-  if (type==="ordinal" || type==="categorical") {
-    /* TODO: use different colours! */
-    colorList = domain.length <= colors.length ?
-      colors[domain.length].slice() :
-      colors[colors.length - 1].slice();
-  }
-  const scale = scaleOrdinal().domain(domain).range(colorList);
-  return (val) => ((val === undefined || domain.indexOf(val) === -1)) ? unknownColor : scale(val);
-};
-
-const booleanColorScale = (val) => {
-  if (!isValueValid(val)) return unknownColor;
-  if (["true", "1", "yes"].includes(String(val).toLowerCase())) return "#4C90C0";
-  return "#CBB742";
-};
-
-const createLegendBounds = (legendValues) => {
-  const valBetween = (x0, x1) => x0 + 0.5*(x1-x0);
-  const len = legendValues.length;
-  const legendBounds = {};
-  legendBounds[legendValues[0]] = [0, valBetween(legendValues[0], legendValues[1])];
-  for (let i = 1; i < len - 1; i++) {
-    legendBounds[legendValues[i]] = [valBetween(legendValues[i-1], legendValues[i]), valBetween(legendValues[i], legendValues[i+1])];
-  }
-  legendBounds[legendValues[len-1]] = [valBetween(legendValues[len-2], legendValues[len-1]), 10000];
-  return legendBounds;
-};
-
 /**
  * calculate the color scale.
  * @param {string} colorBy - provided trait to use as color
@@ -83,7 +20,7 @@ const createLegendBounds = (legendValues) => {
  * @param {object} tree
  * @param {object} treeToo
  * @param {object} metadata
- * @return {{scale: function, continuous: string, colorBy: string, version: int, legendValues: Array, legendBounds: Array, genotype: null|object}}
+ * @return {{scale: function, continuous: string, colorBy: string, version: int, legendValues: Array, legendBounds: Array|undefined, genotype: null|object}}
  */
 export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
   try {
@@ -93,147 +30,33 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     if (!tree.nodes) {
       throw new Error("calcColorScale called before tree is ready.");
     }
+    const colorings = metadata.colorings;
+    const treeTooNodes = treeToo ? treeToo.nodes : undefined;
+    let continuous = false;
+    let colorScale, legendValues, legendBounds;
 
     let genotype;
     if (isColorByGenotype(colorBy) && controls.geneLength) {
       genotype = decodeColorByGenotype(colorBy, controls.geneLength);
       setGenotype(tree.nodes, genotype.gene, genotype.positions, metadata.rootSequence); /* modifies nodes recursively */
     }
-    // const colorOptions = metadata.colorOptions;
-    const colorings = metadata.colorings;
-    const treeTooNodes = treeToo ? treeToo.nodes : undefined;
-    let continuous = false;
-    let colorScale, legendValues, legendBounds;
 
-    if (genotype) { /* G E N O T Y P E */
-      legendValues = orderOfGenotypeAppearance(tree.nodes, controls.mutType);
-      const trueValues = controls.mutType === "nuc" ?
-        legendValues.filter((x) => x !== "X" && x !== "-" && x !== "N" && x !== "") :
-        legendValues.filter((x) => x !== "X" && x !== "-" && x !== "");
-      const domain = [undefined, ...legendValues];
-      const range = [unknownColor, ...genotypeColors.slice(0, trueValues.length)];
-      // Bases are returned by orderOfGenotypeAppearance in order, unknowns at end
-      if (legendValues.indexOf("-") !== -1) {
-        range.push(rgb(217, 217, 217));
-      }
-      if (legendValues.indexOf("N") !== -1 && controls.mutType === "nuc") {
-        range.push(rgb(153, 153, 153));
-      }
-      if (legendValues.indexOf("X") !== -1) {
-        range.push(rgb(102, 102, 102));
-      }
-      colorScale = scaleOrdinal()
-            .domain(domain)
-            .range(range);
+    if (genotype) {
+      ({legendValues, colorScale} = createScaleForGenotype(tree.nodes, controls.mutType));
     } else if (colorings && colorings[colorBy]) {
-      let minMax;
-      /* Is the scale set in the provided colorings object? */
-      if (colorings[colorBy].scale) {
+      if (colorings[colorBy].scale) { /* scale set via JSON */
         ({continuous, legendValues, colorScale} =
           createScaleFromProvidedScaleMap(colorBy, colorings[colorBy].scale, tree.nodes, treeTooNodes));
       } else if (colorings[colorBy].type === "categorical") {
-        continuous = false;
         legendValues = getDiscreteValuesFromTree(tree.nodes, treeTooNodes, colorBy);
         colorScale = createDiscreteScale(legendValues, "categorical");
       } else if (colorings[colorBy].type === "ordinal") {
-        /* currently, ordinal scales are only implemented for those with integer values.
-        TODO: we should be able to have non-numerical ordinal scales (e.g.
-        `["small", "medium", "large"]`) however we currently cannot specify this ordering
-        in the dataset JSON. Ordinal scales may also want to be used for numerical but
-        non-integer values */
-        legendValues = getDiscreteValuesFromTree(tree.nodes, treeTooNodes, colorBy);
-        const allInteger = legendValues.every((x) => Number.isInteger(x));
-
-        if (allInteger) {
-          minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy);
-          if (minMax[1]-minMax[0]<=colors.length) {
-            continuous = false;
-            legendValues = [];
-            for (let i=minMax[0]; i<=minMax[1]; i++) legendValues.push(i);
-            colorScale = createDiscreteScale(legendValues, "ordinal");
-          } else {
-            /* too many integers for the provided colours -- using continuous scale instead */
-            /* TODO - when we refactor this code we can abstract into functions to stop code
-            duplication, as this is identical to that of the continuous scale below */
-            console.warn("Using a continous scale as there are too many values in the ordinal scale");
-            continuous = true;
-            const scale = scaleLinear().domain(genericDomain.map((d) => minMax[0] + d * (minMax[1] - minMax[0]))).range(colors[9]);
-            colorScale = (val) => isValueValid(val) ? scale(val): unknownColor;
-            const spread = minMax[1] - minMax[0];
-            const dp = spread > 5 ? 2 : 3;
-            legendValues = genericDomain.map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)));
-            if (legendValues[0] === -0) legendValues[0] = 0; /* hack to avoid bugs */
-            legendBounds = createLegendBounds(legendValues);
-          }
-        } else {
-          console.warn("Using a categorical scale as currently ordinal scales must only contain integers");
-          continuous = false;
-          colorScale = createDiscreteScale(legendValues, "categorical");
-        }
+        ({continuous, colorScale, legendValues, legendBounds} = createOrdinalScale(colorBy, tree.nodes, treeTooNodes));
       } else if (colorings[colorBy].type === "boolean") {
-        continuous = false;
         legendValues = getDiscreteValuesFromTree(tree.nodes, treeTooNodes, colorBy);
         colorScale = booleanColorScale;
       } else if (colorings[colorBy].type === "continuous") {
-        // console.log("making a continuous color scale for ", colorBy);
-        continuous = true;
-        switch (colorBy) {
-          case "lbi":
-            minMax = [0, 0.7];
-            break;
-          case "num_date":
-            break; /* minMax not needed for num_date */
-          default:
-            minMax = getMinMaxFromTree(tree.nodes, treeTooNodes, colorBy);
-        }
-
-        /* make the continuous scale */
-        let domain, range;
-        switch (colorBy) {
-          case "num_date":
-            /* we want the colorScale to "focus" on the tip dates, and be spaced according to sampling */
-            let rootDate = getTraitFromNode(tree.nodes[0], "num_date");
-            let vals = tree.nodes.filter((n) => !n.hasChildren)
-              .map((n) => getTraitFromNode(n, "num_date"));
-            if (treeTooNodes) {
-              const treeTooRootDate = getTraitFromNode(treeTooNodes[0], "num_date");
-              if (treeTooRootDate < rootDate) rootDate = treeTooRootDate;
-              vals.concat(
-                treeTooNodes.filter((n) => !n.hasChildren)
-                  .map((n) => getTraitFromNode(n, "num_date"))
-              );
-            }
-            vals = vals.sort();
-            domain = [rootDate];
-            const n = 10;
-            const spaceBetween = parseInt(vals.length / (n - 1), 10);
-            for (let i = 0; i < (n-1); i++) domain.push(vals[spaceBetween*i]);
-            domain.push(vals[vals.length-1]);
-            domain = [...new Set(domain)]; /* filter to unique values only */
-            range = colors[domain.length]; /* use the right number of colours */
-            break;
-          default:
-            range = colors[9];
-            domain = genericDomain.map((d) => minMax[0] + d * (minMax[1] - minMax[0]));
-        }
-        const scale = scaleLinear().domain(domain).range(range);
-        colorScale = (val) => isValueValid(val) ? scale(val) : unknownColor;
-
-        /* construct the legend values & their respective bounds */
-        switch (colorBy) {
-          case "lbi":
-            legendValues = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7];
-            break;
-          case "num_date":
-            legendValues = domain.slice(1);
-            break;
-          default:
-            const spread = minMax[1] - minMax[0];
-            const dp = spread > 5 ? 2 : 3;
-            legendValues = genericDomain.map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)));
-        }
-        if (legendValues[0] === -0) legendValues[0] = 0; /* hack to avoid bugs */
-        legendBounds = createLegendBounds(legendValues);
+        ({continuous, colorScale, legendBounds, legendValues} = createContinuousScale(colorBy, tree.nodes, treeTooNodes));
       } else {
         throw new Error(`ColorBy ${colorBy} invalid type -- ${colorings[colorBy].type}`);
       }
@@ -242,8 +65,8 @@ export const calcColorScale = (colorBy, controls, tree, treeToo, metadata) => {
     }
     return {
       scale: colorScale,
-      continuous: continuous,
-      colorBy: colorBy,
+      continuous,
+      colorBy,
       version: controls.colorScale === undefined ? 1 : controls.colorScale.version + 1,
       legendValues,
       legendBounds,
@@ -285,4 +108,198 @@ export function createScaleFromProvidedScaleMap(colorBy, providedScale, t1nodes,
     legendValues: domain,
     colorScale: (val) => (colorMap.get(val) || unknownColor)
   };
+}
+
+function createScaleForGenotype(t1nodes, mutType) {
+  const legendValues = orderOfGenotypeAppearance(t1nodes, mutType);
+  const trueValues = mutType === "nuc" ?
+    legendValues.filter((x) => x !== "X" && x !== "-" && x !== "N" && x !== "") :
+    legendValues.filter((x) => x !== "X" && x !== "-" && x !== "");
+  const domain = [undefined, ...legendValues];
+  const range = [unknownColor, ...genotypeColors.slice(0, trueValues.length)];
+  // Bases are returned by orderOfGenotypeAppearance in order, unknowns at end
+  if (legendValues.indexOf("-") !== -1) {
+    range.push(rgb(217, 217, 217));
+  }
+  if (legendValues.indexOf("N") !== -1 && mutType === "nuc") {
+    range.push(rgb(153, 153, 153));
+  }
+  if (legendValues.indexOf("X") !== -1) {
+    range.push(rgb(102, 102, 102));
+  }
+  return {
+    colorScale: scaleOrdinal().domain(domain).range(range),
+    legendValues
+  };
+}
+
+function createOrdinalScale(colorBy, t1nodes, t2nodes) {
+  /* currently, ordinal scales are only implemented for those with integer values.
+  TODO: we should be able to have non-numerical ordinal scales (e.g.
+  `["small", "medium", "large"]`) however we currently cannot specify this ordering
+  in the dataset JSON. Ordinal scales may also want to be used for numerical but
+  non-integer values */
+  let legendValues = getDiscreteValuesFromTree(t1nodes, t2nodes, colorBy);
+  const allInteger = legendValues.every((x) => Number.isInteger(x));
+  let continuous = false;
+  let colorScale, legendBounds;
+
+  if (allInteger) {
+    const minMax = getMinMaxFromTree(t1nodes, t2nodes, colorBy);
+    if (minMax[1]-minMax[0]<=colors.length) {
+      legendValues = [];
+      for (let i=minMax[0]; i<=minMax[1]; i++) legendValues.push(i);
+      colorScale = createDiscreteScale(legendValues, "ordinal");
+    } else {
+      /* too many integers for the provided colours -- using continuous scale instead */
+      /* TODO - when we refactor this code we can abstract into functions to stop code
+      duplication, as this is identical to that of the continuous scale below */
+      console.warn("Using a continous scale as there are too many values in the ordinal scale");
+      continuous = true;
+      const scale = scaleLinear().domain(genericDomain.map((d) => minMax[0] + d * (minMax[1] - minMax[0]))).range(colors[9]);
+      colorScale = (val) => isValueValid(val) ? scale(val): unknownColor;
+      const spread = minMax[1] - minMax[0];
+      const dp = spread > 5 ? 2 : 3;
+      legendValues = genericDomain.map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)));
+      if (legendValues[0] === -0) legendValues[0] = 0; /* hack to avoid bugs */
+      legendBounds = createLegendBounds(legendValues);
+    }
+  } else {
+    console.warn("Using a categorical scale as currently ordinal scales must only contain integers");
+    continuous = false;
+    colorScale = createDiscreteScale(legendValues, "categorical");
+  }
+  return {continuous, colorScale, legendValues, legendBounds};
+}
+
+function createContinuousScale(colorBy, t1nodes, t2nodes) {
+  // console.log("making a continuous color scale for ", colorBy);
+  let minMax;
+  switch (colorBy) {
+    case "lbi":
+      minMax = [0, 0.7];
+      break;
+    case "num_date":
+      break; /* minMax not needed for num_date */
+    default:
+      minMax = getMinMaxFromTree(t1nodes, t2nodes, colorBy);
+  }
+
+  /* make the continuous scale */
+  let domain, range;
+  switch (colorBy) {
+    case "num_date":
+      /* we want the colorScale to "focus" on the tip dates, and be spaced according to sampling */
+      let rootDate = getTraitFromNode(t1nodes[0], "num_date");
+      let vals = t1nodes.filter((n) => !n.hasChildren)
+        .map((n) => getTraitFromNode(n, "num_date"));
+      if (t2nodes) {
+        const treeTooRootDate = getTraitFromNode(t2nodes[0], "num_date");
+        if (treeTooRootDate < rootDate) rootDate = treeTooRootDate;
+        vals.concat(
+          t2nodes.filter((n) => !n.hasChildren)
+            .map((n) => getTraitFromNode(n, "num_date"))
+        );
+      }
+      vals = vals.sort();
+      domain = [rootDate];
+      const n = 10;
+      const spaceBetween = parseInt(vals.length / (n - 1), 10);
+      for (let i = 0; i < (n-1); i++) domain.push(vals[spaceBetween*i]);
+      domain.push(vals[vals.length-1]);
+      domain = [...new Set(domain)]; /* filter to unique values only */
+      range = colors[domain.length]; /* use the right number of colours */
+      break;
+    default:
+      range = colors[9];
+      domain = genericDomain.map((d) => minMax[0] + d * (minMax[1] - minMax[0]));
+  }
+  const scale = scaleLinear().domain(domain).range(range);
+
+  /* construct the legend values & their respective bounds */
+  let legendValues;
+  switch (colorBy) {
+    case "lbi":
+      legendValues = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7];
+      break;
+    case "num_date":
+      legendValues = domain.slice(1);
+      break;
+    default:
+      const spread = minMax[1] - minMax[0];
+      const dp = spread > 5 ? 2 : 3;
+      legendValues = genericDomain.map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)));
+  }
+  if (legendValues[0] === -0) legendValues[0] = 0; /* hack to avoid bugs */
+
+  return {
+    continuous: true,
+    colorScale: (val) => isValueValid(val) ? scale(val) : unknownColor,
+    legendBounds: createLegendBounds(legendValues),
+    legendValues
+  };
+}
+
+
+function getMinMaxFromTree(nodes, nodesToo, attr) {
+  const arr = nodesToo ? nodes.concat(nodesToo) : nodes.slice();
+  const vals = arr.map((n) => getTraitFromNode(n, attr))
+    .filter((n) => n !== undefined)
+    .filter((item, i, ar) => ar.indexOf(item) === i)
+    .map((v) => +v); // coerce throw new Error(to numeric
+  return [min(vals), max(vals)];
+}
+
+/* this creates a (ramped) list of colours
+   this is necessary as ordinal scales can't interpololate colours.
+   range: [a,b], the colours to go between */
+function createListOfColors(n, range) {
+  const scale = scaleLinear().domain([0, n])
+    .interpolate(interpolateHcl)
+    .range(range);
+  return d3Range(0, n).map(scale);
+}
+
+function getDiscreteValuesFromTree(nodes, nodesToo, attr) {
+  const stateCount = countTraitsAcrossTree(nodes, [attr], false, false)[attr];
+  if (nodesToo) {
+    const stateCountSecondTree = countTraitsAcrossTree(nodesToo, [attr], false, false)[attr];
+    for (const state of stateCountSecondTree.keys()) {
+      const currentCount = stateCount.get(state) || 0;
+      stateCount.set(state, currentCount+1);
+    }
+  }
+  const domain = sortedDomain(Array.from(stateCount.keys()).filter((x) => isValueValid(x)), attr, stateCount);
+  return domain;
+}
+
+function createDiscreteScale(domain, type) {
+  // note: colors[n] has n colors
+  let colorList;
+  if (type==="ordinal" || type==="categorical") {
+    /* TODO: use different colours! */
+    colorList = domain.length <= colors.length ?
+      colors[domain.length].slice() :
+      colors[colors.length - 1].slice();
+  }
+  const scale = scaleOrdinal().domain(domain).range(colorList);
+  return (val) => ((val === undefined || domain.indexOf(val) === -1)) ? unknownColor : scale(val);
+}
+
+function booleanColorScale(val) {
+  if (!isValueValid(val)) return unknownColor;
+  if (["true", "1", "yes"].includes(String(val).toLowerCase())) return "#4C90C0";
+  return "#CBB742";
+}
+
+function createLegendBounds(legendValues) {
+  const valBetween = (x0, x1) => x0 + 0.5*(x1-x0);
+  const len = legendValues.length;
+  const legendBounds = {};
+  legendBounds[legendValues[0]] = [0, valBetween(legendValues[0], legendValues[1])];
+  for (let i = 1; i < len - 1; i++) {
+    legendBounds[legendValues[i]] = [valBetween(legendValues[i-1], legendValues[i]), valBetween(legendValues[i], legendValues[i+1])];
+  }
+  legendBounds[legendValues[len-1]] = [valBetween(legendValues[len-2], legendValues[len-1]), 10000];
+  return legendBounds;
 }

--- a/test/colorScales.test.js
+++ b/test/colorScales.test.js
@@ -1,0 +1,39 @@
+import { unknownColor, createScaleFromProvidedScaleMap } from "../src/util/colorScale";
+
+const crypto = require("crypto");
+
+/* ---------------------------------------------------------------------- */
+
+test("Test that a JSON-provided scale results in nodes using the correct colours", () => {
+  const nodes = makeNodes(50, {country: ['A', 'B', 'D', undefined]});
+  const providedScale = [['A', 'AMBER'], ['B', 'BLUE'], ['C', "CYAN"]];
+  const {colorScale} = createScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);
+  expect(colorScale('A')).toEqual("AMBER");
+  expect(colorScale('B')).toEqual("BLUE");
+  expect(colorScale('C')).toEqual("CYAN"); // Note that 'C' is in the colorMap, even though it is not defined on tree
+  expect(colorScale('D')).not.toEqual(unknownColor); // 'D' is in tree => should be given a grey color, not the unknown color
+  expect(colorScale(undefined)).toEqual(unknownColor); // check `undefined` case returns the unknownColor
+});
+
+
+/** for the purposes of generating colorScales, the linking between nodes isn't used
+ * so we can simply create a list of nodes with values attached.
+ * If you want to skip setting a value on nodes, use `undefined` in the `values` array inside `traits`
+ */
+function makeNodes(n, traits) {
+  const nodes = [];
+  for (let i=0; i<n; i++) {
+    const node = {
+      name: crypto.randomBytes(5).toString('hex'),
+      node_attrs: {}
+    };
+    Object.entries(traits).forEach(([traitName, traitValues]) => {
+      const vIdx = i%traitValues.length;
+      if (traitValues[vIdx]) {
+        node.node_attrs[traitName] = {value: traitValues[vIdx]};
+      }
+    });
+    nodes.push(node);
+  }
+  return nodes;
+}

--- a/test/colorScales.test.js
+++ b/test/colorScales.test.js
@@ -15,6 +15,13 @@ test("Test that a JSON-provided scale results in nodes using the correct colours
   expect(colorScale(undefined)).toEqual(unknownColor); // check `undefined` case returns the unknownColor
 });
 
+test("Test that a misformatted JSON-provided scale throws an error", () => {
+  const nodes = makeNodes(50, {country: ['A', 'B', 'D', undefined]});
+  const providedScale = {A: 'AMBER', B: 'BLUE', C: "CYAN"};
+  expect(() => {createScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);})
+    .toThrow(/has defined a scale which wasn't an array/);
+});
+
 
 /** for the purposes of generating colorScales, the linking between nodes isn't used
  * so we can simply create a list of nodes with values attached.


### PR DESCRIPTION
Colorscales should be able to handle nodes with unknown values for the current `colorScale` (e.g. `getTraitFromNode(node, colorBy=undefined`). This was not being correctly handled in the case where we provided a scale in the dataset JSON. For certain cases (i.e. when traits had not been inferred for internal nodes) this resulted in internal nodes being coloured rather than grey as intended. (Note that which colour was chosen depended on the provided scale values.)

Before (note that the branches on the far left don't have values set for the current colorBy, i.e. `getTraitFromNode(node, colorBy=undefined`)

![image](https://user-images.githubusercontent.com/8350992/100558753-834a9e00-3314-11eb-8ed9-d978848e9051.png)


After:
![image](https://user-images.githubusercontent.com/8350992/100558790-a70de400-3314-11eb-8098-ffb78e56137f.png)

