### PR TITLE
Webpack hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auspice",
-  "version": "2.22.0",
+  "version": "2.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17956,14 +17956,6 @@
         "mkdirp": "^0.5.1",
         "opener": "^1.5.1",
         "ws": "^6.0.0"
-      }
-    },
-    "webpack-chunk-hash": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/webpack-chunk-hash/-/webpack-chunk-hash-0.6.0.tgz",
-      "integrity": "sha512-FsOg1RpW2nf3nYpGTy/Qs59RZ7gYG+sI4VrCE8TIBQYh/Kogi04xD39Pj9zUEeUcNx9HeTVPGSO3mtmpLeX9eQ==",
-      "requires": {
-        "@types/webpack": "^3.0.0 || ^4.0.0"
       }
     },
     "webpack-cli": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "typeface-lato": "^0.0.75",
     "webpack": "^4.30.0",
     "webpack-bundle-analyzer": "^3.3.2",
-    "webpack-chunk-hash": "^0.6.0",
     "webpack-cli": "^3.1.2",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.24.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 const utils = require('./cli/utils');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const WebpackChunkHash = require('webpack-chunk-hash');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 
 /* Webpack config generator */
@@ -97,7 +96,6 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
   ] : [
     new LodashModuleReplacementPlugin(),
     pluginProcessEnvData,
-    new WebpackChunkHash({algorithm: 'md5'}),
     pluginCompress,
     pluginHtml,
     cleanWebpackPlugin


### PR DESCRIPTION
### Description of proposed changes    
Drop third party webpack-chunk-hash library which appears to be abandonware and is causing unexpected behavior in our cached auspice files. 

### Related issue(s)  

Fixes #1266 

### Testing
Follow James's [handy list of steps to reproduce the initial bug](https://github.com/nextstrain/auspice/issues/1266#issue-786386345).
With this patch, the entropy panel is no longer broken when cache is not disabled.
In step 17, the bundles also have identical contents.
