### PR TITLE
Update filters to hide ancestral nodes before last common ancestor

### DIFF
--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -96,7 +96,7 @@ const makeParentVisible = (visArray, node) => {
 /* Recursively hide nodes that do not have more than one child node in
  * the param visArray.
  * Relies on visArray having been updated by `makeParentVisible` */
-const hideNodeIfOnlyOneChildVisible = (visArray, node) => {
+const hideNodesAboveVisibleCommonAncestor = (visArray, node) => {
   if (!node.hasChildren) {
     return; // Terminal node without children
   }
@@ -105,7 +105,7 @@ const hideNodeIfOnlyOneChildVisible = (visArray, node) => {
     return; // This is the common ancestor of visible children
   }
   visArray[node.arrayIdx] = false;
-  visibleChildren.forEach((child) => hideNodeIfOnlyOneChildVisible(visArray, child));
+  visibleChildren.forEach((child) => hideNodesAboveVisibleCommonAncestor(visArray, child));
 };
 
 /* calcVisibility
@@ -171,7 +171,7 @@ export const calcVisibility = (tree, controls, dates) => {
       }
       /* Recursivley hide ancestor nodes that are not the last common
        * ancestor of selected nodes, starting from the root of the tree */
-      hideNodeIfOnlyOneChildVisible(filtered, tree.nodes[0]);
+      hideNodesAboveVisibleCommonAncestor(filtered, tree.nodes[0]);
     }
     /* intersect the various arrays contributing to visibility */
     const visibility = tree.nodes.map((node, idx) => {


### PR DESCRIPTION
This PR closes #1240.

Before this commit, filters determined visibility by:
1. Finding all terminal nodes in view window that match the filters and
mark them as visible.
2. Recursively marking all parent nodes of these terminal nodes visible,
all the way up to the root of the tree.

This commit adds an additional step to hide ancestral nodes before
the last common ancestor of visible terminal nodes. Starting from
the root of the tree, recursively hide each node if it does not have
more than one child node that is visible.