### PR TITLE
Statically define value which will always be false

### DIFF
--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -433,7 +433,7 @@ class Map extends React.Component {
       );
 
       this.moveMapAccordingToData({
-        geoResolutionChanged: nextProps.geoResolution !== this.props.geoResolution,
+        geoResolutionChanged: false,
         visibilityChanged: nextProps.visibility !== this.props.visibility,
         demeData: newDemes,
         demeIndices: this.state.demeIndices


### PR DESCRIPTION
At this '!==' operation, left operand 'nextProps.geoResolution' and
right operand 'this.props.geoResolution' always have the same value
because of the condition
`this.props.geoResolution !== nextProps.geoResolution` above.

### Description of proposed changes    
Simplifies a small chunk of code by statically defining the boolean value `false`. 