### PR TITLE
Allow JSONs to define language

### DIFF
--- a/docs/advanced-functionality/view-settings.md
+++ b/docs/advanced-functionality/view-settings.md
@@ -37,7 +37,7 @@ For instance, if you set `display_defaults.color_by` to `country`, but load the 
 | `branch_label`      | Which set of branch labels are to be displayed | "aa", "lineage" |
 | `panels`            | List of panels which (if available) are to be displayed  | ["tree", "map"] |
 | `transmission_lines`| Should transmission lines (if available) be rendered on the map?  | Boolean |
-
+| `language`          | Language to display Auspice in  | "ja" |
 
 Note that `meta.display_defaults.panels` (optional) differs from `meta.panels` (required), where the latter lists the possible panels that auspice may display for the dataset.
 See the [JSON schema](https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json) for more details.

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -661,6 +661,7 @@ const createMetadataStateFromJSON = (json) => {
       branch_label: "selectedBranchLabel",
       map_triplicate: "mapTriplicate",
       layout: "layout",
+      language: "language",
       sidebar: "sidebar",
       panels: "panels",
       transmission_lines: "showTransmissionLines"

--- a/src/components/controls/language.js
+++ b/src/components/controls/language.js
@@ -19,8 +19,12 @@ class Language extends React.Component {
   async ensureLanguageResources(lang) {
     for (const ns of ["language", "sidebar", "translation"]) {
       if (!i18n.hasResourceBundle(lang, ns)) {
-        const res = await import(/* webpackMode: "lazy-once" */ `../../locales/${lang}/${ns}.json`); // eslint-disable-line
-        i18n.addResourceBundle(lang, ns, res.default);
+        try {
+          const res = await import(/* webpackMode: "lazy-once" */ `../../locales/${lang}/${ns}.json`); // eslint-disable-line
+          i18n.addResourceBundle(lang, ns, res.default);
+        } catch (err) {
+          console.error(`Language ${lang} not found!`);
+        }
       }
     }
   }

--- a/src/reducers/general.js
+++ b/src/reducers/general.js
@@ -46,6 +46,12 @@ const general = (state = {
       return Object.assign({}, state, {
         language: action.data
       });
+    case types.CLEAN_START:
+      const defaultLanguage = action.metadata.displayDefaults["language"] || defaults.language;
+      return Object.assign({}, state, {
+        defaults: Object.assign({}, state.defaults, {language: defaultLanguage}),
+        language: query.lang ? query.lang : defaultLanguage
+      });
     default:
       return state;
   }


### PR DESCRIPTION
This is a squashed & rebased version of PR #1221,
which itself superseded PR #1218.

Closes #1049.

Co-authored-by: @charlie-jones 
Co-authored-by: @eharkins 
