### PR TITLE
Filtering by genotype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice",
-  "version": "2.22.0",
+  "version": "2.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3987,6 +3987,27 @@
         "babel-plugin-jest-hoist": "^25.2.6"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4836,6 +4857,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5351,6 +5377,11 @@
           "dev": true
         }
       }
+    },
+    "csstype": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
     },
     "cwd": {
       "version": "0.10.0",
@@ -15530,6 +15561,41 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-tweet-embed/-/react-tweet-embed-1.2.2.tgz",
       "integrity": "sha512-Y932BlSaJsDUsKDucC2opzzd+uhc0YNhrlTa/4Beb2be1od+AjLGo6Fhuo2wPT0D+fF4VTXOyoZyA8Yc88RdYA=="
+    },
+    "react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        }
+      }
+    },
+    "react-virtualized-select": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
+      "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "prop-types": "^15.5.8",
+        "react-select": "^1.0.0-rc.2",
+        "react-virtualized": "^9.0.0"
+      }
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-select": "^1.0.0-rc.5",
     "react-tooltip": "^4.2.10",
     "react-tweet-embed": "^1.1.0",
+    "react-virtualized-select": "^3.1.3",
     "redux": "^4.0.1",
     "redux-devtools": "^3.5.0",
     "redux-thunk": "^2.3.0",

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -14,7 +14,7 @@ import { determineColorByGenotypeMutType, calcNodeColor } from "../util/colorHel
 import { calcColorScale, createVisibleLegendValues } from "../util/colorScale";
 import { computeMatrixFromRawData } from "../util/processFrequencies";
 import { applyInViewNodesToTree } from "../actions/tree";
-import { isColorByGenotype, decodeColorByGenotype } from "../util/getGenotype";
+import { isColorByGenotype, decodeColorByGenotype, decodeGenotypeFilters } from "../util/getGenotype";
 import { getTraitFromNode, getDivFromNode } from "../util/treeMiscHelpers";
 import { collectAvailableTipLabelOptions } from "../components/controls/choose-tip-label";
 
@@ -99,7 +99,7 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.gt) {
     // todo - error checking etc
     // todo - out-of-order bug whereby root-sequence data won't have yet arrived
-    state.filters[genotypeSymbol] = query.gt.split(',').map((value) => ({value, active: true}));
+    state.filters[genotypeSymbol] = decodeGenotypeFilters(query.gt);
   }
   if (query.animate) {
     const params = query.animate.split(',');

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -15,9 +15,8 @@ import { calcColorScale, createVisibleLegendValues } from "../util/colorScale";
 import { computeMatrixFromRawData } from "../util/processFrequencies";
 import { applyInViewNodesToTree } from "../actions/tree";
 import { isColorByGenotype, decodeColorByGenotype, decodeGenotypeFilters, encodeGenotypeFilters } from "../util/getGenotype";
-import { getTraitFromNode, getDivFromNode } from "../util/treeMiscHelpers";
+import { getTraitFromNode, getDivFromNode, collectGenotypeStates } from "../util/treeMiscHelpers";
 import { collectAvailableTipLabelOptions } from "../components/controls/choose-tip-label";
-import { collectMutationsOnBranch } from "../components/controls/filter";
 
 export const doesColorByHaveConfidence = (controlsState, colorBy) =>
   controlsState.coloringsPresentOnTreeWithConfidence.has(colorBy);
@@ -531,14 +530,7 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree, viewingNarra
     if (!query.s) delete query.s;
   }
   if (state.filters[genotypeSymbol]) {
-    const observedMutations = new Set();
-    tree.nodes.forEach((n) => {
-      collectMutationsOnBranch(n).forEach((m) => observedMutations.add(m));
-    });
-    /* We now remove any genotype filters that we don't observe in the tree.
-    This isn't ideal because we can't filter by basal mutations. A better solution
-    would be to inactivate them (`active` prop -> `false`) and if a root-sequence
-    JSON arrives then reactivate them as appropriate.       james / jan 2021 */
+    const observedMutations = collectGenotypeStates(tree.nodes);
     state.filters[genotypeSymbol] = state.filters[genotypeSymbol]
       .filter((f) => observedMutations.has(f.value));
     query.gt = encodeGenotypeFilters(state.filters[genotypeSymbol]);

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -1,7 +1,7 @@
 import queryString from "query-string";
 import { cloneDeep } from 'lodash';
 import { numericToCalendar, calendarToNumeric } from "../util/dateHelpers";
-import { reallySmallNumber, twoColumnBreakpoint, defaultColorBy, defaultGeoResolution, defaultDateRange, nucleotide_gene, strainSymbol } from "../util/globals";
+import { reallySmallNumber, twoColumnBreakpoint, defaultColorBy, defaultGeoResolution, defaultDateRange, nucleotide_gene, strainSymbol, genotypeSymbol } from "../util/globals";
 import { calcBrowserDimensionsInitialState } from "../reducers/browserDimensions";
 import { getIdxMatchingLabel, calculateVisiblityAndBranchThickness } from "../util/treeVisibilityHelpers";
 import { constructVisibleTipLookupBetweenTrees } from "../util/treeTangleHelpers";
@@ -95,6 +95,11 @@ const modifyStateViaURLQuery = (state, query) => {
   }
   if (query.s) {   // selected strains are a filter too
     state.filters[strainSymbol] = query.s.split(',').map((value) => ({value, active: true}));
+  }
+  if (query.gt) {
+    // todo - error checking etc
+    // todo - out-of-order bug whereby root-sequence data won't have yet arrived
+    state.filters[genotypeSymbol] = query.gt.split(',').map((value) => ({value, active: true}));
   }
   if (query.animate) {
     const params = query.animate.split(',');
@@ -210,6 +215,7 @@ const modifyStateViaMetadata = (state, metadata) => {
     console.warn("JSON did not include any filters");
   }
   state.filters[strainSymbol] = [];
+  state.filters[genotypeSymbol] = []; // TODO - need to double check mutations are defined? Or set this when root-sequence arrives?
   if (metadata.displayDefaults) {
     const keysToCheckFor = ["geoResolution", "colorBy", "distanceMeasure", "layout", "mapTriplicate", "selectedBranchLabel", 'sidebar', "showTransmissionLines", "normalizeFrequencies"];
     const expectedTypes =  ["string",        "string",  "string",          "string", "boolean",       "string",              'string',  "boolean"              , "boolean"]; // eslint-disable-line

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -43,7 +43,6 @@ class FilterData extends React.Component {
      * by looping across each filter and calculating all valid options for each. This function runs
      * each time a filter is toggled on / off.
      */
-    console.log("EXPENSIVE makeOptions()")
     const options = [];
     Object.keys(this.props.activeFilters)
       .forEach((filterName) => {

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import Async from "react-select/lib/Async";
 import { debounce } from 'lodash';
-import { controlsWidth, isValueValid, strainSymbol} from "../../util/globals";
+import { controlsWidth, isValueValid, strainSymbol, genotypeSymbol} from "../../util/globals";
 import { applyFilter } from "../../actions/tree";
 import { FilterBadge } from "../info/filterBadge";
 import { SidebarSubtitle } from "./styles";
@@ -67,6 +67,9 @@ class FilterData extends React.Component {
           });
         });
     }
+    if (genotypeSymbol in this.props.activeFilters) {
+      options.push(...collectObservedMutations(this.props.nodes));
+    }
     return options;
   }
   selectionMade = (sel) => {
@@ -79,7 +82,7 @@ class FilterData extends React.Component {
       const n = this.props.activeFilters[filterName].filter((f) => f.active).length;
       return {
         filterName,
-        displayName: `${n} x ${filterName===strainSymbol ? "samples" : filterName}`,
+        displayName: filterBadgeDisplayName(n, filterName),
         remove: () => {this.props.dispatch(applyFilter("set", filterName, []));}
       };
     });
@@ -142,3 +145,36 @@ export const FilterInfo = (
 );
 
 export default FilterData;
+
+function collectObservedMutations(nodes) {
+  /* todo - this needs to be timed as it could be slow */
+  /* todo - this needs to rerun once (if) root-sequence data arrives */
+  /* todo - this will necessitate more efficient rendering of the select dropdown as there will often be thousands (maybe 100k+) of entries here */
+  /* todo - another option here is to skip this step (and therefore not render them) but allow them to typed in if they are known... */
+  const options = new Set();
+  nodes.forEach((n) => {
+    collectMutationsOnBranch(n).forEach((o) => options.add(o));
+  });
+  return [...options].map((o) => ({
+    label: `mutation ${o}`,
+    value: [genotypeSymbol, o]
+  }));
+}
+
+function collectMutationsOnBranch(n) {
+  const muts = [];
+  if (n.branch_attrs && n.branch_attrs.mutations && Object.keys(n.branch_attrs.mutations).length) {
+    Object.entries(n.branch_attrs.mutations).forEach(([gene, changes]) => {
+      changes.forEach((m) => {
+        muts.push(`${gene}:${m.slice(1)}`); // remove the _from_ base/codon
+      });
+    });
+  }
+  return muts;
+}
+
+function filterBadgeDisplayName(n, filterName) {
+  if (filterName===strainSymbol) return `${n} x samples`;
+  if (filterName===genotypeSymbol) return `${n} x genotypes`;
+  return `${n} x  ${filterName}`;
+}

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -127,7 +127,12 @@ class FilterData extends React.Component {
             </SidebarSubtitle>
             {inUseFilters.map((filter) => (
               <div style={{display: 'inline-block', margin: '2px'}} key={filter.displayName}>
-                <FilterBadge active id={filter.displayName} remove={filter.remove}>
+                <FilterBadge
+                  active
+                  id={filter.displayName}
+                  remove={filter.remove}
+                  onHoverMessage={`Data is currently filtered by ${filter.displayName}`}
+                >
                   {filter.displayName}
                 </FilterBadge>
               </div>

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
-import Async from "react-select/lib/Async";
+import "react-select/dist/react-select.css";
+import "react-virtualized-select/styles.css";
+import Select from "react-virtualized-select";
 import { debounce } from 'lodash';
 import { controlsWidth, isValueValid, strainSymbol, genotypeSymbol} from "../../util/globals";
 import { collectGenotypeStates } from "../../util/treeMiscHelpers";
@@ -106,7 +108,8 @@ class FilterData extends React.Component {
     const divKey = String(Object.keys(this.props.activeFilters).length);
     return (
       <div style={styles.base} key={divKey}>
-        <Async
+        <Select
+          async
           name="filterQueryBox"
           placeholder="Type filter query here..."
           value={undefined}

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -63,7 +63,7 @@ class FilterData extends React.Component {
     if (genotypeSymbol in this.props.activeFilters) {
       const sortedGenotypes = [...collectGenotypeStates(this.props.nodes)].sort();
       options.push(...sortedGenotypes.map((o) => ({
-        label: `mutation ${o}`,
+        label: `genotype ${o}`,
         value: [genotypeSymbol, o]
       })));
     }

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -161,7 +161,7 @@ function collectObservedMutations(nodes) {
   }));
 }
 
-function collectMutationsOnBranch(n) {
+export function collectMutationsOnBranch(n) {
   const muts = [];
   if (n.branch_attrs && n.branch_attrs.mutations && Object.keys(n.branch_attrs.mutations).length) {
     Object.entries(n.branch_attrs.mutations).forEach(([gene, changes]) => {

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -60,6 +60,13 @@ class FilterData extends React.Component {
             });
           });
       });
+    if (genotypeSymbol in this.props.activeFilters) {
+      const sortedGenotypes = [...collectGenotypeStates(this.props.nodes)].sort();
+      options.push(...sortedGenotypes.map((o) => ({
+        label: `mutation ${o}`,
+        value: [genotypeSymbol, o]
+      })));
+    }
     if (strainSymbol in this.props.activeFilters) {
       this.props.nodes
         .filter((n) => !n.hasChildren)
@@ -69,15 +76,6 @@ class FilterData extends React.Component {
             value: [strainSymbol, n.name]
           });
         });
-    }
-    if (genotypeSymbol in this.props.activeFilters) {
-      /* TODO this may necessitate more efficient rendering of the select dropdown as there will often be thousands of entries here
-      (e.g. SARS-CoV-2 with ~4000 tips has ~30,000 genotype states).
-      Another option here is to skip this step (and therefore not render them) but allow them to typed in if they are known. */
-      options.push(...[...collectGenotypeStates(this.props.nodes)].map((o) => ({
-        label: `mutation ${o}`,
-        value: [genotypeSymbol, o]
-      })));
     }
     return options;
   }

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -4,8 +4,8 @@ import * as icons from "../framework/svg-icons";
 import { NODE_VISIBLE } from "../../util/globals";
 import { materialButton } from "../../globalStyles";
 import * as helpers from "./helperFunctions";
-import { getNumSelectedTips } from "../info/info";
 import { getFullAuthorInfoFromNode } from "../../util/treeMiscHelpers";
+import { getNumSelectedTips } from "../../util/treeVisibilityHelpers";
 
 const RectangularTreeIcon = withTheme(icons.RectangularTree);
 const PanelsGridIcon = withTheme(icons.PanelsGrid);

--- a/src/components/download/downloadModal.js
+++ b/src/components/download/downloadModal.js
@@ -6,7 +6,7 @@ import { TRIGGER_DOWNLOAD_MODAL, DISMISS_DOWNLOAD_MODAL } from "../../actions/ty
 import { infoPanelStyles } from "../../globalStyles";
 import { stopProp } from "../tree/infoPanels/click";
 import { getAcknowledgments} from "../framework/footer";
-import { createSummary } from "../info/info";
+import { datasetSummary } from "../info/datasetSummary";
 import { DownloadButtons } from "./downloadButtons";
 
 
@@ -162,15 +162,14 @@ class DownloadModal extends React.Component {
           </div>
 
           <div>
-            {createSummary(
-              this.props.metadata.mainTreeNumTips,
-              this.props.nodes,
-              this.props.filters,
-              this.props.visibility,
-              this.props.visibleStateCounts,
-              undefined, // this.props.branchLengthsToDisplay,
-              this.props.t
-            )}
+            {datasetSummary({
+              mainTreeNumTips: this.props.metadata.mainTreeNumTips,
+              nodes: this.props.nodes,
+              filters: this.props.filters,
+              visibility: this.props.visibility,
+              visibleStateCounts: this.props.visibleStateCounts,
+              t: this.props.t
+            })}
           </div>
           <div style={infoPanelStyles.break}/>
           {" " + t("A full list of sequence authors is available via the TSV files below")}

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -4,7 +4,7 @@ import { spaceBetweenTrees } from "../tree/tree";
 import { getTraitFromNode, getDivFromNode, getFullAuthorInfoFromNode, getVaccineFromNode, getAccessionFromNode } from "../../util/treeMiscHelpers";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { NODE_VISIBLE } from "../../util/globals";
-import { createSummary } from "../info/info";
+import { datasetSummary } from "../info/datasetSummary";
 import { isColorByGenotype } from "../../util/getGenotype";
 
 export const isPaperURLValid = (d) => {
@@ -478,15 +478,14 @@ export const SVG = (dispatch, t, metadata, nodes, filters, visibility, visibleSt
   textStrings.push(`Last updated ${metadata.updated}`);
   const address = window.location.href.replace(/&/g, '&amp;');
   textStrings.push(`Downloaded from <a href="${address}">${address}</a> on ${new Date().toLocaleString()}`);
-  textStrings.push(createSummary(
-    metadata.mainTreeNumTips,
+  textStrings.push(datasetSummary({
+    mainTreeNumTips: metadata.mainTreeNumTips,
     nodes,
     filters,
     visibility,
     visibleStateCounts,
-    undefined, // param is `branchLengthsToDisplay`,
     t
-  ));
+  }));
   textStrings.push("");
   textStrings.push(`${t("Data usage part 1")} A full list of sequence authors is available via <a href="https://nextstrain.org">nextstrain.org</a>.`);
   textStrings.push(`Visualizations are licensed under CC-BY.`);

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -1,68 +1,61 @@
 import React from "react";
-import { useTranslation } from 'react-i18next';
-
+import { connect } from "react-redux";
+import { withTranslation } from 'react-i18next';
+import styled from 'styled-components';
 import { headerFont } from "../../globalStyles";
 
-const styles = {
-  avatar: {
-    marginRight: 5,
-    marginBottom: 2
-  },
-  byline: {
-    fontFamily: headerFont,
-    fontSize: 15,
-    marginLeft: 2,
-    marginTop: 5,
-    marginBottom: 5,
-    fontWeight: 500,
-    color: "#555",
-    lineHeight: 1.4,
-    verticalAlign: "middle"
-  },
-  bylineWeight: {
-    fontFamily: headerFont,
-    fontSize: 15,
-    fontWeight: 500
+@connect((state) => {
+  return {
+    metadata: state.metadata
+  };
+})
+class Byline extends React.Component {
+  constructor(props) {
+    super(props);
   }
-};
 
-const Byline = ({width, metadata}) => {
-  const { t } = useTranslation();
+  render() {
+    const { t } = this.props;
 
-  /** Render a special byline for nexstrain's nCoV (SARS-CoV-2) builds.
-   * This is somewhat temporary and may be switched to a nextstrain.org
-   * auspice customisation in the future.
-   */
-  if (
-    // comment out the next line for testing on localhost
-    (window.location.hostname === "nextstrain.org" || window.location.hostname === "dev.nextstrain.org") &&
-    window.location.pathname.startsWith("/ncov")
-  ) {
+    /** Render a special byline for nexstrain's nCoV (SARS-CoV-2) builds.
+     * This is somewhat temporary and may be switched to a nextstrain.org
+     * auspice customisation in the future.
+     */
+    if (
+      // comment out the next line for testing on localhost
+      (window.location.hostname === "nextstrain.org" || window.location.hostname === "dev.nextstrain.org") &&
+      window.location.pathname.startsWith("/ncov")
+    ) {
+      return (
+        <>
+          {renderAvatar(t, this.props.metadata)}
+          {renderMaintainers(t, this.props.metadata)}
+          {
+            this.props.metadata.buildUrl &&
+            <span>
+              {" Enabled by data from "}
+              <img src="https://www.gisaid.org/fileadmin/gisaid/img/schild.png" alt="gisaid-logo" width="65"/>
+            </span>
+          }
+        </>
+      );
+    }
+    /* End nextstrain-specific ncov / SARS-CoV-2 code */
+
     return (
-      <div width={width} style={styles.byline}>
-        {renderAvatar(t, metadata)}
-        {renderMaintainers(t, metadata)}
-        {
-          metadata.buildUrl &&
-          <span>
-            {" Enabled by data from "}
-            <img src="https://www.gisaid.org/fileadmin/gisaid/img/schild.png" alt="gisaid-logo" width="65"/>
-          </span>
-        }
-      </div>
+      <>
+        {renderAvatar(t, this.props.metadata)}
+        {renderBuildInfo(t, this.props.metadata)}
+        {renderMaintainers(t, this.props.metadata)}
+      </>
     );
   }
-  /* End nextstrain-specific ncov / SARS-CoV-2 code */
+}
 
-
-  return (
-    <div width={width} style={styles.byline}>
-      {renderAvatar(t, metadata)}
-      {renderBuildInfo(t, metadata)}
-      {renderMaintainers(t, metadata)}
-    </div>
-  );
-};
+const AvatarImg = styled.img`
+  margin-right: 5px;
+  margin-bottom: 2px;
+`;
 
 function renderAvatar(t, metadata) {
   const repo = metadata.buildUrl;
@@ -70,7 +63,7 @@ function renderAvatar(t, metadata) {
     const match = repo.match(/(https?:\/\/)?(www\.)?github.com\/([^/]+)/);
     if (match) {
       return (
-        <img style={styles.avatar} alt="avatar" width="28" src={`https://github.com/${match[3]}.png?size=200`}/>
+        <AvatarImg alt="avatar" width="28" src={`https://github.com/${match[3]}.png?size=200`}/>
       );
     }
   }
@@ -124,12 +117,19 @@ function renderMaintainers(t, metadata) {
   return null;
 }
 
+const BylineLink = styled.a`
+  font-family: ${headerFont};
+  font-size: 15;
+  font-weight: 500;
+`;
+
 function Link({url, children}) {
   return (
-    <a style={styles.bylineWeight} rel="noopener noreferrer" href={url} target="_blank">
+    <BylineLink rel="noopener noreferrer" href={url} target="_blank">
       {children}
-    </a>
+    </BylineLink>
   );
 }
 
-export default Byline;
+const WithTranslation = withTranslation()(Byline);
+export default WithTranslation;

--- a/src/components/info/datasetSummary.js
+++ b/src/components/info/datasetSummary.js
@@ -7,7 +7,7 @@ const plurals = {
   authors: "authors"
 };
 
-const pluralise = (word, n) => {
+export const pluralise = (word, n) => {
   if (n === 1) {
     if (word === "authors") word = "author"; // eslint-disable-line
   } else {

--- a/src/components/info/datasetSummary.js
+++ b/src/components/info/datasetSummary.js
@@ -1,0 +1,93 @@
+import { numericToCalendar } from "../../util/dateHelpers";
+import { months } from "../../util/globals";
+import { getVisibleDateRange, getNumSelectedTips } from "../../util/treeVisibilityHelpers";
+
+const plurals = {
+  country: "countries",
+  authors: "authors"
+};
+
+const pluralise = (word, n) => {
+  if (n === 1) {
+    if (word === "authors") word = "author"; // eslint-disable-line
+  } else {
+    if (word in plurals) word = plurals[word]; // eslint-disable-line
+    if (word.slice(-1).toLowerCase() !== "s") word+="s"; // eslint-disable-line
+  }
+  word = word.replace(/_/g, " "); // eslint-disable-line
+  return word;
+};
+
+const arrayToSentence = (arr, {prefix=undefined, suffix=undefined, capatalise=true, fullStop=true}={}) => {
+  let ret;
+  if (!arr.length) return '';
+  if (arr.length === 1) {
+    ret = arr[0];
+  } else {
+    ret = arr.slice(0, -1).join(", ") + " and " + arr[arr.length-1];
+  }
+  if (prefix) ret = prefix + " " + ret;
+  if (suffix) ret += " " + suffix;
+  if (capatalise) ret = ret.charAt(0).toUpperCase();
+  if (fullStop) ret += ".";
+  return ret + " ";
+};
+
+export const styliseDateRange = (date) => {
+  const dateStr = (typeof date === "number") ?
+    numericToCalendar(date) :
+    date;
+  const fields = dateStr.split('-');
+  // 2012-01-22
+  if (fields.length === 3) {
+    return `${months[fields[1]]} ${fields[0]}`;
+  }
+  // other cases like negative numbers
+  return dateStr;
+};
+
+/**
+ * @returns {string}
+ */
+export const datasetSummary = ({nodes, visibility, mainTreeNumTips, branchLengthsToDisplay, filters, visibleStateCounts, t}) => {
+  const nSelectedSamples = getNumSelectedTips(nodes, visibility);
+  const sampledDateRange = getVisibleDateRange(nodes, visibility);
+  let summary = ""; /* text returned from this function */
+
+  /* Number of genomes & their date range */
+  if (branchLengthsToDisplay !== "divOnly" && nSelectedSamples > 0) {
+    summary += t(
+      "Showing {{x}} of {{y}} genomes sampled between {{from}} and {{to}}",
+      {
+        x: nSelectedSamples,
+        y: mainTreeNumTips,
+        from: styliseDateRange(sampledDateRange[0]),
+        to: styliseDateRange(sampledDateRange[1])
+      }
+    );
+  } else {
+    summary += t(
+      "Showing {{x}} of {{y}} genomes",
+      {x: nSelectedSamples, y: mainTreeNumTips}
+    );
+  }
+  summary += ".";
+
+  /* parse filters */
+  const filterTextArr = [];
+  Object.keys(filters).forEach((filterName) => {
+    const n = Object.keys(visibleStateCounts[filterName]).length;
+    if (!n) return;
+    filterTextArr.push(`${n} ${pluralise(filterName, n)}`);
+  });
+  const prefix = t("Comprising");
+  const filterText = arrayToSentence(filterTextArr, {prefix: prefix, capatalise: false});
+  if (filterText.length) {
+    summary += ` ${filterText}`;
+  } else if (summary.endsWith('.')) {
+    summary += " ";
+  } else {
+    summary += ". ";
+  }
+  return summary;
+};

--- a/src/components/info/filterBadge.js
+++ b/src/components/info/filterBadge.js
@@ -96,14 +96,14 @@ export const Tooltip = ({id, children}) => (
  * React component to display a selected filter with associated
  * icons to remove filter. More functionality to be added!
  */
-export const FilterBadge = ({remove, canMakeInactive, active, activate, inactivate, children, id}) => {
+export const FilterBadge = ({remove, canMakeInactive, active, activate, inactivate, children, id, onHoverMessage="The visible data is being filtered by this"}) => {
   return (
     <BadgeContainer striped={canMakeInactive && !active}>
       <TextContainer active={canMakeInactive ? active : true} data-tip data-for={id}>
         {children}
       </TextContainer>
       <Tooltip id={id}>
-        {canMakeInactive && !active ? `This filter is currently inactive` : `The visible data is being filtered by this`}
+        {canMakeInactive && !active ? `This filter is currently inactive` : onHoverMessage}
       </Tooltip>
       {canMakeInactive && (
         <IconContainer onClick={active ? inactivate : activate} role="button" tabIndex={0} data-tip data-for={id+'active'}>

--- a/src/components/info/filtersSummary.js
+++ b/src/components/info/filtersSummary.js
@@ -2,16 +2,27 @@ import React from "react";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
 import { applyFilter, changeDateFilter } from "../../actions/tree";
-import { strainSymbol, genotypeSymbol } from "../../util/globals";
+import { strainSymbol, genotypeSymbol, getAminoAcidName } from "../../util/globals";
 import { FilterBadge, Tooltip } from "./filterBadge";
-import { styliseDateRange } from "./datasetSummary";
+import { styliseDateRange, pluralise } from "./datasetSummary";
+import { createFilterConstellation } from "../../util/treeVisibilityHelpers";
 
 const Intersect = ({id}) => (
-  <span style={{fontSize: "2rem", padding: "0px 4px 0px 2px", cursor: 'help'}} data-tip data-for={id}>
+  <span style={{fontSize: "2rem", fontWeight: 300, padding: "0px 4px 0px 2px", cursor: 'help'}} data-tip data-for={id}>
     ∩
-    <Tooltip id={id}>{`Groups of filters are combined by taking the intersect`}</Tooltip>
+    <Tooltip id={id}>{`Groups of filters are combined by intersection`}</Tooltip>
   </span>
 );
+const Union = () => (
+  <span style={{fontSize: "1.5rem", padding: "0px 3px 0px 2px"}}>
+    ∪
+  </span>
+);
+const openBracketBig = <span style={{fontSize: "2rem", fontWeight: 300, padding: "0px 0px 0px 2px"}}>{'{'}</span>;
+const closeBracketBig = <span style={{fontSize: "2rem", fontWeight: 300, padding: "0px 2px"}}>{'}'}</span>;
+const openBracketSmall = <span style={{fontSize: "1.8rem", fontWeight: 300, padding: "0px 2px"}}>{'{'}</span>;
+const closeBracketSmall = <span style={{fontSize: "1.8rem", fontWeight: 300, padding: "0px 2px"}}>{'}'}</span>;
+
 
 @connect((state) => {
   return {
@@ -35,12 +46,28 @@ class FiltersSummary extends React.Component {
   constructor(props) {
     super(props);
   }
-  makeFilteredDatesButton() {
+  createIndividualBadge({filterName, item, label, onHoverMessage}) {
+    return (
+      <FilterBadge
+        key={item.value}
+        id={String(item.value)}
+        remove={() => {this.props.dispatch(applyFilter("remove", filterName, [item.value]));}}
+        canMakeInactive
+        onHoverMessage={onHoverMessage}
+        active={item.active}
+        activate={() => {this.props.dispatch(applyFilter("add", filterName, [item.value]));}}
+        inactivate={() => {this.props.dispatch(applyFilter("inactivate", filterName, [item.value]));}}
+      >
+        {label}
+      </FilterBadge>
+    );
+  }
+  createFilterBadgesForTime() {
     return ([
-      'timeFilter',
       <FilterBadge
         key="timefilter"
         id="timefilter"
+        onHoverMessage="Filtering to data sampled in this date range"
         remove={() => this.props.dispatch(changeDateFilter({newMin: this.props.absoluteDateMin, newMax: this.props.absoluteDateMax}))}
       >
         {`${styliseDateRange(this.props.dateMin)} to ${styliseDateRange(this.props.dateMax)}`}
@@ -48,55 +75,109 @@ class FiltersSummary extends React.Component {
     ]);
   }
   createFilterBadges(filterName) {
+    const filterNameString = filterName===strainSymbol ? "sample" : filterName;
+    const nFilterValues = this.props.filters[filterName].length;
+    const onHoverMessage = nFilterValues === 1 ?
+      `Filtering data to this ${filterNameString}` :
+      `Filtering data to these ${nFilterValues} ${pluralise(filterNameString)}`;
     return this.props.filters[filterName]
       .sort((a, b) => a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
-      .map((item) => ([
-        item.value,
-        <FilterBadge
-          key={item.value}
-          id={String(item.value)}
-          remove={() => {this.props.dispatch(applyFilter("remove", filterName, [item.value]));}}
-          canMakeInactive
-          active={item.active}
-          activate={() => {this.props.dispatch(applyFilter("add", filterName, [item.value]));}}
-          inactivate={() => {this.props.dispatch(applyFilter("inactivate", filterName, [item.value]));}}
-        >
-          <span>
-            {item.value}
-            {filterName!==strainSymbol && filterName!==genotypeSymbol && ` (${this.props.totalStateCounts[filterName].get(item.value)})`}
-          </span>
-        </FilterBadge>
-      ]));
+      .map((item) => {
+        let label = `${item.value}`;
+        if (filterName!==strainSymbol) label+= ` (${this.props.totalStateCounts[filterName].get(item.value)})`;
+        return this.createIndividualBadge({filterName, item, label, onHoverMessage});
+      });
+  }
+  createFilterBadgesForGenotype() {
+    const filters = this.props.filters[genotypeSymbol];
+    const activeSet = new Set(filters.filter((f) => f.active).map((f) => f.value));
+    const constellation = createFilterConstellation(filters.map((f) => f.value));
+    return constellation.map((c) => {
+      const nt = c[0]==="nuc";
+      if (c[2].size===1) { // filtered to a single codon/nt at this position
+        const residue = [...c[2]][0];
+        const onHoverMessage = nt ?
+          `Filtering to sequences with nucleotide ${residue} at base ${c[1]}` :
+          `Filtering to sequences with ${getAminoAcidName(residue)} at codon ${c[1]} in ${c[0]}`;
+        const label = `${c[0]} ${c[1]}${residue}`;
+        const item = {active: activeSet.has(label), value: label};
+        return this.createIndividualBadge({filterName: genotypeSymbol, item, label: item.value, onHoverMessage});
+      }
+      // filtered to multiple residues at this position using OR logic.
+      const residues = [...c[2]];
+      const labels = residues.map((residue) => `${c[0]} ${c[1]}${residue}`);
+      const activeResidues = residues.filter((_, i) => activeSet.has(labels[i])); // active means filter is active
+      const stringify = (l) => l.length>1 ? `${l.slice(0, -1).join(", ")} or ${l[l.length-1]}` : l[0];
+      const onHoverMessage = nt ?
+        `Filtering to sequences with nucleotides ${stringify(activeResidues)} at position ${c[1]}` :
+        `Filtering to sequences with ${stringify(activeResidues.map((r) => getAminoAcidName(r)))} at codon ${c[1]} in ${c[0]}`;
+      return residues.map((residue) => {
+        const label = `${c[0]} ${c[1]}${residue}`;
+        const item = {active: activeSet.has(label), value: label};
+        return this.createIndividualBadge({filterName: genotypeSymbol, item, label: item.value, onHoverMessage});
+      });
+    });
   }
   render() {
     const { t } = this.props;
+    // create an array of objects, with each object containing the badges for a filter category.
+    // E.g. `filtersByCategory[i] = {name: "country", badges: Array<FilterBadgeComponent>`}`
     const filtersByCategory = [];
     Reflect.ownKeys(this.props.filters)
       .filter((filterName) => this.props.filters[filterName].length > 0)
       .forEach((filterName) => {
-        const name = filterName===strainSymbol ? 'strain' : filterName===genotypeSymbol ? 'genotype' : filterName;
-        filtersByCategory.push({name, badges: this.createFilterBadges(filterName)});
+        if (filterName===strainSymbol) {
+          filtersByCategory.push({name: 'sample', badges: this.createFilterBadges(strainSymbol)});
+        } else if (filterName===genotypeSymbol) {
+          filtersByCategory.push({name: 'genotype', badges: this.createFilterBadgesForGenotype()});
+        } else {
+          filtersByCategory.push({name: filterName, badges: this.createFilterBadges(filterName)});
+        }
       });
+    // temporal filtering is not a regular filter (i.e. this.props.filters)
     if (!(this.props.dateMin===this.props.absoluteDateMin && this.props.dateMax===this.props.absoluteDateMax)) {
-      filtersByCategory.push({name: 'temporal', badges: [this.makeFilteredDatesButton()]});
+      filtersByCategory.push({name: 'temporal', badges: this.createFilterBadgesForTime()});
     }
     if (!filtersByCategory.length) return null;
+
     return (
       <>
         {t("Filtered to") + " "}
-        {filtersByCategory.map((filter, idx) => (
-          <span style={{fontSize: "2rem", padding: "0px 2px"}} key={filter.name}>
-            {idx!==0 && <Intersect id={'intersect'+idx}/>}
-            {filter.badges.length === 1 ? null : `{`}
-            {filter.badges.map(([name, badge], i) => (
-              <span key={name}>
-                {badge}
-                {i!==filter.badges.length-1 ? ", " : null}
-              </span>
-            ))}
-            {filter.badges.length === 1 ? null : `}`}
-          </span>
-        ))}
+        {filtersByCategory.map((filterCategory, idx) => {
+          const multipleFilterBadges = filterCategory.badges.length > 1;
+          const previousCategoriesRendered = idx!==0;
+
+          return (
+            <span style={{fontSize: "2rem", padding: "0px 2px"}} key={filterCategory.name}>
+              {previousCategoriesRendered && <Intersect id={'intersect'+idx}/>}
+              {multipleFilterBadges && openBracketBig} {/* multiple badges => surround with set notation */}
+              {filterCategory.badges.map((badge, badgeIdx) => {
+                if (Array.isArray(badge)) { // if `badge` is an array then we wish to render a set-within-a-set
+                  return (
+                    <span key={badge.map((b) => b.props.id).join("")}>
+                      {openBracketSmall}
+                      {badge.map((el, elIdx) => (
+                        <span key={el.props.id}>
+                          {el}
+                          {elIdx!==badge.length-1 && <Union/>}
+                        </span>
+                      ))}
+                      {closeBracketSmall}
+                      {badgeIdx!==filterCategory.badges.length-1 && ", "}
+                    </span>
+                  );
+                }
+                return (
+                  <span key={badge.props.id}>
+                    {badge}
+                    {badgeIdx!==filterCategory.badges.length-1 && ", "}
+                  </span>
+                );
+              })}
+              {multipleFilterBadges && closeBracketBig}
+            </span>
+          );
+        })}
         {". "}
       </>
     );

--- a/src/components/info/filtersSummary.js
+++ b/src/components/info/filtersSummary.js
@@ -1,0 +1,107 @@
+import React from "react";
+import { connect } from "react-redux";
+import { withTranslation } from 'react-i18next';
+import { applyFilter, changeDateFilter } from "../../actions/tree";
+import { strainSymbol, genotypeSymbol } from "../../util/globals";
+import { FilterBadge, Tooltip } from "./filterBadge";
+import { styliseDateRange } from "./datasetSummary";
+
+const Intersect = ({id}) => (
+  <span style={{fontSize: "2rem", padding: "0px 4px 0px 2px", cursor: 'help'}} data-tip data-for={id}>
+    ∩
+    <Tooltip id={id}>{`Groups of filters are combined by taking the intersect`}</Tooltip>
+  </span>
+);
+
+@connect((state) => {
+  return {
+    browserDimensions: state.browserDimensions.browserDimensions,
+    filters: state.controls.filters,
+    animationPlayPauseButton: state.controls.animationPlayPauseButton,
+    metadata: state.metadata,
+    nodes: state.tree.nodes,
+    visibleStateCounts: state.tree.visibleStateCounts,
+    totalStateCounts: state.tree.totalStateCounts,
+    visibility: state.tree.visibility,
+    selectedClade: state.tree.selectedClade,
+    dateMin: state.controls.dateMin,
+    dateMax: state.controls.dateMax,
+    absoluteDateMin: state.controls.absoluteDateMin,
+    absoluteDateMax: state.controls.absoluteDateMax,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay
+  };
+})
+class FiltersSummary extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  makeFilteredDatesButton() {
+    return ([
+      'timeFilter',
+      <FilterBadge
+        key="timefilter"
+        id="timefilter"
+        remove={() => this.props.dispatch(changeDateFilter({newMin: this.props.absoluteDateMin, newMax: this.props.absoluteDateMax}))}
+      >
+        {`${styliseDateRange(this.props.dateMin)} to ${styliseDateRange(this.props.dateMax)}`}
+      </FilterBadge>
+    ]);
+  }
+  createFilterBadges(filterName) {
+    return this.props.filters[filterName]
+      .sort((a, b) => a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
+      .map((item) => ([
+        item.value,
+        <FilterBadge
+          key={item.value}
+          id={String(item.value)}
+          remove={() => {this.props.dispatch(applyFilter("remove", filterName, [item.value]));}}
+          canMakeInactive
+          active={item.active}
+          activate={() => {this.props.dispatch(applyFilter("add", filterName, [item.value]));}}
+          inactivate={() => {this.props.dispatch(applyFilter("inactivate", filterName, [item.value]));}}
+        >
+          <span>
+            {item.value}
+            {filterName!==strainSymbol && filterName!==genotypeSymbol && ` (${this.props.totalStateCounts[filterName].get(item.value)})`}
+          </span>
+        </FilterBadge>
+      ]));
+  }
+  render() {
+    const { t } = this.props;
+    const filtersByCategory = [];
+    Reflect.ownKeys(this.props.filters)
+      .filter((filterName) => this.props.filters[filterName].length > 0)
+      .forEach((filterName) => {
+        const name = filterName===strainSymbol ? 'strain' : filterName===genotypeSymbol ? 'genotype' : filterName;
+        filtersByCategory.push({name, badges: this.createFilterBadges(filterName)});
+      });
+    if (!(this.props.dateMin===this.props.absoluteDateMin && this.props.dateMax===this.props.absoluteDateMax)) {
+      filtersByCategory.push({name: 'temporal', badges: [this.makeFilteredDatesButton()]});
+    }
+    if (!filtersByCategory.length) return null;
+    return (
+      <>
+        {t("Filtered to") + " "}
+        {filtersByCategory.map((filter, idx) => (
+          <span style={{fontSize: "2rem", padding: "0px 2px"}} key={filter.name}>
+            {idx!==0 && <Intersect id={'intersect'+idx}/>}
+            {filter.badges.length === 1 ? null : `{`}
+            {filter.badges.map(([name, badge], i) => (
+              <span key={name}>
+                {badge}
+                {i!==filter.badges.length-1 ? ", " : null}
+              </span>
+            ))}
+            {filter.badges.length === 1 ? null : `}`}
+          </span>
+        ))}
+        {". "}
+      </>
+    );
+  }
+}
+
+const WithTranslation = withTranslation()(FiltersSummary);
+export default WithTranslation;

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -1,294 +1,63 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
-
 import Card from "../framework/card";
 import { titleFont, headerFont, medGrey, darkGrey } from "../../globalStyles";
-import { applyFilter, changeDateFilter } from "../../actions/tree";
-import { getVisibleDateRange } from "../../util/treeVisibilityHelpers";
-import { numericToCalendar } from "../../util/dateHelpers";
-import { months, NODE_VISIBLE, strainSymbol, genotypeSymbol } from "../../util/globals";
 import Byline from "./byline";
-import { FilterBadge, Tooltip } from "./filterBadge";
+import {datasetSummary} from "./datasetSummary";
+import FiltersSummary from "./filtersSummary";
 
-const plurals = {
-  country: "countries",
-  authors: "authors"
-};
-
-const pluralise = (word, n) => {
-  if (n === 1) {
-    if (word === "authors") word = "author"; // eslint-disable-line
-  } else {
-    if (word in plurals) word = plurals[word]; // eslint-disable-line
-    if (word.slice(-1).toLowerCase() !== "s") word+="s"; // eslint-disable-line
-  }
-  word = word.replace(/_/g, " "); // eslint-disable-line
-  return word;
-};
-
-const styliseDateRange = (date) => {
-  const dateStr = (typeof date === "number") ?
-    numericToCalendar(date) :
-    date;
-  const fields = dateStr.split('-');
-  // 2012-01-22
-  if (fields.length === 3) {
-    return `${months[fields[1]]} ${fields[0]}`;
-  }
-  // other cases like negative numbers
-  return dateStr;
-};
-
-export const getNumSelectedTips = (nodes, visibility) => {
-  let count = 0;
-  nodes.forEach((d, idx) => {
-    // nodes which are not inView have a visibility of NODE_NOT_VISIBLE
-    // so this check accounts for them as well
-    if (!d.hasChildren && visibility[idx] === NODE_VISIBLE) count += 1;
-  });
-  return count;
-};
-
-const arrayToSentence = (arr, {prefix=undefined, suffix=undefined, capatalise=true, fullStop=true}={}) => {
-  let ret;
-  if (!arr.length) return '';
-  if (arr.length === 1) {
-    ret = arr[0];
-  } else {
-    ret = arr.slice(0, -1).join(", ") + " and " + arr[arr.length-1];
-  }
-  if (prefix) ret = prefix + " " + ret;
-  if (suffix) ret += " " + suffix;
-  if (capatalise) ret = ret.charAt(0).toUpperCase();
-  if (fullStop) ret += ".";
-  return ret + " ";
-};
-
-export const createSummary = (mainTreeNumTips, nodes, filters, visibility, visibleStateCounts, branchLengthsToDisplay, t) => {
-  const nSelectedSamples = getNumSelectedTips(nodes, visibility);
-  const sampledDateRange = getVisibleDateRange(nodes, visibility);
-  let summary = ""; /* text returned from this function */
-
-  /* Number of genomes & their date range */
-  if (branchLengthsToDisplay !== "divOnly" && nSelectedSamples > 0) {
-    summary += t(
-      "Showing {{x}} of {{y}} genomes sampled between {{from}} and {{to}}",
-      {
-        x: nSelectedSamples,
-        y: mainTreeNumTips,
-        from: styliseDateRange(sampledDateRange[0]),
-        to: styliseDateRange(sampledDateRange[1])
-      }
-    );
-  } else {
-    summary += t(
-      "Showing {{x}} of {{y}} genomes",
-      {x: nSelectedSamples, y: mainTreeNumTips}
-    );
-  }
-  summary += ".";
-
-  /* parse filters */
-  const filterTextArr = [];
-  Object.keys(filters).forEach((filterName) => {
-    const n = Object.keys(visibleStateCounts[filterName]).length;
-    if (!n) return;
-    filterTextArr.push(`${n} ${pluralise(filterName, n)}`);
-  });
-  const prefix = t("Comprising");
-  const filterText = arrayToSentence(filterTextArr, {prefix: prefix, capatalise: false});
-  if (filterText.length) {
-    summary += ` ${filterText}`;
-  } else if (summary.endsWith('.')) {
-    summary += " ";
-  } else {
-    summary += ". ";
-  }
-  return summary;
-};
-
+/**
+ * The <Info> panel is shown above data viz panels and conveys static and dynamic
+ * information about the dataset, including
+ * Title
+ * Byline (maintainers, build link etc)
+ * Dataset summary (dynamic)
+ * Current Filters (dynamic)
+ */
 @connect((state) => {
   return {
-    browserDimensions: state.browserDimensions.browserDimensions,
-    filters: state.controls.filters,
+    browserWidth: state.browserDimensions.browserDimensions.width,
     animationPlayPauseButton: state.controls.animationPlayPauseButton,
     metadata: state.metadata,
     nodes: state.tree.nodes,
     visibleStateCounts: state.tree.visibleStateCounts,
-    totalStateCounts: state.tree.totalStateCounts,
-    visibility: state.tree.visibility,
-    selectedClade: state.tree.selectedClade,
-    dateMin: state.controls.dateMin,
-    dateMax: state.controls.dateMax,
-    absoluteDateMin: state.controls.absoluteDateMin,
-    absoluteDateMax: state.controls.absoluteDateMax,
-    branchLengthsToDisplay: state.controls.branchLengthsToDisplay
+    filters: state.controls.filters,
+    branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
+    visibility: state.tree.visibility
   };
 })
 class Info extends React.Component {
   constructor(props) {
     super(props);
   }
-  getStyles(width) {
-    let fontSize = 28;
-    if (this.props.browserDimensions.width < 1000) {
-      fontSize = 27;
-    }
-    if (this.props.browserDimensions.width < 800) {
-      fontSize = 26;
-    }
-    if (this.props.browserDimensions.width < 600) {
-      fontSize = 25;
-    }
-    if (this.props.browserDimensions.width < 400) {
-      fontSize = 24;
-    }
-    return {
-      base: {
-        width: width + 34,
-        display: "inline-block",
-        maxWidth: width,
-        marginTop: 0
-      },
-      title: {
-        fontFamily: titleFont,
-        fontSize: fontSize,
-        marginLeft: 0,
-        marginTop: 0,
-        marginBottom: 5,
-        fontWeight: 500,
-        color: darkGrey,
-        letterSpacing: "-0.5px",
-        lineHeight: 1.2
-      },
-      n: {
-        fontFamily: headerFont,
-        fontSize: 14,
-        marginLeft: 2,
-        marginTop: 5,
-        marginBottom: 5,
-        fontWeight: 500,
-        color: medGrey,
-        lineHeight: 1.4
-      }
-    };
-  }
-
-  makeFilteredDatesButton() {
-    return ([
-      'timeFilter',
-      <FilterBadge
-        key="timefilter"
-        id="timefilter"
-        remove={() => this.props.dispatch(changeDateFilter({newMin: this.props.absoluteDateMin, newMax: this.props.absoluteDateMax}))}
-      >
-        {`${styliseDateRange(this.props.dateMin)} to ${styliseDateRange(this.props.dateMax)}`}
-      </FilterBadge>
-    ]);
-  }
-  createFilterBadges(filterName) {
-    return this.props.filters[filterName]
-      .sort((a, b) => a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
-      .map((item) => ([
-        item.value,
-        <FilterBadge
-          key={item.value}
-          id={String(item.value)}
-          remove={() => {this.props.dispatch(applyFilter("remove", filterName, [item.value]));}}
-          canMakeInactive
-          active={item.active}
-          activate={() => {this.props.dispatch(applyFilter("add", filterName, [item.value]));}}
-          inactivate={() => {this.props.dispatch(applyFilter("inactivate", filterName, [item.value]));}}
-        >
-          <span>
-            {item.value}
-            {filterName!==strainSymbol && filterName!==genotypeSymbol && ` (${this.props.totalStateCounts[filterName].get(item.value)})`}
-          </span>
-        </FilterBadge>
-      ]));
-  }
-  clearFilterButton(field) {
-    return (
-      <span
-        style={{cursor: "pointer", color: '#5097BA'}}
-        key={field}
-        onClick={() => this.props.dispatch(applyFilter("set", field, []))}
-        role="button"
-        tabIndex={0}
-      >
-        {field}
-      </span>
-    );
-  }
-
-  renderTitle(styles) {
-    let title = "";
-    if (this.props.metadata.title) {
-      title = this.props.metadata.title;
-    }
-    return (
-      <div width={this.props.width} style={styles.title}>
-        {title}
-      </div>
-    );
-  }
 
   render() {
     const { t } = this.props;
     if (!this.props.metadata || !this.props.nodes || !this.props.visibility) return null;
-    const styles = this.getStyles(this.props.width);
-    // const filtersWithValues = Object.keys(this.props.filters).filter((n) => this.props.filters[n].length > 0);
+    const styles = computeStyles(this.props.width, this.props.browserWidth);
     const animating = this.props.animationPlayPauseButton === "Pause";
     const showExtended = !animating && !this.props.selectedStrain;
-    const datesMaxed = this.props.dateMin === this.props.absoluteDateMin && this.props.dateMax === this.props.absoluteDateMax;
-
-    /* the content is made up of two parts:
-    (1) the summary - e.g. Showing 4 of 379 sequences, from 1 author, 1 country and 1 region, dated Apr 2016 to Jun 2016.
-    (2) The active filters: Filtered to [[Metsky et al Zika Virus Evolution And Spread In The Americas (76)]], [[Colombia (28)]].
-    */
-
-    const summary = createSummary(
-      this.props.metadata.mainTreeNumTips,
-      this.props.nodes,
-      this.props.filters,
-      this.props.visibility,
-      this.props.visibleStateCounts,
-      this.props.branchLengthsToDisplay,
-      this.props.t
-    );
-
-    /* part II - the filters in play (both active and inactive) */
-    const filtersByCategory = [];
-    Reflect.ownKeys(this.props.filters)
-      .filter((filterName) => this.props.filters[filterName].length > 0)
-      .forEach((filterName) => {
-        const name = filterName===strainSymbol ? 'strain' : filterName===genotypeSymbol ? 'genotype' : filterName;
-        filtersByCategory.push({name, badges: this.createFilterBadges(filterName)});
-      });
-    if (!datesMaxed) {
-      filtersByCategory.push({name: 'temporal', badges: [this.makeFilteredDatesButton()]});
-    }
-
     return (
       <Card center infocard>
         <div style={styles.base}>
-          {this.renderTitle(styles)}
-          <Byline styles={styles} width={this.props.width} metadata={this.props.metadata}/>
+
+          <div width={this.props.width} style={styles.title}>
+            {this.props.metadata.title || ""}
+          </div>
+
+          <div width={this.props.width} style={styles.byline}>
+            <Byline/>
+          </div>
+
           <div width={this.props.width} style={styles.n}>
             {animating ? t("Animation in progress") + ". " : null}
-            {/* part 1 - the summary */}
-            {showExtended ? summary : null}
-            {/* part 2 - the filters */}
-            {showExtended && filtersByCategory.length ? (
+            {showExtended &&
               <>
-                {t("Filtered to") + " "}
-                {filtersByCategory.map((filter, idx) => (
-                  <Brackets idx={idx} badges={filter.badges} key={filter.name}/>
-                ))}
-                {". "}
+                {datasetSummary({...this.props, mainTreeNumTips: this.props.metadata.mainTreeNumTips})}
+                <FiltersSummary/>
               </>
-            ) : null}
+            }
           </div>
         </div>
       </Card>
@@ -296,27 +65,53 @@ class Info extends React.Component {
   }
 }
 
-const Intersect = ({id}) => (
-  <span style={{fontSize: "2rem", padding: "0px 4px 0px 2px", cursor: 'help'}} data-tip data-for={id}>
-    ∩
-    <Tooltip id={id}>{`Groups of filters are combined by taking the intersect`}</Tooltip>
-  </span>
-);
-
-const Brackets = ({badges, idx}) => (
-  <span style={{fontSize: "2rem", padding: "0px 2px"}}>
-    {idx!==0 && <Intersect id={'intersect'+idx}/>}
-    {badges.length === 1 ? null : `{`}
-    {badges.map(([name, badge], i) => (
-      <span key={name}>
-        {badge}
-        {i!==badges.length-1 ? ", " : null}
-      </span>
-    ))}
-    {badges.length === 1 ? null : `}`}
-  </span>
-);
-
+function computeStyles(width, browserWidth) {
+  let fontSize = 28;
+  if (browserWidth < 1000) fontSize = 27;
+  if (browserWidth < 800) fontSize = 26;
+  if (browserWidth < 600) fontSize = 25;
+  if (browserWidth < 400) fontSize = 24;
+  return {
+    base: {
+      width: width + 34,
+      display: "inline-block",
+      maxWidth: width,
+      marginTop: 0
+    },
+    title: {
+      fontFamily: titleFont,
+      fontSize: fontSize,
+      marginLeft: 0,
+      marginTop: 0,
+      marginBottom: 5,
+      fontWeight: 500,
+      color: darkGrey,
+      letterSpacing: "-0.5px",
+      lineHeight: 1.2
+    },
+    n: {
+      fontFamily: headerFont,
+      fontSize: 14,
+      marginLeft: 2,
+      marginTop: 5,
+      marginBottom: 5,
+      fontWeight: 500,
+      color: medGrey,
+      lineHeight: 1.4
+    },
+    byline: {
+      fontFamily: headerFont,
+      fontSize: 15,
+      marginLeft: 2,
+      marginTop: 5,
+      marginBottom: 5,
+      fontWeight: 500,
+      color: "#555",
+      lineHeight: 1.4,
+      verticalAlign: "middle"
+    }
+  };
+}
 
 const WithTranslation = withTranslation()(Info);
 export default WithTranslation;

--- a/src/components/info/info.js
+++ b/src/components/info/info.js
@@ -7,7 +7,7 @@ import { titleFont, headerFont, medGrey, darkGrey } from "../../globalStyles";
 import { applyFilter, changeDateFilter } from "../../actions/tree";
 import { getVisibleDateRange } from "../../util/treeVisibilityHelpers";
 import { numericToCalendar } from "../../util/dateHelpers";
-import { months, NODE_VISIBLE, strainSymbol } from "../../util/globals";
+import { months, NODE_VISIBLE, strainSymbol, genotypeSymbol } from "../../util/globals";
 import Byline from "./byline";
 import { FilterBadge, Tooltip } from "./filterBadge";
 
@@ -203,7 +203,7 @@ class Info extends React.Component {
         >
           <span>
             {item.value}
-            {filterName!==strainSymbol && ` (${this.props.totalStateCounts[filterName].get(item.value)})`}
+            {filterName!==strainSymbol && filterName!==genotypeSymbol && ` (${this.props.totalStateCounts[filterName].get(item.value)})`}
           </span>
         </FilterBadge>
       ]));
@@ -263,7 +263,8 @@ class Info extends React.Component {
     Reflect.ownKeys(this.props.filters)
       .filter((filterName) => this.props.filters[filterName].length > 0)
       .forEach((filterName) => {
-        filtersByCategory.push({name: filterName===strainSymbol?'strain':filterName, badges: this.createFilterBadges(filterName)});
+        const name = filterName===strainSymbol ? 'strain' : filterName===genotypeSymbol ? 'genotype' : filterName;
+        filtersByCategory.push({name, badges: this.createFilterBadges(filterName)});
       });
     if (!datesMaxed) {
       filtersByCategory.push({name: 'temporal', badges: [this.makeFilteredDatesButton()]});

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -2,7 +2,7 @@ import queryString from "query-string";
 import * as types from "../actions/types";
 import { numericToCalendar } from "../util/dateHelpers";
 import { shouldDisplayTemporalConfidence } from "../reducers/controls";
-import { strainSymbol } from "../util/globals";
+import { genotypeSymbol, strainSymbol } from "../util/globals";
 
 /**
  * This middleware acts to keep the app state and the URL query state in sync by
@@ -61,8 +61,10 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       }
       break;
     case types.APPLY_FILTER: {
-      /* for historical reasons, strains get stored under the `s` query key */
-      const queryKey = action.trait === strainSymbol ? 's' : `f_${action.trait}`;
+      const queryKey = action.trait === strainSymbol ? 's' : // for historical reasons, strains get stored under the `s` query key
+        action.trait === genotypeSymbol ? "gt" :
+          `f_${action.trait}`;
+      // todo - decide how to store mutation filters. E.g. `gt=nuc:123T,456G,S:789K` ?
       query[queryKey] = action.values
         .filter((item) => item.active) // only active filters in the URL
         .map((item) => item.value)

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -3,6 +3,7 @@ import * as types from "../actions/types";
 import { numericToCalendar } from "../util/dateHelpers";
 import { shouldDisplayTemporalConfidence } from "../reducers/controls";
 import { genotypeSymbol, strainSymbol } from "../util/globals";
+import { encodeGenotypeFilters } from "../util/getGenotype";
 
 /**
  * This middleware acts to keep the app state and the URL query state in sync by
@@ -61,10 +62,12 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       }
       break;
     case types.APPLY_FILTER: {
+      if (action.trait === genotypeSymbol) {
+        query.gt = encodeGenotypeFilters(action.values);
+        break;
+      }
       const queryKey = action.trait === strainSymbol ? 's' : // for historical reasons, strains get stored under the `s` query key
-        action.trait === genotypeSymbol ? "gt" :
-          `f_${action.trait}`;
-      // todo - decide how to store mutation filters. E.g. `gt=nuc:123T,456G,S:789K` ?
+        `f_${action.trait}`;
       query[queryKey] = action.values
         .filter((item) => item.active) // only active filters in the URL
         .map((item) => item.value)

--- a/src/util/getGenotype.js
+++ b/src/util/getGenotype.js
@@ -76,13 +76,13 @@ export const encodeGenotypeFilters = (values) => {
     .filter((item) => item.active) // only active filters in the URL
     .map((item) => item.value)
     .reduce((map, value) => {
-      const [gene, mut] = value.split(":");
+      const [gene, mut] = value.split(" ");
       if (!map.has(gene)) map.set(gene, []);
       map.get(gene).push(mut);
       return map;
     }, new Map());
   return Array.from(geneToMuts.entries())
-    .map(([gene, muts]) => `${gene}:${muts.join(',')}`)
+    .map(([gene, muts]) => `${gene}.${muts.join(',')}`)
     .join(",");
 };
 
@@ -94,11 +94,12 @@ export const decodeGenotypeFilters = (query) => {
   let currentGene;
   return query.split(',')
     .map((x) => {
-      if (x.includes(':')) {
-        currentGene = x.split(":")[0];
-        return x;
+      if (x.includes('.')) {
+        const parts = x.split(".");
+        currentGene = parts[0];
+        return parts.join(" ");
       }
-      return `${currentGene}:${x}`;
+      return `${currentGene} ${x}`;
     })
     .map((value) => ({active: true, value})); // all URL filters _start_ active
 };

--- a/src/util/getGenotype.js
+++ b/src/util/getGenotype.js
@@ -66,3 +66,40 @@ export const decodePositions = (positions, geneLength = 'Infinity') => {
     .map((x) => parseInt(x, 10))
     .filter((x) => x > 0 && x <= Math.floor(geneLength));
 };
+
+/**
+ * Encode genotype filters for storage in URL query state.
+ * (Query schema is undocumented, see `tests/genotype.test.js` for examples)
+ */
+export const encodeGenotypeFilters = (values) => {
+  const geneToMuts = values
+    .filter((item) => item.active) // only active filters in the URL
+    .map((item) => item.value)
+    .reduce((map, value) => {
+      const [gene, mut] = value.split(":");
+      if (!map.has(gene)) map.set(gene, []);
+      map.get(gene).push(mut);
+      return map;
+    }, new Map());
+  return Array.from(geneToMuts.entries())
+    .map(([gene, muts]) => `${gene}:${muts.join(',')}`)
+    .join(",");
+};
+
+/**
+ * Decode genotype filters stored in URL query state.
+ * Returns array of type FilterValue (i.e. object with props `value` {str} and `active` {bool})
+ */
+export const decodeGenotypeFilters = (query) => {
+  let currentGene;
+  return query.split(',')
+    .map((x) => {
+      if (x.includes(':')) {
+        currentGene = x.split(":")[0];
+        return x;
+      }
+      return `${currentGene}:${x}`;
+    })
+    .map((value) => ({active: true, value})); // all URL filters _start_ active
+};
+

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -225,3 +225,28 @@ export const getMapTilesSettings = () => {
     mapboxWordmark: true
   };
 };
+
+const aminoAcids = {
+  A: "Alanine",
+  R: "Arginine",
+  N: "Asparagine",
+  D: "Aspartic acid",
+  C: "Cysteine",
+  Q: "Glutamine",
+  E: "Glutamic acid",
+  G: "Glycine",
+  H: "Histidine",
+  I: "Isoleucine",
+  L: "Leucine",
+  K: "Lysine",
+  M: "Methionine",
+  F: "Phenylalanine",
+  P: "Proline",
+  S: "Serine",
+  T: "Threonine",
+  W: "Tryptophan",
+  Y: "Tyrosine",
+  V: "Valine"
+};
+
+export const getAminoAcidName = (x) => aminoAcids[x.toUpperCase()] || "Unknown";

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -205,6 +205,7 @@ export const isValueValid = (value) => {
   return true;
 };
 export const strainSymbol = Symbol('strain');
+export const genotypeSymbol = Symbol('genotype');
 
 /**
  * Address to fetch tiles from (including access key).

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -78,3 +78,25 @@ export const getAccessionFromNode = (node) => {
 /* see comment at top of this file */
 export const getUrlFromNode = (node) =>
   (node.node_attrs && node.node_attrs.url) ? node.node_attrs.url : undefined;
+
+/**
+ * Traverses the tree and returns a set of genotype states such as
+ * {"nuc:123A", "S:418K"}.
+ * Note 1: Only variable sites are considered.
+ * Note 2: Basal states are included in the returned value.
+ */
+export function collectGenotypeStates(nodes) {
+  const observedStates = new Set();
+  nodes.forEach((n) => {
+    if (n.branch_attrs && n.branch_attrs.mutations && Object.keys(n.branch_attrs.mutations).length) {
+      Object.entries(n.branch_attrs.mutations).forEach(([gene, mutations]) => {
+        mutations.forEach((m) => {
+          const [from, pos, to] = [m.slice(0, 1), m.slice(1, -1), m.slice(-1)];
+          observedStates.add(`${gene}:${pos}${to}`);
+          observedStates.add(`${gene}:${pos}${from}`); // ancestral state, relative to this node
+        });
+      });
+    }
+  });
+  return observedStates;
+}

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -92,8 +92,8 @@ export function collectGenotypeStates(nodes) {
       Object.entries(n.branch_attrs.mutations).forEach(([gene, mutations]) => {
         mutations.forEach((m) => {
           const [from, pos, to] = [m.slice(0, 1), m.slice(1, -1), m.slice(-1)];
-          observedStates.add(`${gene}:${pos}${to}`);
-          observedStates.add(`${gene}:${pos}${from}`); // ancestral state, relative to this node
+          observedStates.add(`${gene} ${pos}${to}`);
+          observedStates.add(`${gene} ${pos}${from}`); // ancestral state, relative to this node
         });
       });
     }

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -351,7 +351,7 @@ function performGenotypeFilterMatch(filtered, filters, nodes) {
  * The returned array will be sorted to improve readability.
  * @param {Array<string>} filters genotype filters
  */
-function createFilterConstellation(filters) {
+export function createFilterConstellation(filters) {
   return filters
     .map((x) => {
       const [gene, state] = x.split(' ');

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -289,7 +289,7 @@ function performGenotypeFilterMatch(filtered, filters, nodes) {
   if (!filtered) { // happens if there are no other filters in play
     filtered = Array.from({length: nodes.length}, () => true); // eslint-disable-line no-param-reassign
   }
-  const filterConstellationLong = createFilterConstellation(genotypeFilters)
+  const filterConstellationLong = createFilterConstellation(genotypeFilters);
   const nGt = filterConstellationLong.length; // Note: may not be the same as genotypeFilters.length
   // type basalGt: Array<string> // entries at index `i` are the basal nt / aa at genotypeFilters[i]
   const basalGt = new Array(nGt); // stores the basal nt / aa of the position
@@ -397,3 +397,12 @@ export function sortConstellationLongFn(a, b) {
   return 0;
 }
 
+export const getNumSelectedTips = (nodes, visibility) => {
+  let count = 0;
+  nodes.forEach((d, idx) => {
+    // nodes which are not inView have a visibility of NODE_NOT_VISIBLE
+    // so this check accounts for them as well
+    if (!d.hasChildren && visibility[idx] === NODE_VISIBLE) count += 1;
+  });
+  return count;
+};

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -290,7 +290,7 @@ function performGenotypeFilterMatch(filtered, filters, nodes) {
     filtered = Array.from({length: nodes.length}, () => true); // eslint-disable-line no-param-reassign
   }
   const filterConstellationLong = genotypeFilters.map((x) => {
-    const [gene, state] = x.split(':');
+    const [gene, state] = x.split(' ');
     return [gene, state.slice(0, -1), state.slice(-1)];
   });
   const nGt = filterConstellationLong.length; // same as genotypeFilters.length

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -249,63 +249,101 @@ export const calculateVisiblityAndBranchThickness = (tree, controls, dates) => {
   };
 };
 
+/**
+ * Compute whether each node is filtered (visibile) by any defined genotype filters.
+ *
+ * Idea behind how we check genotype filter matches:
+ * A "constellation" is a set of mutations -- for instance, the filters define such a set (see `filterConstellationLong`)
+ * We define `constellationMatchesPerNode` which, for each node, defines an array of values corresponding to that node's membership of the constellation.
+ * We recursively traverse the tree and use mutations (defined per node) to modulate this data.
+ * Note that we don't know the basal genotype for a given position until we have traversed the tree, thus we cannot test a nodes membership (of
+ * a constellation) until after traversal.
+ * Example:
+ *   genotypeFilters[i]: S:484K
+ *     the ith genotype filter specifies Spike residue 484 to be Lysine (K). Note that this may include E484K but also others.
+ *   constellationMatchesPerNode[nodeIdx][i]: false|true|undefined.
+ *     False means an observed mutation means this node has a residue that is _not_ K.
+ *     true means that an observed mutation informs us that this node _is_ K.
+ *     undefined means that no muts were observed during the traversal to this node, so we must rely on the basal state, which may not yet be known.
+ *
+ * Pseudo-typescript type declarations are added as comments, the intention of which is to help readability & understanding.
+ * @param {Array<bool>} filtered length nodes.length & in 1-1 correspondence
+ * @param {Object} filters
+ * @param {Array<TreeNode>} nodes
+ * @returns {Array<bool>}
+ */
 function performGenotypeFilterMatch(filtered, filters, nodes) {
-  // check visibility of nodes based on genotype, utilising tree structure
-  // todo: this has the potential to be rather slow. Timing / optimisaiton needed.
-  // todo: race condition re: root-sequence data
-  // note: rather similar (in spirit) to how we calculate entropy - can we refactor / combine / speed up?
-  // todo: the (new) "zoom to selected" isn't working with genotypes currently (as we're not calculating CA and storing as `idxOfFilteredRoot`)
-  // todo: the entropy view is sometimes broken after filtering by genotype, but this shouldn't be the case (we can filter by other traits which are homoplasic and it works)
+  // type genotypeFilters: Array<string> // active genotype filters. Examples: "nuc:123A", "S:484K" etc
   const genotypeFilters = Reflect.ownKeys(filters).includes(genotypeSymbol) ?
     filters[genotypeSymbol].filter((item) => item.active).map((item) => item.value) :
     false;
-  if (genotypeFilters && genotypeFilters.length) {
-    if (!filtered) { // happens if there are no other filters in play
-      filtered = Array.from({length: nodes.length}, () => true); // eslint-disable-line no-param-reassign
-    }
-    const filterConstellationLong = genotypeFilters.map((x) => {
-      const [gene, state] = x.split(':');
-      return [gene, state.slice(0, -1), state.slice(-1)];
-    });
-    const nGt = filterConstellationLong.length; // same as genotypeFilters.length
-    console.log("filterConstellationLong", filterConstellationLong);
-    // console.log(genotypeFilters, filterConstellation);
-    const recurse = (node, constellationMatch) => {
-      if (node.branch_attrs && node.branch_attrs.mutations && Object.keys(node.branch_attrs.mutations).length) {
-        const bmuts = node.branch_attrs.mutations;
-        for (let i=0; i<nGt; i++) {
-          // consider each individual genotype which the filter requests
-          // does this branch encode a mutation which means it matches this filter, or reverts away from it?
-          // modify the array-of-bools `constellationMatch` accordingly
-          if (bmuts[filterConstellationLong[i][0]]) {
-            // todo -- move these array creations out of the constellation loop & pre-compute for unique set of {gene,position} within `genotypeFilters`
-            const bposns = bmuts[filterConstellationLong[i][0]].map((m) => m.slice(1, -1));
-            const bmutsto = bmuts[filterConstellationLong[i][0]].map((m) => m.slice(-1));
-            const posIdx = bposns.indexOf(filterConstellationLong[i][1]);
-            if (posIdx!==-1) {
-              if (bmutsto[posIdx]===filterConstellationLong[i][2]) {
-                // we have branch mutation leading to the constellation mutation
-                console.log("Mutation observed @ ", node.name, bmuts[filterConstellationLong[i][0]][posIdx], "; node matches", genotypeFilters[i]);
-                constellationMatch[i] = true;
-              } else {
-                // we have branch mutation either leading away from the constellation mutation
-                // (or switching from a non-constellation mut to another non-constellation mut)
-                console.log("Mutation observed @ ", node.name, bmuts[filterConstellationLong[i][0]][posIdx], "; node doesn't match", genotypeFilters[i]);
-                constellationMatch[i] = false;
-              }
+  if (!genotypeFilters || !genotypeFilters.length) {
+    return filtered;
+  }
+
+  // todo: this has the potential to be rather slow. Timing / optimisation needed.
+  // note: rather similar (in spirit) to how we calculate entropy - can we refactor / combine / speed up?
+  // todo: the (new) "zoom to selected" isn't working with genotypes currently (as we're not calculating CA and storing as `idxOfFilteredRoot`)
+  // todo: the entropy view is sometimes broken after filtering by genotype, but this shouldn't be the case (we can filter by other traits which are homoplasic and it works)
+
+  if (!filtered) { // happens if there are no other filters in play
+    filtered = Array.from({length: nodes.length}, () => true); // eslint-disable-line no-param-reassign
+  }
+  const filterConstellationLong = genotypeFilters.map((x) => {
+    const [gene, state] = x.split(':');
+    return [gene, state.slice(0, -1), state.slice(-1)];
+  });
+  const nGt = filterConstellationLong.length; // same as genotypeFilters.length
+  // console.log("filterConstellationLong", filterConstellationLong);
+  // type basalGt: Array<string> // entries at index `i` are the basal nt / aa at genotypeFilters[i]
+  const basalGt = new Array(nGt); // stores the basal nt / aa of the position
+  // type constellationEntry: undefined | false | true
+  // type constellationMatch: Array<constellationEntry>
+  // type constellationMatchesPerNode: Array<constellationMatch>
+  const constellationMatchesPerNode = new Array(nodes.length);
+
+  const recurse = (node, constellationMatch) => {
+    if (node.branch_attrs && node.branch_attrs.mutations && Object.keys(node.branch_attrs.mutations).length) {
+      const bmuts = node.branch_attrs.mutations;
+      for (let i=0; i<nGt; i++) {
+        // does this branch encode a mutation which means it matches the ith filter, or reverts away from it?
+        if (bmuts[filterConstellationLong[i][0]]) {
+          // todo -- move these array creations out of the constellation loop & pre-compute for unique set of {gene,position} within `genotypeFilters`
+          const bposns = bmuts[filterConstellationLong[i][0]].map((m) => m.slice(1, -1));
+          const bmutsto = bmuts[filterConstellationLong[i][0]].map((m) => m.slice(-1));
+          const posIdx = bposns.indexOf(filterConstellationLong[i][1]);
+          if (posIdx!==-1) {
+            /* part I: does the mutation mean the node (at this idx) matches the ith entry in the constellation? */
+            if (bmutsto[posIdx]===filterConstellationLong[i][2]) { // branch mutation leading to the constellation mutation
+              constellationMatch[i] = true;
+            } else { // branch mutation meaning the inherited state does not match the constellation
+              constellationMatch[i] = false;
+            }
+            /* part II: store the basal state of this position (if not already defined) */
+            if (!basalGt[i]) {
+              // console.log("Hey - get basal from", bmuts[filterConstellationLong[i][0]][posIdx]);
+              basalGt[i] = bmuts[filterConstellationLong[i][0]][posIdx].slice(0, 1);
             }
           }
         }
       }
-      // filtered state is determined by checking if node (internal or leaf) has the "correct" constellation of mutations
-      // (if `filtered[idx]` was already `false` it means another filter (non-gt) excluded it)
-      filtered[node.arrayIdx] = filtered[node.arrayIdx] && constellationMatch.every((el) => el);
-      // recurse to children & pass down (copy of) `constellationMatch` which can then be modified by descendants
-      if (node.hasChildren) {
-        node.children.forEach((c) => recurse(c, [...constellationMatch]));
-      }
-    };
-    recurse(nodes[0], Array.from({length: nGt}, () => false)); // todo: 2nd arg depends on knowing root-sequence
-  }
-  return filtered;
+    }
+    constellationMatchesPerNode[node.arrayIdx] = constellationMatch;
+    // recurse to children & pass down (copy of) `constellationMatch` which can then be modified by descendants
+    if (node.hasChildren) {
+      node.children.forEach((c) => recurse(c, [...constellationMatch]));
+    }
+  };
+  recurse(nodes[0], Array.from({length: nGt}, () => undefined));
+
+  /* We can now compute whether the basal positions match the relevant filter */
+  const basalConstellationMatch = basalGt.map((basalState, i) => filterConstellationLong[i][2]===basalState);
+
+  // filtered state is determined by checking if each node has the "correct" constellation of mutations
+  return filtered.map((prevFilterValue, idx) => {
+    if (!prevFilterValue) return false; // means that another filter (non-gt) excluded it
+    return constellationMatchesPerNode[idx]
+      .map((match, i) => match===undefined ? basalConstellationMatch[i] : match) // See docstring for defn of `undefined` here
+      .every((el) => el);
+  });
 }

--- a/test/genotype.test.js
+++ b/test/genotype.test.js
@@ -1,0 +1,21 @@
+import { encodeGenotypeFilters, decodeGenotypeFilters } from "../src/util/getGenotype";
+
+const filtersToQuery = [
+  [[{active: true, value: "NS3:572L"}], "NS3:572L"],
+  [[{active: true, value: "NS3:572L"}, {active: true, value: "NS3:40I"}], "NS3:572L,40I"],
+  [[{active: true, value: "NS3:572L"}, {active: false, value: "NS3:40I"}], "NS3:572L"],
+  [[{active: true, value: "g1:a"}, {active: true, value: "g1:b"}, {active: true, value: "g2:c"}], "g1:a,b,g2:c"]
+];
+
+test("Genotype filters are correctly encoded for the URL", () => {
+  filtersToQuery.forEach(([filterValues, expectedQuery]) => {
+    expect(encodeGenotypeFilters(filterValues)).toStrictEqual(expectedQuery);
+  });
+});
+
+test("Genotype URL queries are correctly decoded", () => {
+  filtersToQuery.forEach(([filterValues, expectedQuery]) => {
+    const activeFilterValues = filterValues.filter((v) => v.active); // URLs only encode the active filters
+    expect(decodeGenotypeFilters(expectedQuery)).toStrictEqual(activeFilterValues);
+  });
+});

--- a/test/genotype.test.js
+++ b/test/genotype.test.js
@@ -1,10 +1,10 @@
 import { encodeGenotypeFilters, decodeGenotypeFilters } from "../src/util/getGenotype";
 
 const filtersToQuery = [
-  [[{active: true, value: "NS3:572L"}], "NS3:572L"],
-  [[{active: true, value: "NS3:572L"}, {active: true, value: "NS3:40I"}], "NS3:572L,40I"],
-  [[{active: true, value: "NS3:572L"}, {active: false, value: "NS3:40I"}], "NS3:572L"],
-  [[{active: true, value: "g1:a"}, {active: true, value: "g1:b"}, {active: true, value: "g2:c"}], "g1:a,b,g2:c"]
+  [[{active: true, value: "NS3 572L"}], "NS3.572L"],
+  [[{active: true, value: "NS3 572L"}, {active: true, value: "NS3 40I"}], "NS3.572L,40I"],
+  [[{active: true, value: "NS3 572L"}, {active: false, value: "NS3 40I"}], "NS3.572L"],
+  [[{active: true, value: "g1 a"}, {active: true, value: "g1 b"}, {active: true, value: "g2 c"}], "g1.a,b,g2.c"]
 ];
 
 test("Genotype filters are correctly encoded for the URL", () => {

--- a/test/genotype.test.js
+++ b/test/genotype.test.js
@@ -1,4 +1,5 @@
 import { encodeGenotypeFilters, decodeGenotypeFilters } from "../src/util/getGenotype";
+import { sortConstellationLongFn } from "../src/util/treeVisibilityHelpers";
 
 const filtersToQuery = [
   [[{active: true, value: "NS3 572L"}], "NS3.572L"],
@@ -17,5 +18,31 @@ test("Genotype URL queries are correctly decoded", () => {
   filtersToQuery.forEach(([filterValues, expectedQuery]) => {
     const activeFilterValues = filterValues.filter((v) => v.active); // URLs only encode the active filters
     expect(decodeGenotypeFilters(expectedQuery)).toStrictEqual(activeFilterValues);
+  });
+});
+
+
+const constellationsToSort = [
+  [ // singleton
+    [["HA1", "186", "D"]],
+    [["HA1", "186", "D"]]
+  ],
+  [ // residues are alphabetical
+    [["HA1", "186", "S"], ["HA1", "186", "D"]],
+    [["HA1", "186", "D"], ["HA1", "186", "S"]]
+  ],
+  [ // bases are numerically sorted
+    [["HA1", "186", "S"], ["HA1", "91", "X"]],
+    [["HA1", "91", "X"], ["HA1", "186", "S"]]
+  ],
+  [ // genes are sorted alphabetically, with "nuc" last
+    [["BBB", "1", "B"], ["nuc", "0", "N"], ["AAA", "2", "A"]],
+    [["AAA", "2", "A"], ["BBB", "1", "B"], ["nuc", "0", "N"]]
+  ]
+];
+
+test("Genotype sorting function", () => {
+  constellationsToSort.forEach(([unsorted, sorted]) => {
+    expect(unsorted.sort(sortConstellationLongFn)).toStrictEqual(sorted);
   });
 });


### PR DESCRIPTION
_This comment was updated Jan 22nd_

### PR Status
Ready for review. I believe there are no bugs (see below) but testing is required and performance may not be good enough for release.

### Summary
This PR adds genotype filters to the side-bar dropdown allowing filtering of the dataset by any observed genotype, as long as it was at a variable site.
 
### Notes and example URLs

_Updated to relect the changes introduced in 3ca2c02_

* Example of N501Y + D614G + P681H which corresponds to 20I/501Y.v1 / B.1.1.17: https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?gt=S.501Y,614G,681H
* Example of N501Y + E484K, a constellation which is so far shared by 20J/501Y.V3 and 20H/501Y.V2: https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?gt=S.501Y,484K
* Example of a basal "mutation": https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?gt=S.982S
* Example of a mutation at a variable site but which is not observed in the data, which is silently removed at load: https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?gt=S.982S
* Example of a genotype state (nuc:502A) which does exist, but is at a non-variable site. The filter is silently removed: https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?c=gt-nuc_502&gt=nuc.502A
* "zoom-to-selected" hasn't been considered and doesn't work as it ideally should. This seems to require the same fix as that which  @joverlee521 is currently working on.
* ~Initial rendering of the filtering-dropdown is very slow. [This](https://codesandbox.io/s/lxv7omv65l?file=/index.js) seems to be one solution, which I may add in this PR or via another PR.~ See below for update.
* We don't yet allow OR filtering for the same position, thus one cannot filter by (e.g.) `S 501Y || S 501T` https://auspice-filter-by-genot-lf7x8o.herokuapp.com/ncov/global?gt=S.501Y,501T

cc @kairstenfay @joverlee521 @trvrb @eharkins @huddlej re: this morning's meeting, any testing would be super useful!

