### PR TITLE
Zoom to selected

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -74,6 +74,7 @@ export const updateVisibleTipsAndBranchThicknesses = (
       branchThickness: data.branchThickness,
       branchThicknessVersion: data.branchThicknessVersion,
       idxOfInViewRootNode: rootIdxTree1,
+      idxOfFilteredRoot: data.idxOfFilteredRoot,
       cladeName: cladeSelected,
       selectedClade: cladeSelected,
       stateCountAttrs: Object.keys(controls.filters)
@@ -93,6 +94,7 @@ export const updateVisibleTipsAndBranchThicknesses = (
       dispatchObj.branchThicknessToo = dataToo.branchThickness;
       dispatchObj.branchThicknessVersionToo = dataToo.branchThicknessVersion;
       dispatchObj.idxOfInViewRootNodeToo = rootIdxTree2;
+      dispatchObj.idxOfFilteredRootToo = dataToo.idxOfFilteredRoot;
       /* tip selected is the same as the first tree - the reducer uses that */
     }
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -97,14 +97,32 @@ class Tree extends React.Component {
   getStyles = () => {
     const activeResetTreeButton = this.props.tree.idxOfInViewRootNode !== 0 ||
       this.props.treeToo.idxOfInViewRootNode !== 0;
+
+    const filteredTree = !!this.props.tree.idxOfFilteredRoot &&
+      this.props.tree.idxOfInViewRootNode !== this.props.tree.idxOfFilteredRoot;
+    const filteredTreeToo = !!this.props.treeToo.idxOfFilteredRoot &&
+      this.props.treeToo.idxOfInViewRootNode !== this.props.treeToo.idxOfFilteredRoot;
+    const activeZoomButton = filteredTree || filteredTreeToo;
+
     return {
-      resetTreeButton: {
+      treeButtonsDiv: {
         zIndex: 100,
         position: "absolute",
         right: 5,
-        top: 0,
+        top: 0
+      },
+      resetTreeButton: {
+        zIndex: 100,
+        display: "inline-block",
         cursor: activeResetTreeButton ? "pointer" : "auto",
         color: activeResetTreeButton ? darkGrey : lightGrey
+      },
+      zoomToSelectedButton: {
+        zIndex: 100,
+        dispaly: "inline-block",
+        cursor: activeZoomButton ? "pointer" : "auto",
+        color: activeZoomButton ? darkGrey : lightGrey,
+        pointerEvents: activeZoomButton ? "auto" : "none"
       }
     };
   };
@@ -120,6 +138,12 @@ class Tree extends React.Component {
       />
     );
   }
+
+  zoomToSelected = () => {
+    this.props.dispatch(updateVisibleTipsAndBranchThicknesses({
+      root: [this.props.tree.idxOfFilteredRoot, this.props.treeToo.idxOfFilteredRoot]
+    }));
+  };
 
   render() {
     const { t } = this.props;
@@ -169,12 +193,20 @@ class Tree extends React.Component {
           null
         }
         {this.props.narrativeMode ? null : (
-          <button
-            style={{...tabSingle, ...styles.resetTreeButton}}
-            onClick={this.redrawTree}
-          >
-            {t("Reset Layout")}
-          </button>
+          <div style={{...styles.treeButtonsDiv}}>
+            <button
+              style={{...tabSingle, ...styles.zoomToSelectedButton}}
+              onClick={this.zoomToSelected}
+            >
+              {t("Zoom to Selected")}
+            </button>
+            <button
+              style={{...tabSingle, ...styles.resetTreeButton}}
+              onClick={this.redrawTree}
+            >
+              {t("Reset Layout")}
+            </button>
+          </div>
         )}
       </Card>
     );

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -114,6 +114,7 @@ class Tree extends React.Component {
       resetTreeButton: {
         zIndex: 100,
         display: "inline-block",
+        marginLeft: 4,
         cursor: activeResetTreeButton ? "pointer" : "auto",
         color: activeResetTreeButton ? darkGrey : lightGrey
       },

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -46,6 +46,7 @@ const Tree = (state = getDefaultTreeState(), action) => {
         branchThickness: action.branchThickness,
         branchThicknessVersion: action.branchThicknessVersion,
         idxOfInViewRootNode: action.idxOfInViewRootNode,
+        idxOfFilteredRoot: action.idxOfFilteredRoot,
         cladeName: action.cladeName,
         selectedClade: action.cladeName,
         visibleStateCounts: countTraitsAcrossTree(state.nodes, action.stateCountAttrs, action.visibility, true),

--- a/src/reducers/treeToo.js
+++ b/src/reducers/treeToo.js
@@ -32,6 +32,7 @@ const treeToo = (state = getDefaultTreeState(), action) => {
           branchThickness: action.branchThicknessToo,
           branchThicknessVersion: action.branchThicknessVersionToo,
           idxOfInViewRootNode: action.idxOfInViewRootNodeToo,
+          idxOfFilteredRoot: action.idxOfFilteredRootToo,
           selectedStrain: action.selectedStrain
         });
       }

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -93,19 +93,25 @@ const makeParentVisible = (visArray, node) => {
   makeParentVisible(visArray, node.parent);
 };
 
-/* Recursively hide nodes that do not have more than one child node in
- * the param visArray.
- * Relies on visArray having been updated by `makeParentVisible` */
+/* Recursively hide nodes that do not have more than one child node by updating
+ * the boolean values in the param visArray.
+ * Relies on visArray having been updated by `makeParentVisible`
+ * Returns the index of the visible commonn ancestor. */
 const hideNodesAboveVisibleCommonAncestor = (visArray, node) => {
   if (!node.hasChildren) {
-    return; // Terminal node without children
+    return node.arrayIdx; // Terminal node without children
   }
   const visibleChildren = node.children.filter((child) => visArray[child.arrayIdx]);
   if (visibleChildren.length > 1) {
-    return; // This is the common ancestor of visible children
+    return node.arrayIdx; // This is the common ancestor of visible children
   }
   visArray[node.arrayIdx] = false;
-  visibleChildren.forEach((child) => hideNodesAboveVisibleCommonAncestor(visArray, child));
+  for (let i = 0; i < visibleChildren.length; i++) {
+    const commonAncestorIdx = hideNodesAboveVisibleCommonAncestor(visArray, visibleChildren[i]);
+    if (commonAncestorIdx) return commonAncestorIdx;
+  }
+  // If there is no visible common ancestor, then return null
+  return null;
 };
 
 /* calcVisibility

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -96,7 +96,7 @@ const makeParentVisible = (visArray, node) => {
 /* Recursively hide nodes that do not have more than one child node in
  * the param visArray.
  * Relies on visArray having been updated by `makeParentVisible` */
-const hideNodeIfOnlyOneChildVisible = (visArray, node) => {
+const hideNodesAboveVisibleCommonAncestor = (visArray, node) => {
   if (!node.hasChildren) {
     return; // Terminal node without children
   }
@@ -105,7 +105,7 @@ const hideNodeIfOnlyOneChildVisible = (visArray, node) => {
     return; // This is the common ancestor of visible children
   }
   visArray[node.arrayIdx] = false;
-  visibleChildren.forEach((child) => hideNodeIfOnlyOneChildVisible(visArray, child));
+  visibleChildren.forEach((child) => hideNodesAboveVisibleCommonAncestor(visArray, child));
 };
 
 /* calcVisibility
@@ -171,7 +171,7 @@ export const calcVisibility = (tree, controls, dates) => {
       }
       /* Recursivley hide ancestor nodes that are not the last common
        * ancestor of selected nodes, starting from the root of the tree */
-      hideNodeIfOnlyOneChildVisible(filtered, tree.nodes[0]);
+      hideNodesAboveVisibleCommonAncestor(filtered, tree.nodes[0]);
     }
     /* intersect the various arrays contributing to visibility */
     const visibility = tree.nodes.map((node, idx) => {


### PR DESCRIPTION
Built on top of changes in #1248. Partly addresses #1132.

Adds a "Zoom to Selected" button that allows users to zoom into the selected tips, with TMRCA as the new root node. 
This is currently just a basic zoom, without the accordion style zoom described in #1132. Creating this PR because even the basic zoom adds a lot of usability while the accordion zoom is taking me longer to figure out. 