### PR TITLE
Legend no longer obscures branches/tips.

### DIFF
--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -279,6 +279,10 @@ export const mapToScreen = function mapToScreen() {
     right: this.params.margins.right,
     top: this.params.margins.top,
     bottom: this.params.margins.bottom};
+  if (this.layout==="rect" || this.layout==="unrooted") {
+    // legend is 12px, but 6px is enough to prevent tips being obscured
+    tmpMargins.top += 6;
+  }
   const inViewTerminalNodes = this.nodes.filter((d) => d.terminal).filter((d) => d.inView);
   if (inViewTerminalNodes.length < this.params.tipLabelBreakL1) {
 


### PR DESCRIPTION
Shifts the top of the tree down slightly so that tips and branches cannot be hidden behind the (closed) legend, which prevents interacting with them. This only happens in rectangular / unrooted trees, as radial / clock views almost never have tips rendered in the top-left corner.

![image](https://user-images.githubusercontent.com/8350992/110555400-6d653880-81a1-11eb-8716-7399d7f1267b.png)
_Note that the horizontal position of the tips in this screenshot has been changed for testing purposes_

This PR is a trade off -- we reduce the available display space for all (rectangular & unrooted) trees to prevent the (rare) cases of tips being rendered in the top-left corner and thus obscured by the legend. A more intelligent solution would be to make `mapToScreen()` aware of when tips are rendered behind the legend and only increase the margin in this case.

Closes #1295

