### PR TITLE
controls/filter: Avoid spread syntax with potentially large arrays

### DIFF
--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -61,11 +61,14 @@ class FilterData extends React.Component {
           });
       });
     if (genotypeSymbol in this.props.activeFilters) {
-      const sortedGenotypes = [...collectGenotypeStates(this.props.nodes)].sort();
-      options.push(...sortedGenotypes.map((o) => ({
-        label: `genotype ${o}`,
-        value: [genotypeSymbol, o]
-      })));
+      Array.from(collectGenotypeStates(this.props.nodes))
+        .sort()
+        .forEach((o) => {
+          options.push({
+            label: `genotype ${o}`,
+            value: [genotypeSymbol, o]
+          });
+        });
     }
     if (strainSymbol in this.props.activeFilters) {
       this.props.nodes


### PR DESCRIPTION
Push each value individually instead of all at once, which results in
more method calls but a much smaller call stack size.  Alternatively,
Array.concat could be used, but this follows the pattern of surrounding
code and avoids reassignment of "options", which would also necessitate
removal of the "const" declaration.

The /tb/global build has ~277k genotype states, which resulted in a call
to Array.push with as many arguments when the spread syntax was used.
This blew through the call stack size limit on Chrome with an error
like:

    RangeError: Maximum call stack size exceeded
        at FilterData.eval [as makeOptions] (filter.js?6bcb:65)
        at FilterData.render (filter.js?6bcb:100)
        …

Firefox was unaffected, so presumably has a larger limit.

Debugging was waylaid for a bit by the assumption that exceeding the
call stack size necessarily meant deep recursion, but the lack of a deep
stack trace led to the realization that it can also occur when a
function's arguments are too many.

Resolves #1292.

