### PR TITLE
disable (broken) smoke test for /ncov/global

### DIFF
--- a/test/smoke-test/urls.txt
+++ b/test/smoke-test/urls.txt
@@ -1,7 +1,9 @@
 # First token represents the path to access, remaining tokens are a
 # comma separated list of text assertions (text we expect to find in the
 # rendered page):
-/ncov/global, novel coronavirus, Phylogeny, Diversity, Filter by Location
+
+# Following smoke test passed locally, but failed stochastically on GitHub Actions
+#/ncov/global, novel coronavirus, Phylogeny, Diversity, Filter by Location
 
 /zika, Zika virus evolution, rectangular
 /zika?c=region&l=clock&legend=open&m=div&r=region, Zika virus evolution, rectangular


### PR DESCRIPTION
Smoke testing works as intended when running locally, however it
is currently broken on GitHub Actions which causes confusion.
https://github.com/nextstrain/auspice/issues/1215 has been created
to fix this.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
