### PR TITLE
increase max number mutations to display in hover.js

### DIFF
--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -150,7 +150,7 @@ const Mutations = ({node, t}) => {
   /* --------- NUCLEOTIDE MUTATIONS --------------- */
   /* Nt mutations are found at `mutations.nuc` -> Array of strings */
   if (mutations.nuc && mutations.nuc.length) {
-    const nDisplay = 9; // max number of mutations to display
+    const nDisplay = 21; // max number of mutations to display
 
     const isMutGap = (mut) => mut.slice(-1) === "-" || mut.slice(0, 1) === "-";
     const isMutUnknown = (mut) => mut.slice(-1) === "N" || mut.slice(0, 1) === "N";
@@ -196,8 +196,8 @@ const Mutations = ({node, t}) => {
     }
   }
   if (shouldDisplay) {
-    const nDisplay = 3; // number of mutations to display per protein
-    const nProtsToDisplay = 7; // max number of proteins to display
+    const nDisplay = 10; // number of mutations to display per protein
+    const nProtsToDisplay = 8; // max number of proteins to display
     const mutationsToRender = [];
     Object.keys(mutationsToDisplay).forEach((prot, idx) => {
       if (idx < nProtsToDisplay) {

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -150,7 +150,7 @@ const Mutations = ({node, t}) => {
   /* --------- NUCLEOTIDE MUTATIONS --------------- */
   /* Nt mutations are found at `mutations.nuc` -> Array of strings */
   if (mutations.nuc && mutations.nuc.length) {
-    const nDisplay = 21; // max number of mutations to display
+    const nDisplay = 25; // max number of mutations to display
 
     const isMutGap = (mut) => mut.slice(-1) === "-" || mut.slice(0, 1) === "-";
     const isMutUnknown = (mut) => mut.slice(-1) === "N" || mut.slice(0, 1) === "N";
@@ -196,7 +196,7 @@ const Mutations = ({node, t}) => {
     }
   }
   if (shouldDisplay) {
-    const nDisplay = 10; // number of mutations to display per protein
+    const nDisplay = 12; // number of mutations to display per protein
     const nProtsToDisplay = 8; // max number of proteins to display
     const mutationsToRender = [];
     Object.keys(mutationsToDisplay).forEach((prot, idx) => {

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -283,7 +283,7 @@ const AttributionInfo = ({node}) => {
 const Container = ({node, panelDims, children}) => {
   const xOffset = 10;
   const yOffset = 10;
-  const width = 200;
+  const width = (!node.branch_attrs || !node.branch_attrs.mutations || !node.branch_attrs.mutations.nuc) ? 200 : ((node.branch_attrs.mutations.nuc.length > 15) ? 400 : 200);
 
   /* this adjusts the x-axis for the right tree in dual tree view */
   const xPos = node.shell.that.params.orientation[0] === -1 ?


### PR DESCRIPTION
### Description of proposed changes    
increase max number mutations to display in hover.js

### Testing
Tested on time and divergence tree of https://nextstrain.org/charon/getDataset?prefix=/groups/neherlab/ncov/S.E484
and https://nextstrain.org/groups/blab/sars-like-cov

No exception raised. 
Away from long branches the normal behavior is preserved