### PR TITLE
[frequencies panel] Don't round frequencies below 1%

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -277,7 +277,8 @@ export const drawStream = (
     /* what's the closest pivot? */
     const date = scales.x.invert(mousex);
     const pivotIdx = pivots.reduce((closestIdx, val, idx, arr) => Math.abs(val - date) < Math.abs(arr[closestIdx] - date) ? idx : closestIdx, 0);
-    const freqVal = Math.round((d[pivotIdx][1] - d[pivotIdx][0]) * 100) + "%";
+    const frequency = (d[pivotIdx][1] - d[pivotIdx][0]) * 100;
+    const freqVal = frequency < 1 ? "<1%" : Math.round(frequency) + "%";
     const xValueOfPivot = scales.x(pivots[pivotIdx]);
     const y1ValueOfPivot = scales.y(d[pivotIdx][1]);
     const y2ValueOfPivot = scales.y(d[pivotIdx][0]);


### PR DESCRIPTION
When a frequency value is below 1% we now display "<1%" rather than rounding to the nearest integer which could lead to confusing output of  "frequency: 0%".

Closes #1279