### PR TITLE
Update webpack chunk-hash-generation settings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,6 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
   ] : [
     new LodashModuleReplacementPlugin(),
     pluginProcessEnvData,
-    new webpack.HashedModuleIdsPlugin({}),
     new WebpackChunkHash({algorithm: 'md5'}),
     pluginCompress,
     pluginHtml,


### PR DESCRIPTION
This removes `HashedModuleIdsPlugin` from the build pipeline as
we use `WebpackChunkHash` to generate contenthash for each chunk.

This caused hard-to-debug bugs in auspice (and nextstrain.org)
where a hash was being generated from the pre-minified (etc)
bundle contents, but different minification resulted in different
bundle contents. As the bundle name was the same, clients could
use their (out-of-date) cached version, which would result in
a variety of errors in auspice.
