### PR TITLE
Download data improvements

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -34,13 +34,13 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, mutType, 
         name="Tree (Newick)"
         description="Phylogenetic tree in Newick format with branch lengths in units of divergence."
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.newick(dispatch, filePrefix, tree.nodes[0], false)}
+        onClick={() => helpers.newick(dispatch, filePrefix, tree, false)}
       />
       <Button
         name="TimeTree (Newick)"
         description="Phylogenetic tree in Newick format with branch lengths measured in years."
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.newick(dispatch, filePrefix, tree.nodes[0], true)}
+        onClick={() => helpers.newick(dispatch, filePrefix, tree, true)}
       />
       <Button
         name="Metadata (TSV)"

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -16,43 +16,32 @@ const iconWidth = 25;
  * A React Component displaying buttons which trigger data-downloads. Intended for display within the
  * larger Download modal component
  */
-export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, mutType, panelsToDisplay, panelLayout, filters, visibility, visibleStateCounts, relevantPublications}) => {
+export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, mutType, distanceMeasure, panelsToDisplay, panelLayout, filters, visibility, visibleStateCounts, relevantPublications}) => {
   const totalTipCount = metadata.mainTreeNumTips;
   const selectedTipsCount = getNumSelectedTips(tree.nodes, tree.visibility);
   const partialData = selectedTipsCount !== totalTipCount;
   const filePrefix = getFilePrefix();
+  const temporal = distanceMeasure === "num_date";
 
   return (
     <>
       <div style={{fontWeight: 500, marginTop: "0px", marginBottom: "20px"}}>
-        {partialData ?
-          `The current view is displaying data for ${selectedTipsCount}/${totalTipCount} tips. Downloaded data is representative of this (i.e. it is a subset of the entire dataset).` :
-          `Download data for the entire dataset (${totalTipCount} tips).`
-        }
+        Downloaded data represents the currently displayed view.
+        By zooming the tree, changing the branch-length metric, applying filters etc, the downloaded data will change accordingly.
+        <p/>
+        {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
       <Button
-        name="Tree (Newick)"
-        description="Phylogenetic tree in Newick format with branch lengths in units of divergence."
+        name={`${temporal ? 'TimeTree' : 'Tree'} (Newick)`}
+        description={`Phylogenetic tree in Newick format with branch lengths in units of ${temporal?'years':'divergence'}.`}
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal: false})}
+        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal})}
       />
       <Button
-        name="TimeTree (Newick)"
-        description="Phylogenetic tree in Newick format with branch lengths measured in years."
+        name={`${temporal ? 'TimeTree' : 'Tree'} (Nexus)`}
+        description={`Phylogeny in Nexus format with branch lengths in units of ${temporal?'years':'divergence'}. Colorings are included as annotations.`}
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal: true})}
-      />
-      <Button
-        name="Tree (Nexus)"
-        description="Phylogeny in Nexus format with branch lengths in units of divergence. Colorings are included as annotations."
-        icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal: false})}
-      />
-      <Button
-        name="TimeTree (Nexus)"
-        description="Phylogeny in Neexus format with branch lengths measured in years. Colorings are included as annotations."
-        icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal: true})}
+        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal})}
       />
       <Button
         name="Metadata (TSV)"

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -16,7 +16,7 @@ const iconWidth = 25;
  * A React Component displaying buttons which trigger data-downloads. Intended for display within the
  * larger Download modal component
  */
-export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, mutType, panelsToDisplay, panelLayout, filters, visibility, visibleStateCounts, relevantPublications}) => {
+export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, mutType, panelsToDisplay, panelLayout, filters, visibility, visibleStateCounts, relevantPublications}) => {
   const totalTipCount = metadata.mainTreeNumTips;
   const selectedTipsCount = getNumSelectedTips(tree.nodes, tree.visibility);
   const partialData = selectedTipsCount !== totalTipCount;
@@ -34,13 +34,25 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, mutType, 
         name="Tree (Newick)"
         description="Phylogenetic tree in Newick format with branch lengths in units of divergence."
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.newick(dispatch, filePrefix, tree, false)}
+        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal: false})}
       />
       <Button
         name="TimeTree (Newick)"
         description="Phylogenetic tree in Newick format with branch lengths measured in years."
         icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.newick(dispatch, filePrefix, tree, true)}
+        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal: true})}
+      />
+      <Button
+        name="Tree (Nexus)"
+        description="Phylogeny in Nexus format with branch lengths in units of divergence. Colorings are included as annotations."
+        icon={<RectangularTreeIcon width={iconWidth} selected />}
+        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal: false})}
+      />
+      <Button
+        name="TimeTree (Nexus)"
+        description="Phylogeny in Neexus format with branch lengths measured in years. Colorings are included as annotations."
+        icon={<RectangularTreeIcon width={iconWidth} selected />}
+        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal: true})}
       />
       <Button
         name="Metadata (TSV)"

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -123,7 +123,7 @@ function getNumUniqueAuthors(nodes) {
   return uniqueAuthors.size;
 }
 
-export function getFilePrefix() {
+function getFilePrefix() {
   return "nextstrain_" +
     window.location.pathname
         .replace(/^\//, '')       // Remove leading slashes

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -1,0 +1,132 @@
+import React from "react";
+import { withTheme } from 'styled-components';
+import * as icons from "../framework/svg-icons";
+import { materialButton } from "../../globalStyles";
+import * as helpers from "./helperFunctions";
+import { getNumSelectedTips } from "../info/info";
+import { getFullAuthorInfoFromNode } from "../../util/treeMiscHelpers";
+
+const RectangularTreeIcon = withTheme(icons.RectangularTree);
+const PanelsGridIcon = withTheme(icons.PanelsGrid);
+const MetaIcon = withTheme(icons.Meta);
+
+export const DownloadButtons = ({dispatch, t, tree, nodes, entropy, metadata, mutType, panelsToDisplay, panelLayout, filters, visibility, visibleStateCounts, relevantPublications}) => {
+  // and with the check done to make sure the node is visible in strainTSV(),
+  // so if speed becomes a concern, getNumUniqueAuthorscould alter this to just generate the list of selected nodes once,
+  // on modal creation, and add it as a property on the modal
+  const selectedTipsCount = getNumSelectedTips(nodes, tree.visibility);
+  // likewise, this is somewhat redundant with authorTSV()
+  const uniqueAuthorCount = getNumUniqueAuthors(nodes);
+  const filePrefix = getFilePrefix();
+  const iconWidth = 25;
+  const buttons = [
+    <Button
+      name="Tree (Newick)"
+      description="Phylogenetic tree in Newick format with branch lengths in units of divergence."
+      icon={<RectangularTreeIcon width={iconWidth} selected />}
+      onClick={() => helpers.newick(dispatch, filePrefix, nodes[0], false)}
+    />,
+    <Button
+      name="TimeTree (Newick)"
+      description="Phylogenetic tree in Newick format with branch lengths measured in years."
+      icon={<RectangularTreeIcon width={iconWidth} selected />}
+      onClick={() => helpers.newick(dispatch, filePrefix, nodes[0], true)}
+    />,
+    <Button
+      name="All Metadata (TSV)"
+      description={`Per-sample metadata for all samples in the dataset (n = ${metadata.mainTreeNumTips}).`}
+      icon={<MetaIcon width={iconWidth} selected />}
+      onClick={() => helpers.strainTSV(dispatch, filePrefix, nodes, metadata.colorings, false, null)}
+    />
+  ];
+  if (selectedTipsCount > 0) {
+    buttons.push(
+      <Button
+        name="Selected Metadata (TSV)"
+        description={`Per-sample metadata for strains which are currently displayed (n = ${selectedTipsCount}/${metadata.mainTreeNumTips}).`}
+        icon={<MetaIcon width={iconWidth} selected />}
+        onClick={() => helpers.strainTSV(dispatch, filePrefix, nodes, metadata.colorings, true, tree.visibility)}
+      />
+    );
+  }
+  if (helpers.areAuthorsPresent(tree)) {
+    buttons.push(
+      <Button
+        name="Author Metadata (TSV)"
+        description={`Metadata for all samples in the dataset (n = ${metadata.mainTreeNumTips}) grouped by their ${uniqueAuthorCount} authors.`}
+        icon={<MetaIcon width={iconWidth} selected />}
+        onClick={() => helpers.authorTSV(dispatch, filePrefix, tree)}
+      />
+    );
+  }
+  if (entropy.loaded) {
+    let description = `The data behind the diversity panel`;
+    description += ` showing ${entropy.showCounts ? `a count of changes across the tree` : `normalised shannon entropy`}`;
+    description += mutType === "nuc" ? " per nucleotide." : " per codon.";
+    if (selectedTipsCount !== metadata.mainTreeNumTips) {
+      description += ` Restricted to strains which are currently displayed (n = ${selectedTipsCount}/${metadata.mainTreeNumTips}).`;
+    }
+    buttons.push(
+      <Button
+        name="Genetic diversity data (TSV)"
+        description={description}
+        icon={<MetaIcon width={iconWidth} selected />}
+        onClick={() => helpers.entropyTSV(dispatch, filePrefix, entropy, mutType)}
+      />
+    );
+  }
+  buttons.push(
+    <Button
+      name="Screenshot (SVG)"
+      description="Screenshot of the current nextstrain display in SVG format; CC-BY licensed."
+      icon={<PanelsGridIcon width={iconWidth} selected />}
+      onClick={() => helpers.SVG(
+        dispatch,
+        t,
+        metadata,
+        nodes,
+        filters,
+        visibility,
+        visibleStateCounts,
+        getFilePrefix(),
+        panelsToDisplay,
+        panelLayout,
+        relevantPublications
+      )}
+    />
+  );
+  return buttons;
+};
+
+function Button({name, description, icon, onClick}) {
+  const buttonTextStyle = Object.assign({}, materialButton, {backgroundColor: "rgba(0,0,0,0)", paddingLeft: "10px", color: "white", minWidth: "300px", textAlign: "left" });
+  const buttonLabelStyle = { fontStyle: "italic", fontSize: "14px", color: "lightgray" };
+  return (
+    <div key={name} onClick={onClick} style={{cursor: 'pointer' }}>
+      {icon}
+      <button style={buttonTextStyle} name={name}>
+        {name}
+      </button>
+      <div style={{ display: "inline-block", height: "30px", verticalAlign: "top", paddingTop: "6px" }}>
+        <label style={buttonLabelStyle} htmlFor={name}>
+          {description}
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function getNumUniqueAuthors(nodes) {
+  const authors = nodes.map((n) => getFullAuthorInfoFromNode(n))
+    .filter((a) => a && a.value);
+  const uniqueAuthors = new Set(authors.map((a) => a.value));
+  return uniqueAuthors.size;
+}
+
+export function getFilePrefix() {
+  return "nextstrain_" +
+    window.location.pathname
+        .replace(/^\//, '')       // Remove leading slashes
+        .replace(/:/g, '-')       // Change ha:na to ha-na
+        .replace(/\//g, '_');     // Replace slashes with spaces
+}

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -45,6 +45,7 @@ export const publications = {
   browserDimensions: state.browserDimensions.browserDimensions,
   show: state.controls.showDownload,
   colorBy: state.controls.colorBy,
+  distanceMeasure: state.controls.distanceMeasure,
   metadata: state.metadata,
   entropy: state.entropy,
   mutType: state.controls.mutType,

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -1,21 +1,15 @@
 import React from "react";
 import Mousetrap from "mousetrap";
 import { connect } from "react-redux";
-import { withTheme } from 'styled-components';
 import { withTranslation } from 'react-i18next';
-
 import { DISMISS_DOWNLOAD_MODAL } from "../../actions/types";
-import { materialButton, infoPanelStyles } from "../../globalStyles";
+import { infoPanelStyles } from "../../globalStyles";
 import { stopProp } from "../tree/infoPanels/click";
 import * as helpers from "./helperFunctions";
-import * as icons from "../framework/svg-icons";
 import { getAcknowledgments} from "../framework/footer";
-import { createSummary, getNumSelectedTips } from "../info/info";
-import { getFullAuthorInfoFromNode } from "../../util/treeMiscHelpers";
+import { createSummary } from "../info/info";
+import { DownloadButtons, getFilePrefix } from "./downloadButtons";
 
-const RectangularTreeIcon = withTheme(icons.RectangularTree);
-const PanelsGridIcon = withTheme(icons.PanelsGrid);
-const MetaIcon = withTheme(icons.Meta);
 
 // const dataUsage = [
 //   `The data presented here is intended to rapidly disseminate analysis of important pathogens.
@@ -112,7 +106,19 @@ class DownloadModal extends React.Component {
   }
   componentDidMount() {
     Mousetrap.bind('d', () => {
-      helpers.SVG(this.props.dispatch, this.getFilePrefix(), this.props.panelsToDisplay, this.props.panelLayout, this.makeTextStringsForSVGExport());
+      helpers.SVG(
+        this.props.dispatch,
+        this.props.t,
+        this.props.metadata,
+        this.props.nodes,
+        this.props.filters,
+        this.props.visibility,
+        this.props.visibleStateCounts,
+        getFilePrefix(),
+        this.props.panelsToDisplay,
+        this.props.panelLayout,
+        this.getRelevantPublications()
+      );
     });
   }
   getRelevantPublications() {
@@ -137,113 +143,8 @@ class DownloadModal extends React.Component {
       </span>
     );
   }
-  getFilePrefix() {
-    return "nextstrain_" +
-      window.location.pathname
-          .replace(/^\//, '')       // Remove leading slashes
-          .replace(/:/g, '-')       // Change ha:na to ha-na
-          .replace(/\//g, '_');     // Replace slashes with spaces
-  }
-  makeTextStringsForSVGExport() {
-    const x = [];
-    x.push(this.props.metadata.title);
-    x.push(`Last updated ${this.props.metadata.updated}`);
-    const address = window.location.href.replace(/&/g, '&amp;');
-    x.push(`Downloaded from <a href="${address}">${address}</a> on ${new Date().toLocaleString()}`);
-    x.push(this.createSummaryWrapper());
-    x.push("");
-    x.push(`${this.props.t("Data usage part 1")} A full list of sequence authors is available via <a href="https://nextstrain.org">nextstrain.org</a>.`);
-    x.push(`Visualizations are licensed under CC-BY.`);
-    x.push(`Relevant publications:`);
-    this.getRelevantPublications().forEach((pub) => {
-      x.push(`<a href="${pub.href}">${pub.author}, ${pub.title}, ${pub.journal} (${pub.year})</a>`);
-    });
-    return x;
-  }
-  getNumUniqueAuthors(nodes) {
-    const authors = nodes.map((n) => getFullAuthorInfoFromNode(n))
-      .filter((a) => a && a.value);
-    const uniqueAuthors = new Set(authors.map((a) => a.value));
-    return uniqueAuthors.size;
-  }
-  downloadButtons() {
-    // getNumSelectedTips() is redundant work with createSummaryWrapper() below,
-    // and with the check done to make sure the node is visible in strainTSV(),
-    // so if speed becomes a concern, could alter this to just generate the list of selected nodes once,
-    // on modal creation, and add it as a property on the modal
-    const selectedTipsCount = getNumSelectedTips(this.props.nodes, this.props.tree.visibility);
-    // likewise, this is somewhat redundant with authorTSV()
-    const uniqueAuthorCount = this.getNumUniqueAuthors(this.props.nodes);
-    const filePrefix = this.getFilePrefix();
-    const iconWidth = 25;
-    const buttons = [
-      ["Tree", "Phylogenetic tree in Newick format with branch lengths in units of divergence.",
-        (<RectangularTreeIcon width={iconWidth} selected />), () => helpers.newick(this.props.dispatch, filePrefix, this.props.nodes[0], false)],
-      ["TimeTree", "Phylogenetic tree in Newick format with branch lengths measured in years.",
-        (<RectangularTreeIcon width={iconWidth} selected />), () => helpers.newick(this.props.dispatch, filePrefix, this.props.nodes[0], true)],
-      ["All Metadata (TSV)", `Per-sample metadata for all samples in the dataset (n = ${this.props.metadata.mainTreeNumTips}).`,
-        (<MetaIcon width={iconWidth} selected />), () => helpers.strainTSV(this.props.dispatch, filePrefix, this.props.nodes, this.props.metadata.colorings, false, null)]
-    ];
-    if (selectedTipsCount > 0) {
-      buttons.push(["Selected Metadata (TSV)", `Per-sample metadata for strains which are currently displayed (n = ${selectedTipsCount}/${this.props.metadata.mainTreeNumTips}).`,
-        (<MetaIcon width={iconWidth} selected />), () => helpers.strainTSV(this.props.dispatch, filePrefix, this.props.nodes,
-          this.props.metadata.colorings, true, this.props.tree.visibility)]);
-    }
-    if (helpers.areAuthorsPresent(this.props.tree)) {
-      buttons.push(["Author Metadata (TSV)", `Metadata for all samples in the dataset (n = ${this.props.metadata.mainTreeNumTips}) grouped by their ${uniqueAuthorCount} authors.`,
-        (<MetaIcon width={iconWidth} selected />), () => helpers.authorTSV(this.props.dispatch, filePrefix, this.props.tree)]);
-    }
-    if (this.props.entropy.loaded) {
-      let msg = `The data behind the diversity panel`;
-      msg += ` showing ${this.props.entropy.showCounts ? `a count of changes across the tree` : `normalised shannon entropy`}`;
-      msg += this.props.mutType === "nuc" ? " per nucleotide." : " per codon.";
-      if (selectedTipsCount !== this.props.metadata.mainTreeNumTips) {
-        msg += ` Restricted to strains which are currently displayed (n = ${selectedTipsCount}/${this.props.metadata.mainTreeNumTips}).`;
-      }
-      buttons.push([
-        "Genetic diversity data (TSV)",
-        msg,
-        (<MetaIcon width={iconWidth} selected />),
-        () => helpers.entropyTSV(this.props.dispatch, filePrefix, this.props.entropy, this.props.mutType)
-      ]);
-    }
-    buttons.push(
-      ["Screenshot (SVG)", "Screenshot of the current nextstrain display in SVG format; CC-BY licensed.",
-        (<PanelsGridIcon width={iconWidth} selected />), () => helpers.SVG(this.props.dispatch, filePrefix, this.props.panelsToDisplay, this.props.panelLayout, this.makeTextStringsForSVGExport())]
-    );
-    const buttonTextStyle = Object.assign({}, materialButton, {backgroundColor: "rgba(0,0,0,0)", paddingLeft: "10px", color: "white", minWidth: "300px", textAlign: "left" });
-    const buttonLabelStyle = { fontStyle: "italic", fontSize: "14px", color: "lightgray" };
-    return (
-      <div style={{display: "block", justifyContent: "space-around", marginLeft: "25px", width: "100%" }}>
-        <div style={{ width: "100%" }}>
-          {buttons.map((data) => (
-            <div key={data[0]} onClick={data[3]} style={{cursor: 'pointer' }}>
-              {data[2]}
-              <button style={buttonTextStyle} name={data[0]}>
-                {data[0]}
-              </button>
-              <div style={{ display: "inline-block", height: "30px", verticalAlign: "top", paddingTop: "6px" }}>
-                <label style={buttonLabelStyle} htmlFor={data[0]}>{data[1]}</label>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
   dismissModal() {
     this.props.dispatch({ type: DISMISS_DOWNLOAD_MODAL });
-  }
-  createSummaryWrapper() {
-    return createSummary(
-      this.props.metadata.mainTreeNumTips,
-      this.props.nodes,
-      this.props.filters,
-      this.props.visibility,
-      this.props.visibleStateCounts,
-      undefined, // this.props.branchLengthsToDisplay,
-      this.props.t
-    );
   }
   render() {
     const { t } = this.props;
@@ -258,6 +159,8 @@ class DownloadModal extends React.Component {
     panelStyle.fontSize = 14;
     panelStyle.lineHeight = 1.4;
 
+    const relevantPublications = this.getRelevantPublications();
+
     const meta = this.props.metadata;
     return (
       <div style={infoPanelStyles.modalContainer} onClick={this.dismissModal}>
@@ -271,7 +174,15 @@ class DownloadModal extends React.Component {
           </div>
 
           <div>
-            {this.createSummaryWrapper()}
+            {createSummary(
+              this.props.metadata.mainTreeNumTips,
+              this.props.nodes,
+              this.props.filters,
+              this.props.visibility,
+              this.props.visibleStateCounts,
+              undefined, // this.props.branchLengthsToDisplay,
+              this.props.t
+            )}
           </div>
           <div style={infoPanelStyles.break}/>
           {" " + t("A full list of sequence authors is available via the TSV files below")}
@@ -286,14 +197,17 @@ class DownloadModal extends React.Component {
           <div style={infoPanelStyles.modalSubheading}>
             {t("Please cite the authors who contributed genomic data (where relevant), as well as")+":"}
           </div>
-          {this.formatPublications(this.getRelevantPublications())}
+          {this.formatPublications(relevantPublications)}
 
 
           <div style={infoPanelStyles.modalSubheading}>
             {t("Download data")}:
           </div>
-          {this.downloadButtons()}
-
+          <div style={{display: "block", justifyContent: "space-around", marginLeft: "25px", width: "100%" }}>
+            <div style={{ width: "100%" }}>
+              <DownloadButtons {...this.props} relevantPublications={relevantPublications}/>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -303,3 +217,4 @@ class DownloadModal extends React.Component {
 
 const WithTranslation = withTranslation()(DownloadModal);
 export default WithTranslation;
+

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -2,13 +2,12 @@ import React from "react";
 import Mousetrap from "mousetrap";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
-import { DISMISS_DOWNLOAD_MODAL } from "../../actions/types";
+import { TRIGGER_DOWNLOAD_MODAL, DISMISS_DOWNLOAD_MODAL } from "../../actions/types";
 import { infoPanelStyles } from "../../globalStyles";
 import { stopProp } from "../tree/infoPanels/click";
-import * as helpers from "./helperFunctions";
 import { getAcknowledgments} from "../framework/footer";
 import { createSummary } from "../info/info";
-import { DownloadButtons, getFilePrefix } from "./downloadButtons";
+import { DownloadButtons } from "./downloadButtons";
 
 
 // const dataUsage = [
@@ -106,19 +105,7 @@ class DownloadModal extends React.Component {
   }
   componentDidMount() {
     Mousetrap.bind('d', () => {
-      helpers.SVG(
-        this.props.dispatch,
-        this.props.t,
-        this.props.metadata,
-        this.props.nodes,
-        this.props.filters,
-        this.props.visibility,
-        this.props.visibleStateCounts,
-        getFilePrefix(),
-        this.props.panelsToDisplay,
-        this.props.panelLayout,
-        this.getRelevantPublications()
-      );
+      this.props.dispatch({type: this.props.show ? DISMISS_DOWNLOAD_MODAL : TRIGGER_DOWNLOAD_MODAL});
     });
   }
   getRelevantPublications() {

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -4,6 +4,7 @@ import { spaceBetweenTrees } from "../tree/tree";
 import { getTraitFromNode, getDivFromNode, getFullAuthorInfoFromNode, getVaccineFromNode, getAccessionFromNode } from "../../util/treeMiscHelpers";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { NODE_VISIBLE } from "../../util/globals";
+import { createSummary } from "../info/info";
 
 export const isPaperURLValid = (d) => {
   return (
@@ -408,7 +409,30 @@ const writeSVGPossiblyIncludingMap = (dispatch, filePrefix, panelsInDOM, panelLa
   }
 };
 
-export const SVG = (dispatch, filePrefix, panelsInDOM, panelLayout, textStrings) => {
+export const SVG = (dispatch, t, metadata, nodes, filters, visibility, visibleStateCounts, filePrefix, panelsInDOM, panelLayout, publications) => {
+  /* make the text strings */
+  const textStrings = [];
+  textStrings.push(metadata.title);
+  textStrings.push(`Last updated ${metadata.updated}`);
+  const address = window.location.href.replace(/&/g, '&amp;');
+  textStrings.push(`Downloaded from <a href="${address}">${address}</a> on ${new Date().toLocaleString()}`);
+  textStrings.push(createSummary(
+    metadata.mainTreeNumTips,
+    nodes,
+    filters,
+    visibility,
+    visibleStateCounts,
+    undefined, // param is `branchLengthsToDisplay`,
+    t
+  ));
+  textStrings.push("");
+  textStrings.push(`${t("Data usage part 1")} A full list of sequence authors is available via <a href="https://nextstrain.org">nextstrain.org</a>.`);
+  textStrings.push(`Visualizations are licensed under CC-BY.`);
+  textStrings.push(`Relevant publications:`);
+  publications.forEach((pub) => {
+    textStrings.push(`<a href="${pub.href}">${pub.author}, ${pub.title}, ${pub.journal} (${pub.year})</a>`);
+  });
+
   /* downloading the map tiles is an async call */
   if (panelsInDOM.indexOf("map") !== -1) {
     window.L.getMapSvg(writeSVGPossiblyIncludingMap.bind(this, dispatch, filePrefix, panelsInDOM, panelLayout, textStrings));
@@ -432,3 +456,4 @@ export const entropyTSV = (dispatch, filePrefix, entropy, mutType) => {
   write(filename, MIME.tsv, lines.join("\n"));
   dispatch(infoNotification({message: `Diversity data exported to ${filename}`}));
 };
+


### PR DESCRIPTION
This PR makes a number of improvements to the download-data functionality in auspice. See individual commit messages for specifics. Testing on diverse datasets would be highly valuable at this point.

This PR introduces consistency by making downloaded data represent the selected data (before it was different depending on what was being downloaded). This means that if you have manipulated the data (e.g. zoomed the tree, filtered the dataset) then every downloaded file -- trees, metadata, entropy -- will reflect this. 

We also allow the abliity to download BEAST-style Nexus trees which can be read by FigTree. These are annotated with all of the colorings in the dataset (as well as genotype and div, as applicable). I failed to find a proper schema for the annotations block, which means there's likely some scenarios where exported trees can't be read by FigTree. I also imagine there's more annotations which can be exported, such as defining colours for annotation values. Please let me know of any you come across! This functionality allows nextstrain data to be used in FigTree -- for instance, here's a global nCoV tree filtered to England samples and zoomed to clade 20B in Auspice, exported, imported into FigTree, and annotated there by mapping tip colours to pangolin lineage, tip labels to num_date, node labels to num_date_CI, tip & node shapes to divergence. 


![image](https://user-images.githubusercontent.com/8350992/102555704-27fa1780-412c-11eb-9623-0cb6d96471cf.png)



