### PR TITLE
Correctly format BCE dates

### DIFF
--- a/src/util/dateHelpers.js
+++ b/src/util/dateHelpers.js
@@ -153,7 +153,13 @@ export const prettifyDate = (unit, date) => {
   const stringDate = typeof date ==="number" ? numericToCalendar(date) :
     date instanceof Date ? dateToString(date) :
       date;
-  const [year, month, day] = stringDate.split("-");
+  let year, month, day;
+  if (!stringDate.startsWith("-")) {
+    [year, month, day] = stringDate.split("-");
+  } else {
+    [year, month, day] = stringDate.slice(1).split("-");
+    year = `-${year}`;
+  }
   switch (unit) {
     case "CENTURY": // falls through
     case "DECADE": // falls through

--- a/test/dates.test.js
+++ b/test/dates.test.js
@@ -91,4 +91,5 @@ test("dates are prettified as expected", () => {
   expect(prettifyDate("YEAR", "2020-01-01")).toStrictEqual("2020");
   expect(prettifyDate("MONTH", "2020-01-05")).toStrictEqual("2020-Jan-05");
   expect(prettifyDate("MONTH", "2020-01-01")).toStrictEqual("2020-Jan");
+  expect(prettifyDate("CENTURY", "-3000-01-01")).toStrictEqual("-3000"); // BCE
 });


### PR DESCRIPTION
BCE dates were correctly interpreted but incorrectly rendered
due to a bug in the final string-prettying step. This would
result in a tree with the correct layout and positioning, but
incorrect labels ("-undefined"). This commit remedies this and
adds a test.

Closes #1294