### PR TITLE
Allow node traits to define URLs

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -96,8 +96,7 @@ const MutationTable = ({mutations}) => {
 
 
 const AccessionAndUrl = ({node}) => {
-  const accession = getAccessionFromNode(node);
-  const url = getUrlFromNode(node);
+  const {accession, url} = getAccessionFromNode(node);
   const genbank_accession = getTraitFromNode(node, "genbank_accession");
 
   /* `gisaid_epi_isl` is a special value attached to nodes introduced during the 2019 nCoV outbreak.
@@ -230,10 +229,16 @@ const Trait = ({node, trait, colorings}) => {
       value = Number.parseFloat(value_tmp).toPrecision(3);
     }
   }
+  if (!isValueValid(value)) return null;
+
   const name = (colorings && colorings[trait] && colorings[trait].title) ?
     colorings[trait].title :
     trait;
-  return isValueValid(value) ? item(name, value) : null;
+  const url = getUrlFromNode(node, trait);
+  if (url) {
+    return <Link title={name} url={formatURL(url)} value={value}/>;
+  }
+  return item(name, value);
 };
 
 /**

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -42,15 +42,6 @@ const item = (key, value, href) => (
   </tr>
 );
 
-const formatURL = (url) => {
-  if (url !== undefined && url.startsWith("https_")) {
-    return url.replace("https_", "https:");
-  } else if (url !== undefined && url.startsWith("http_")) {
-    return url.replace("http_", "http:");
-  }
-  return url;
-};
-
 const Link = ({url, title, value}) => (
   <tr>
     <th style={infoPanelStyles.item}>{title}</th>
@@ -96,12 +87,10 @@ const MutationTable = ({mutations}) => {
 
 
 const AccessionAndUrl = ({node}) => {
-  const {accession, url} = getAccessionFromNode(node);
-  const genbank_accession = getTraitFromNode(node, "genbank_accession");
-
-  /* `gisaid_epi_isl` is a special value attached to nodes introduced during the 2019 nCoV outbreak.
-  If set, the display is different from the normal behavior */
+  /* If `gisaid_epi_isl` or `genbank_accession` exist as node attrs, these preempt normal use of `accession` and `url`.
+  These special values were introduced during the 2019 nCoV outbreak. */
   const gisaid_epi_isl = getTraitFromNode(node, "gisaid_epi_isl");
+  const genbank_accession = getTraitFromNode(node, "genbank_accession");
   if (isValueValid(gisaid_epi_isl)) {
     return (
       <>
@@ -113,22 +102,24 @@ const AccessionAndUrl = ({node}) => {
       </>
     );
   }
-
   if (isValueValid(genbank_accession)) {
     return (
       <Link title={"Genbank accession"} value={genbank_accession} url={"https://www.ncbi.nlm.nih.gov/nuccore/" + genbank_accession}/>
     );
-  } else if (isValueValid(accession) && isValueValid(url)) {
+  }
+
+  const {accession, url} = getAccessionFromNode(node);
+  if (accession && url) {
     return (
-      <Link url={formatURL(url)} value={accession} title={"Accession"}/>
+      <Link url={url} value={accession} title={"Accession"}/>
     );
-  } else if (isValueValid(accession)) {
+  } else if (accession) {
     return (
       item("Accession", accession)
     );
-  } else if (isValueValid(url)) {
+  } else if (url) {
     return (
-      <Link title={"Strain URL"} url={formatURL(url)} value={"click here"}/>
+      <Link title={"Strain URL"} url={url} value={"click here"}/>
     );
   }
   return null;
@@ -236,7 +227,7 @@ const Trait = ({node, trait, colorings}) => {
     trait;
   const url = getUrlFromNode(node, trait);
   if (url) {
-    return <Link title={name} url={formatURL(url)} value={value}/>;
+    return <Link title={name} url={url} value={value}/>;
   }
   return item(name, value);
 };

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -218,7 +218,7 @@ const SampleDate = ({node, t}) => {
 const getTraitsToDisplay = (node) => {
   // TODO -- this should be centralised somewhere
   if (!node.node_attrs) return [];
-  const ignore = ["author", "div", "num_date", "gisaid_epi_isl", "genbank_accession"];
+  const ignore = ["author", "div", "num_date", "gisaid_epi_isl", "genbank_accession", "accession", "url"];
   return Object.keys(node.node_attrs).filter((k) => !ignore.includes(k));
 };
 

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -69,15 +69,25 @@ export const getFullAuthorInfoFromNode = (node) =>
 
 export const getAccessionFromNode = (node) => {
   /* see comment at top of this file */
-  if (node.node_attrs && node.node_attrs.accession) {
-    return node.node_attrs.accession;
+  let accession, url;
+  if (node.node_attrs) {
+    if (isValueValid(node.node_attrs.accession)) {
+      accession = node.node_attrs.accession;
+    }
+    if (typeof node.node_attrs.url === "string") {
+      url = node.node_attrs.url;
+    }
   }
-  return undefined;
+  return {accession, url};
 };
 
 /* see comment at top of this file */
-export const getUrlFromNode = (node) =>
-  (node.node_attrs && node.node_attrs.url) ? node.node_attrs.url : undefined;
+export const getUrlFromNode = (node, trait) => {
+  if (node.node_attrs && node.node_attrs[trait] && typeof node.node_attrs[trait].url === "string") {
+    return node.node_attrs[trait].url;
+  }
+  return undefined;
+};
 
 /**
  * Traverses the tree and returns a set of genotype states such as

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -74,20 +74,37 @@ export const getAccessionFromNode = (node) => {
     if (isValueValid(node.node_attrs.accession)) {
       accession = node.node_attrs.accession;
     }
-    if (typeof node.node_attrs.url === "string") {
-      url = node.node_attrs.url;
-    }
+    url = validateUrl(node.node_attrs.url);
   }
   return {accession, url};
 };
 
 /* see comment at top of this file */
 export const getUrlFromNode = (node, trait) => {
-  if (node.node_attrs && node.node_attrs[trait] && typeof node.node_attrs[trait].url === "string") {
-    return node.node_attrs[trait].url;
-  }
-  return undefined;
+  if (!node.node_attrs || !node.node_attrs[trait]) return undefined;
+  return validateUrl(node.node_attrs[trait].url);
 };
+
+/**
+ * Check if a URL seems valid & return it.
+ * For historical reasons, we allow URLs to be defined as `http[s]_` and coerce these into `http[s]:`
+ * URls are interpreted by `new URL()` and thus may be returned with a trailing slash
+ * @param {String} url URL string to validate
+ * @returns {String|undefined} potentially modified URL string or `undefined` (if it doesn't seem valid)
+ */
+function validateUrl(url) {
+  if (url===undefined) return undefined; // urls are optional, so return early to avoid the console warning
+  try {
+    if (typeof url !== "string") throw new Error();
+    if (url.startsWith("http_")) url = url.replace("http_", "http:"); // eslint-disable-line no-param-reassign
+    if (url.startsWith("https_")) url = url.replace("https_", "https:"); // eslint-disable-line no-param-reassign
+    const urlObj = new URL(url);
+    return urlObj.href;
+  } catch (err) {
+    console.warn(`Dataset provided the invalid URL ${url}`);
+    return undefined;
+  }
+}
 
 /**
  * Traverses the tree and returns a set of genotype states such as


### PR DESCRIPTION
This PR extends traits defined on nodes to allow an optional `url` property, which results in a link being rendered in the tip-clicked panel.

As an example, this allows the following node structure to be rendered as follows:

```json
"node_attrs": {
  "originating_lab": {
    "value": "Area of Virology, Serology and Virology Division (SAViD), New South Wales Health Pathology Randwick"
  },
  "pangolin_lineage": {
    "value": "B.1.1.7",
    "url": "https://cov-lineages.org/lineages/lineage_B.1.1.7.html"
  },
  "recency": {
    "value": "Older"
  },
```

![image](https://user-images.githubusercontent.com/8350992/111717466-f32d6600-88bc-11eb-952d-d220ccc6a5c7.png)

(P.S. `colorings` in the dataset JSON provides a title for `pangolin_lineage`, `recency` and `originating_lab`, which results in them being rendered as `PANGO Lineage`,  `Submission Date` and `Originating Lab`).

Additionally the code around processing URL strings has been improved and tests added.

Closes #1307
