### PR TITLE
Scatterplots

### DIFF
--- a/docs/advanced-functionality/view-settings.md
+++ b/docs/advanced-functionality/view-settings.md
@@ -33,7 +33,7 @@ For instance, if you set `display_defaults.color_by` to `country`, but load the 
 | `geo_resolution`    | Geographic resolution | "country" |
 | `distance_measure`  | Phylogeny x-axis measure     | "div" or "num_date" |
 | `map_triplicate`    | Should the map repeat, so that you can pan further in each direction? | Boolean |
-| `layout`            | Tree layout        | "rect", "radial", "clock" or "unrooted |
+| `layout`            | Tree layout        | "rect", "radial", "unrooted", "clock" or "scatter" |
 | `branch_label`      | Which set of branch labels are to be displayed | "aa", "lineage" |
 | `panels`            | List of panels which (if available) are to be displayed  | ["tree", "map"] |
 | `transmission_lines`| Should transmission lines (if available) be rendered on the map?  | Boolean |
@@ -58,6 +58,11 @@ All URL queries modify the view away from the default settings -- if you change 
 | `r`        | Geographic resolution | `r=region` |
 | `m`        | Phylogeny x-axis measure | `m=div` |
 | `l`        | Phylogeny layout | `l=clock` |
+| `scatterX` | Scatterplot X variable | `scatterX=num_date` |
+| `scatterY` | Scatterplot Y variable | `scatterY=num_date` |
+| `branches` | Hide branches | `branches=hide` |
+| `regression` | Show/Hide regression line | `regression=hide`, `regression=show` |
+| `transmissions` | Hide transmission lines | `transmissions=hide`|
 | `lang`     | Language | `lang=ja` (Japanese) |
 | `dmin`     | Temporal range (minimum) | `dmin=2008-05-13` |
 | `dmax`     | Temporal range (maximum) | `dmax=2010-05-13` |

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -14,6 +14,7 @@ import { determineColorByGenotypeMutType, calcNodeColor } from "../util/colorHel
 import { calcColorScale, createVisibleLegendValues } from "../util/colorScale";
 import { computeMatrixFromRawData, checkIfNormalizableFromRawData } from "../util/processFrequencies";
 import { applyInViewNodesToTree } from "../actions/tree";
+import { getStartingScatterVariables } from "../util/scatterplotHelpers";
 import { isColorByGenotype, decodeColorByGenotype, decodeGenotypeFilters, encodeGenotypeFilters } from "../util/getGenotype";
 import { getTraitFromNode, getDivFromNode, collectGenotypeStates } from "../util/treeMiscHelpers";
 import { collectAvailableTipLabelOptions } from "../components/controls/choose-tip-label";
@@ -556,7 +557,7 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree, viewingNarra
   /* if we are starting in a scatterplot layout, we need to ensure we have x & v variables */
   // todo: these should be URL query & JSON definable (and stored as defaults)
   if (state.layout==="scatter") {
-    state.scatterVariables = {x: state.distanceMeasure, y: state.colorBy};
+    state.scatterVariables = getStartingScatterVariables(metadata.colorings, state.distanceMeasure, state.colorBy);
   }
   return state;
 };

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -14,7 +14,7 @@ import { determineColorByGenotypeMutType, calcNodeColor } from "../util/colorHel
 import { calcColorScale, createVisibleLegendValues } from "../util/colorScale";
 import { computeMatrixFromRawData, checkIfNormalizableFromRawData } from "../util/processFrequencies";
 import { applyInViewNodesToTree } from "../actions/tree";
-import { getStartingScatterVariables } from "../util/scatterplotHelpers";
+import { validateScatterVariables } from "../util/scatterplotHelpers";
 import { isColorByGenotype, decodeColorByGenotype, decodeGenotypeFilters, encodeGenotypeFilters } from "../util/getGenotype";
 import { getTraitFromNode, getDivFromNode, collectGenotypeStates } from "../util/treeMiscHelpers";
 import { collectAvailableTipLabelOptions } from "../components/controls/choose-tip-label";
@@ -554,10 +554,12 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree, viewingNarra
     state.sidebarOpen=true;
   }
 
-  /* if we are starting in a scatterplot layout, we need to ensure we have x & v variables */
+  /* if we are starting in a scatterplot-like layout, we need to ensure we have `scatterVariables`
+  If not, we deliberately don't instantiate them, so that they are instantiated when first
+  triggering a scatterplot, thus defaulting to the colorby in use at that time */
   // todo: these should be URL query & JSON definable (and stored as defaults)
-  if (state.layout==="scatter") {
-    state.scatterVariables = getStartingScatterVariables(metadata.colorings, state.distanceMeasure, state.colorBy);
+  if (state.layout==="scatter" || state.layout==="clock") {
+    state.scatterVariables = validateScatterVariables({}, metadata.colorings, state.distanceMeasure, state.colorBy, state.layout==="clock");
   }
   return state;
 };

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -553,6 +553,11 @@ const checkAndCorrectErrorsInState = (state, metadata, query, tree, viewingNarra
     state.sidebarOpen=true;
   }
 
+  /* if we are starting in a scatterplot layout, we need to ensure we have x & v variables */
+  // todo: these should be URL query & JSON definable (and stored as defaults)
+  if (state.layout==="scatter") {
+    state.scatterVariables = {x: state.distanceMeasure, y: state.colorBy};
+  }
   return state;
 };
 

--- a/src/components/controls/choose-branch-labelling.js
+++ b/src/components/controls/choose-branch-labelling.js
@@ -9,7 +9,8 @@ import { controlsWidth } from "../../util/globals";
 
 @connect((state) => ({
   selected: state.controls.selectedBranchLabel,
-  available: state.tree.availableBranchLabels
+  available: state.tree.availableBranchLabels,
+  canRenderBranchLabels: state.controls.canRenderBranchLabels
 }))
 class ChooseBranchLabelling extends React.Component {
   constructor(props) {
@@ -17,6 +18,7 @@ class ChooseBranchLabelling extends React.Component {
     this.change = (value) => {this.props.dispatch({type: CHANGE_BRANCH_LABEL, value: value.value});};
   }
   render() {
+    if (!this.props.canRenderBranchLabels) return null;
     const { t } = this.props;
     return (
       <div style={{paddingTop: 5}}>

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -13,6 +13,7 @@ import { collectScatterVariables, getStartingScatterVariables } from "../../util
 import { CHANGE_LAYOUT } from "../../actions/types";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { SidebarSubtitle, SidebarButton } from "./styles";
+import Toggle from "./toggle";
 
 
 const RectangularTreeIcon = withTheme(icons.RectangularTree);
@@ -47,7 +48,7 @@ class ChooseLayout extends React.Component {
       this.props.dispatch({
         type: CHANGE_LAYOUT,
         layout: "scatter",
-        scatterVariables
+        scatterVariables: {...this.props.scatterVariables, ...scatterVariables}
       });
     };
   }
@@ -85,7 +86,7 @@ class ChooseLayout extends React.Component {
             <Select
               {...miscSelectProps}
               value={selected.x}
-              onChange={(value) => this.updateScatterplot({x: value.value, y: this.props.scatterVariables.y})}
+              onChange={(value) => this.updateScatterplot({x: value.value})}
             />
           </ScatterSelectContainer>
         </ScatterVariableContainer>
@@ -96,9 +97,18 @@ class ChooseLayout extends React.Component {
             <Select
               {...miscSelectProps}
               value={selected.y}
-              onChange={(value) => this.updateScatterplot({x: this.props.scatterVariables.x, y: value.value})}
+              onChange={(value) => this.updateScatterplot({y: value.value})}
             />
           </ScatterSelectContainer>
+        </ScatterVariableContainer>
+        <div style={{paddingTop: "2px"}}/>
+        <ScatterVariableContainer>
+          <Toggle
+            display
+            on={this.props.scatterVariables.showBranches}
+            callback={() => this.updateScatterplot({showBranches: !this.props.scatterVariables.showBranches})}
+            label={"Show branches"}
+          />
         </ScatterVariableContainer>
       </>
     );
@@ -161,7 +171,7 @@ class ChooseLayout extends React.Component {
           <ScatterIcon width={25} selected={selected === "scatter"}/>
           <SidebarButton
             selected={selected === "scatter"}
-            onClick={() => this.updateScatterplot({x: this.props.distanceMeasure, y: this.props.colorBy})}
+            onClick={() => this.updateScatterplot(getStartingScatterVariables(this.props.colorings, this.props.distanceMeasure, this.props.colorBy))}
           >
             {t("sidebar:scatter")}
           </SidebarButton>

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -9,9 +9,8 @@ import { withTranslation } from 'react-i18next';
 import Select from "react-select/lib/Select";
 import * as icons from "../framework/svg-icons";
 import { controlsWidth } from "../../util/globals";
-import { collectScatterVariables, getStartingScatterVariables } from "../../util/scatterplotHelpers";
+import { collectAvailableScatterVariables, validateScatterVariables} from "../../util/scatterplotHelpers";
 import { CHANGE_LAYOUT } from "../../actions/types";
-import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { SidebarSubtitle, SidebarButton } from "./styles";
 import Toggle from "./toggle";
 
@@ -44,38 +43,19 @@ class ChooseLayout extends React.Component {
   }
   constructor(props) {
     super(props);
-    this.updateScatterplot = (scatterVariables) => {
-      this.props.dispatch({
-        type: CHANGE_LAYOUT,
-        layout: "scatter",
-        scatterVariables: {...this.props.scatterVariables, ...scatterVariables}
-      });
+    this.updateLayout = (layout, modifiedScatterVariables=undefined) => {
+      if (window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference) return;
+      const scatterVariables = modifiedScatterVariables ?
+        {...this.props.scatterVariables, ...modifiedScatterVariables} :
+        this.props.scatterVariables;
+      this.props.dispatch({type: CHANGE_LAYOUT, layout, scatterVariables});
     };
   }
 
-  handleChangeLayoutClicked(userSelectedLayout) {
-    const loopRunning = window.NEXTSTRAIN && window.NEXTSTRAIN.animationTickReference;
-    if (!loopRunning) {
-      if (userSelectedLayout === "rect") {
-        analyticsControlsEvent("change-layout-rectangular");
-      } else if (userSelectedLayout === "radial") {
-        analyticsControlsEvent("change-layout-radial");
-      } else if (userSelectedLayout === "unrooted") {
-        analyticsControlsEvent("change-layout-unrooted");
-      } else if (userSelectedLayout === "clock") {
-        analyticsControlsEvent("change-layout-clock");
-      } else {
-        console.warn("Odd... controls/choose-layout.js tried to set a layout we don't offer...");
-      }
-      this.props.dispatch({
-        type: CHANGE_LAYOUT,
-        layout: userSelectedLayout
-      });
-    }
-  }
-
-  selectScatterVariables() {
-    const {options, selected} = collectScatterVariables(this.props.colorings, this.props.scatterVariables);
+  renderScatterplotAxesSelector() {
+    const options = collectAvailableScatterVariables(this.props.colorings);
+    const selectedX = options.filter((o) => o.value===this.props.scatterVariables.x)[0];
+    const selectedY = options.filter((o) => o.value===this.props.scatterVariables.y)[0];
     const miscSelectProps = {options, clearable: false, searchable: false, multi: false, valueKey: "label"};
 
     return (
@@ -85,8 +65,8 @@ class ChooseLayout extends React.Component {
           <ScatterSelectContainer>
             <Select
               {...miscSelectProps}
-              value={selected.x}
-              onChange={(value) => this.updateScatterplot({x: value.value})}
+              value={selectedX}
+              onChange={(value) => this.updateLayout("scatter", {x: value.value, xLabel: value.label})}
             />
           </ScatterSelectContainer>
         </ScatterVariableContainer>
@@ -96,20 +76,37 @@ class ChooseLayout extends React.Component {
           <ScatterSelectContainer>
             <Select
               {...miscSelectProps}
-              value={selected.y}
-              onChange={(value) => this.updateScatterplot({y: value.value})}
+              value={selectedY}
+              onChange={(value) => this.updateLayout("scatter", {y: value.value, yLabel: value.label})}
             />
           </ScatterSelectContainer>
         </ScatterVariableContainer>
+      </>
+    );
+  }
+
+  renderScatterplotToggles() {
+    return (
+      <>
         <div style={{paddingTop: "2px"}}/>
         <ScatterVariableContainer>
           <Toggle
             display
             on={this.props.scatterVariables.showBranches}
-            callback={() => this.updateScatterplot({showBranches: !this.props.scatterVariables.showBranches})}
+            callback={() => this.updateLayout(this.props.layout, {showBranches: !this.props.scatterVariables.showBranches})}
             label={"Show branches"}
           />
         </ScatterVariableContainer>
+        <div style={{paddingTop: "2px"}}/>
+        <ScatterVariableContainer>
+          <Toggle
+            display
+            on={this.props.scatterVariables.showRegression}
+            callback={() => this.updateLayout(this.props.layout, {showRegression: !this.props.scatterVariables.showRegression})}
+            label={"Show regression"}
+          />
+        </ScatterVariableContainer>
+        <div style={{paddingTop: "2px"}}/>
       </>
     );
   }
@@ -127,7 +124,7 @@ class ChooseLayout extends React.Component {
           <RectangularTreeIcon width={25} selected={selected === "rect"}/>
           <SidebarButton
             selected={selected === "rect"}
-            onClick={this.handleChangeLayoutClicked.bind(this, "rect")}
+            onClick={() => this.updateLayout("rect")}
           >
             {t("sidebar:rectangular")}
           </SidebarButton>
@@ -136,7 +133,7 @@ class ChooseLayout extends React.Component {
           <RadialTreeIcon width={25} selected={selected === "radial"}/>
           <SidebarButton
             selected={selected === "radial"}
-            onClick={this.handleChangeLayoutClicked.bind(this, "radial")}
+            onClick={() => this.updateLayout("radial")}
           >
             {t("sidebar:radial")}
           </SidebarButton>
@@ -145,7 +142,7 @@ class ChooseLayout extends React.Component {
           <UnrootedTreeIcon width={25} selected={selected === "unrooted"}/>
           <SidebarButton
             selected={selected === "unrooted"}
-            onClick={this.handleChangeLayoutClicked.bind(this, "unrooted")}
+            onClick={() => this.updateLayout("unrooted")}
           >
             {t("sidebar:unrooted")}
           </SidebarButton>
@@ -158,24 +155,36 @@ class ChooseLayout extends React.Component {
                 <ClockIcon width={25} selected={selected === "clock"}/>
                 <SidebarButton
                   selected={selected === "clock"}
-                  onClick={this.handleChangeLayoutClicked.bind(this, "clock")}
+                  onClick={() => this.updateLayout(
+                    "clock",
+                    validateScatterVariables(this.props.scatterVariables, this.props.colorings, this.props.distanceMeasure, this.props.colorBy, true)
+                  )}
                 >
                   {t("sidebar:clock")}
                 </SidebarButton>
+                {selected==="clock" && this.renderScatterplotToggles()}
               </RowContainer>
             ) :
             null
         }
-        { /* Scatterplot view -- when selected this shows x & y dropdown selectors */ }
+        { /* Scatterplot view -- when selected this shows x & y dropdown selectors etc */ }
         <RowContainer>
           <ScatterIcon width={25} selected={selected === "scatter"}/>
           <SidebarButton
             selected={selected === "scatter"}
-            onClick={() => this.updateScatterplot(getStartingScatterVariables(this.props.colorings, this.props.distanceMeasure, this.props.colorBy))}
+            onClick={() => this.updateLayout(
+              "scatter",
+              validateScatterVariables(this.props.scatterVariables, this.props.colorings, this.props.distanceMeasure, this.props.colorBy, false)
+            )}
           >
             {t("sidebar:scatter")}
           </SidebarButton>
-          {selected==="scatter" && this.selectScatterVariables()}
+          {selected==="scatter" && (
+            <>
+              {this.renderScatterplotAxesSelector()}
+              {this.renderScatterplotToggles()}
+            </>
+          )}
         </RowContainer>
       </div>
     );

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -21,7 +21,7 @@ class ChooseMetric extends React.Component {
   render() {
     const { t } = this.props;
     if (this.props.branchLengthsToDisplay !== "divAndDate") return null;
-    if (this.props.layout==="scatter") return null;
+    if (this.props.layout==="scatter" || this.props.layout==="clock") return null;
     /* this used to be added to the first SidebarSubtitle
     const potentialOffset = this.props.showTreeToo ? {marginTop: "0px"} : {}; */
     return (

--- a/src/components/controls/choose-metric.js
+++ b/src/components/controls/choose-metric.js
@@ -11,6 +11,7 @@ import Toggle from "./toggle";
 @connect((state) => {
   return {
     distanceMeasure: state.controls.distanceMeasure,
+    layout: state.controls.layout,
     showTreeToo: state.controls.showTreeToo,
     branchLengthsToDisplay: state.controls.branchLengthsToDisplay,
     temporalConfidence: state.controls.temporalConfidence
@@ -20,6 +21,7 @@ class ChooseMetric extends React.Component {
   render() {
     const { t } = this.props;
     if (this.props.branchLengthsToDisplay !== "divAndDate") return null;
+    if (this.props.layout==="scatter") return null;
     /* this used to be added to the first SidebarSubtitle
     const potentialOffset = this.props.showTreeToo ? {marginTop: "0px"} : {}; */
     return (

--- a/src/components/framework/svg-icons.js
+++ b/src/components/framework/svg-icons.js
@@ -42,6 +42,27 @@ export const Clock = ({theme, selected, width}) => {
   );
 };
 
+export const Scatter = ({theme, selected, width}) => {
+  const stroke = selected ? theme.selectedColor : theme.unselectedColor;
+  return (
+    <svg width={width} height={width + 5}>
+      <g transform="translate(0,4)">
+        <svg width={width} height={width} viewBox="0 0 30 30 ">
+          <g id="Group" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(17.000000, 20.000000)">
+            <polyline id="Path-3" stroke={stroke} points="-15 5 -15 -25 "/>
+            <polyline id="Path-4" stroke={stroke} points="-15 5 25 5"/>
+            <circle id="c-1" stroke={stroke} cx="-8" cy="0" r="2"/>
+            <circle id="c-2" stroke={stroke} cx="3" cy="0" r="2"/>
+            <circle id="c-3" stroke={stroke} cx="8" cy="-5" r="2"/>
+            <circle id="c-4" stroke={stroke} cx="-4" cy="-15" r="2"/>
+            <circle id="c-5" stroke={stroke} cx="1" cy="-11" r="2"/>
+          </g>
+        </svg>
+      </g>
+    </svg>
+  );
+};
+
 export const RadialTree = ({theme, selected, width}) => {
   const stroke = selected ? theme.selectedColor : theme.unselectedColor;
   return (

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -20,6 +20,7 @@ const Tree = connect((state) => ({
   showTangle: state.controls.showTangle,
   panelsToDisplay: state.controls.panelsToDisplay,
   selectedBranchLabel: state.controls.selectedBranchLabel,
+  canRenderBranchLabels: state.controls.canRenderBranchLabels,
   tipLabelKey: state.controls.tipLabelKey,
   narrativeMode: state.narrative.display,
   animationPlayPauseButton: state.controls.animationPlayPauseButton

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -10,6 +10,7 @@ const Tree = connect((state) => ({
   colorBy: state.controls.colorBy,
   colorByConfidence: state.controls.colorByConfidence,
   layout: state.controls.layout,
+  scatterVariables: state.controls.scatterVariables,
   temporalConfidence: state.controls.temporalConfidence,
   distanceMeasure: state.controls.distanceMeasure,
   mutType: state.controls.mutType,

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -164,7 +164,7 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
   }
   if (elemsToUpdate.has('.regression')) {
     this.removeRegression();
-    if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
+    if (this.regression) this.drawRegression();
   }
 
   /* confidence intervals */
@@ -200,7 +200,7 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
  * step 2: when step 1 has finished, move tips across the screen.
  * step 3: when step 2 has finished, redraw everything. No transition here.
  */
-export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTimeFadeOut, transitionTimeMoveTips) {
+export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTimeFadeOut, transitionTimeMoveTips, extras) {
   elemsToUpdate.delete(".tip");
   this.hideGrid();
   let inProgress = 0; /* counter of transitions currently in progress */
@@ -213,8 +213,8 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
     this.drawTips();
     if (this.vaccines) this.drawVaccines();
     this.showTemporalSlice();
-    if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
-    if (elemsToUpdate.has(".branchLabel")) this.drawBranchLabels(this.params.branchLabelKey);
+    if (this.regression) this.drawRegression();
+    if (elemsToUpdate.has(".branchLabel")) this.drawBranchLabels(extras.newBranchLabellingKey || this.params.branchLabelKey);
   };
 
   /* STEP 2: move tips */
@@ -375,7 +375,7 @@ export const change = function change({
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   extras.hideTipLabels = animationInProgress;
   if (useModifySVGInStages) {
-    this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 1000);
+    this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 1000, extras);
   } else {
     this.modifySVG(elemsToUpdate, svgPropsToUpdate, transitionTime, extras);
   }

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -257,7 +257,7 @@ export const change = function change({
   /* change these things to provided value (unless undefined) */
   newDistance = undefined,
   newLayout = undefined,
-  updateLayout = undefined,
+  updateLayout = undefined, // todo - this seems identical to `newLayout`
   newBranchLabellingKey = undefined,
   newTipLabelKey = undefined,
   /* arrays of data (the same length as nodes) */
@@ -266,7 +266,9 @@ export const change = function change({
   fill = undefined,
   visibility = undefined,
   tipRadii = undefined,
-  branchThickness = undefined
+  branchThickness = undefined,
+  /* other data */
+  scatterVariables = undefined
 }) {
   // console.log("\n** phylotree.change() (time since last run:", Date.now() - this.timeLastRenderRequested, "ms) **\n\n");
   timerStart("phylotree.change()");
@@ -342,9 +344,11 @@ export const change = function change({
 
   /* run calculations as needed - these update properties on the phylotreeNodes (similar to updateNodesWithNewData) */
   /* distance */
-  if (newDistance) this.setDistance(newDistance);
+  if (newDistance || updateLayout) this.setDistance(newDistance);
   /* layout (must run after distance) */
-  if (newDistance || newLayout || updateLayout) this.setLayout(newLayout || this.layout);
+  if (newDistance || newLayout || updateLayout) {
+    this.setLayout(newLayout || this.layout, scatterVariables);
+  }
   /* show confidences - set this param which actually adds the svg paths for
      confidence intervals when mapToScreen() gets called below */
   if (showConfidences) this.params.confidence = true;

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -47,14 +47,14 @@ const addSVGGroupsIfNeeded = (groups, svg) => {
 };
 
 /**
- * Create the separation between major & minor grid lines for divergence scales.
- * @param {numeric} range amount of divergence (subs/site/year _or_ num mutations) present in current view
+ * Create the separation between major & minor grid lines for numeric scales.
+ * @param {numeric} range e.g. amount of divergence (subs/site/year _or_ num mutations) present in current view
  * @param {numeric} minorTicks num of minor ticks desired between each major step
  * @returns {object}
  *  - property `majorStep` {numeric}: space between major x-axis gridlines (measure of divergence)
  *  - property `minorStep` {numeric}: space between minor x-axis gridlines (measure of divergence)
  */
-const calculateDivGridSeperation = (range, minorTicks) => {
+const calculateNumericGridSeparation = (range, minorTicks) => {
   /* make an informed guess of the step size to start with.
   E.g. 0.07 => step of 0.01, 70 => step size of 10 */
   const logRange = Math.floor(Math.log10(range));
@@ -72,33 +72,35 @@ const calculateDivGridSeperation = (range, minorTicks) => {
   return {majorStep, minorStep};
 };
 
-const computeDivergenceGridPoints = (xmin, xmax, layout, minorTicks) => {
+/**
+ * Return `{majorGridPoints, minorGridPoints}` for numeric scales (e.g. divergence)
+ */
+const computeNumericGridPoints = (minVal, maxVal, layout, nMinorTicks, axis) => {
   const majorGridPoints = [];
   const minorGridPoints = [];
 
-  /* step is the amount (same units of xmax, xmin) of seperation between major grid lines */
-  const {majorStep, minorStep} = calculateDivGridSeperation(xmax-xmin, minorTicks);
+  /* step is the amount (same units of minVal, maxVal) of separation between major grid lines */
+  const {majorStep, minorStep} = calculateNumericGridSeparation(maxVal-minVal, nMinorTicks);
 
-  const gridMin = Math.floor(xmin/majorStep)*majorStep;
-  const minVis = layout==="radial" ? xmin : gridMin;
-  const maxVis = xmax;
+  const gridMin = Math.floor(minVal/majorStep)*majorStep;
+  const minVis = layout==="radial" ? minVal : gridMin;
+  const maxVis = maxVal;
 
-  for (let ii = 0; ii <= (xmax - gridMin)/majorStep+3; ii++) {
+  for (let ii = 0; ii <= (maxVal - gridMin)/majorStep+3; ii++) {
     const pos = gridMin + majorStep*ii;
     majorGridPoints.push({
       position: pos,
       name: pos.toFixed(Math.max(0, -Math.floor(Math.log10(majorStep)))),
       visibility: ((pos<minVis) || (pos>maxVis)) ? "hidden" : "visible",
-      axis: "x"
+      axis
     });
-    for (let minorPos=pos+minorStep; minorPos<(pos+majorStep) && minorPos<xmax; minorPos+=minorStep) {
+    for (let minorPos=pos+minorStep; minorPos<(pos+majorStep) && minorPos<maxVal; minorPos+=minorStep) {
       minorGridPoints.push({
         position: minorPos,
         visibility: ((minorPos<minVis) || (minorPos>maxVis+minorStep)) ? "hidden" : "visible",
-        axis: "x"
+        axis
       });
     }
-
   }
   return {majorGridPoints, minorGridPoints};
 };
@@ -161,25 +163,26 @@ const calculateTemporalGridSeperation = (timeRange, pxAvailable) => {
 
 /**
  * Compute the major & minor temporal grid points for display.
- * @param {numeric} xmin numeric date of minimum value in view
- * @param {numeric} xmax numeric date of maximum value in view
+ * @param {numeric} numDateMin numeric date of minimum value in view
+ * @param {numeric} numDateMax numeric date of maximum value in view
  * @param {numeric} pxAvailable pixels in which to display the date range (xmin, xmax)
+ * @param {string} axis "x" or "y"
  * @returns {Object} properties: `majorGridPoints`, `minorGridPoints`
  */
-export const computeTemporalGridPoints = (xmin, xmax, pxAvailable) => {
+export const computeTemporalGridPoints = (numDateMin, numDateMax, pxAvailable, axis) => {
   const [majorGridPoints, minorGridPoints] = [[], []];
-  const {majorStep, minorStep} = calculateTemporalGridSeperation(xmax-xmin, Math.abs(pxAvailable));
+  const {majorStep, minorStep} = calculateTemporalGridSeperation(numDateMax-numDateMin, Math.abs(pxAvailable));
 
   /* Major Grid Points */
-  const overallStopDate = getNextDate(majorStep.unit, numericToDateObject(xmax));
-  let proposedDate = getPreviousDate(majorStep.unit, numericToDateObject(xmin));
+  const overallStopDate = getNextDate(majorStep.unit, numericToDateObject(numDateMax));
+  let proposedDate = getPreviousDate(majorStep.unit, numericToDateObject(numDateMin));
   while (proposedDate < overallStopDate) {
     majorGridPoints.push({
       date: proposedDate,
       position: calendarToNumeric(dateToString(proposedDate)),
       name: prettifyDate(majorStep.unit, proposedDate),
       visibility: 'visible',
-      axis: "x"
+      axis
     });
     for (let i=0; i<majorStep.n; i++) {
       proposedDate = getNextDate(majorStep.unit, proposedDate);
@@ -199,7 +202,7 @@ export const computeTemporalGridPoints = (xmin, xmax, pxAvailable) => {
         minorGridPoints.push({
           position: calendarToNumeric(dateToString(proposedDate)),
           visibility: 'visible',
-          axis: "x"
+          axis
         });
         for (let i=0; i<minorStep.n; i++) {
           proposedDate = getNextDate(minorStep.unit, proposedDate);
@@ -208,27 +211,6 @@ export const computeTemporalGridPoints = (xmin, xmax, pxAvailable) => {
     });
   }
   return {majorGridPoints, minorGridPoints};
-};
-
-
-const computeYGridPoints = (ymin, ymax) => {
-  const majorGridPoints = [];
-  let yStep = 0;
-  yStep = calculateDivGridSeperation(ymax-ymin).majorStep;
-  const precisionY = Math.max(0, -Math.floor(Math.log10(yStep)));
-  const gridYMin = Math.floor(ymin/yStep)*yStep;
-  const maxYVis = ymax;
-  const minYVis = gridYMin;
-  for (let ii = 1; ii <= (ymax - gridYMin)/yStep+10; ii++) {
-    const pos = gridYMin + yStep*ii;
-    majorGridPoints.push({
-      position: pos,
-      name: pos.toFixed(precisionY),
-      visibility: ((pos<minYVis)||(pos>maxYVis)) ? "hidden" : "visible",
-      axis: "y"
-    });
-  }
-  return {majorGridPoints};
 };
 
 /**
@@ -256,9 +238,17 @@ export const addGrid = function addGrid() {
   /* determine grid points (i.e. on the x/polar axis where lines/circles will be drawn through)
   Major grid points are thicker and have text
   Minor grid points have no text */
-  const {majorGridPoints, minorGridPoints} = this.distance === "num_date" ?
-    computeTemporalGridPoints(xmin, xmax, xAxisPixels) :
-    computeDivergenceGridPoints(xmin, xmax, layout, this.params.minorTicks);
+  let xGridPoints;
+  if (
+    (this.layout==="scatter" && this.scatterVariables.x==="num_date") ||
+    this.layout==="clock" ||
+    this.distance==="num_date"
+  ) {
+    xGridPoints = computeTemporalGridPoints(xmin, xmax, xAxisPixels, "x");
+  } else {
+    xGridPoints = computeNumericGridPoints(xmin, xmax, layout, this.params.minorTicks, "x");
+  }
+  const {majorGridPoints, minorGridPoints} = xGridPoints;
 
   /* HOF, which returns the fn which constructs the SVG path string
   to draw the axis lines (circles for radial trees).
@@ -323,13 +313,19 @@ export const addGrid = function addGrid() {
     return "start";
   };
 
-  /* for clock layouts, add y-points to the majorGridPoints array
-  Note that these don't have lines drawn, only text */
+  /* for scatterplot-like layouts, add grid points for the y-axis (rendered as horizontal lines) */
   if (this.layout==="clock" || this.layout==="scatter") {
-    majorGridPoints.push(...computeYGridPoints(ymin, ymax).majorGridPoints);
+    if (this.layout==="scatter" && this.scatterVariables.y==="num_date") {
+      const yAxisPixels = this.yScale.range()[1] - this.yScale.range()[0];
+      const temporalGrid = computeTemporalGridPoints(ymin, ymax, yAxisPixels, "y");
+      majorGridPoints.push(...temporalGrid.majorGridPoints);
+    } else {
+      const numericGrid = computeNumericGridPoints(ymin, ymax, layout, 1, "y");
+      majorGridPoints.push(...numericGrid.majorGridPoints);
+    }
   }
 
-  /* D3 commands to add grid + text to the DOM
+  /* Add grid lines (horizontal & vertical) to the DOM + text for major lines
   Note that the groups were created the first time this function was called */
   // add major grid to svg
   this.groups.majorGrid.selectAll("*").remove();
@@ -344,7 +340,6 @@ export const addGrid = function addGrid() {
         .style("visibility", (d) => d.visibility)
         .style("stroke", this.params.majorGridStroke)
         .style("stroke-width", this.params.majorGridWidth);
-
   // add minor grid to SVG
   this.groups.minorGrid.selectAll("*").remove();
   this.svg.selectAll(".minorGrid").remove();
@@ -359,7 +354,6 @@ export const addGrid = function addGrid() {
         .style("visibility", (d) => d.visibility)
         .style("stroke", this.params.minorGridStroke)
         .style("stroke-width", this.params.minorGridWidth);
-
   /* draw the text labels for majorGridPoints */
   this.groups.gridText.selectAll("*").remove();
   this.svg.selectAll(".gridText").remove();

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -265,7 +265,7 @@ export const addGrid = function addGrid() {
   const gridline = (xScale, yScale, layoutShadow) => (gridPoint) => {
     let svgPath="";
     if (gridPoint.axis === "x") {
-      if (layoutShadow==="rect" || layoutShadow==="clock") {
+      if (layoutShadow==="rect" || layoutShadow==="clock" || layoutShadow==="scatter") {
         const xPos = xScale(gridPoint.position);
         svgPath = 'M'+xPos.toString() +
           " " +
@@ -324,7 +324,7 @@ export const addGrid = function addGrid() {
 
   /* for clock layouts, add y-points to the majorGridPoints array
   Note that these don't have lines drawn, only text */
-  if (this.layout==="clock") {
+  if (this.layout==="clock" || this.layout==="scatter") {
     majorGridPoints.push(...computeYGridPoints(ymin, ymax).majorGridPoints);
   }
 

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { max } from "d3-array";
 import {getTraitFromNode, getDivFromNode} from "../../../util/treeMiscHelpers";
 
 /** get a string to be used as the DOM element ID
@@ -156,3 +157,15 @@ export const getParentBeyondPolytomy = (node, distanceMeasure) => {
   }
   return potentialNode;
 };
+
+/**
+ * Prior to Jan 2020, the divergence measure was always "subs per site per year"
+ * however certain datasets changed this to "subs per year" across entire sequence.
+ * This distinction is not set in the JSON, so in order to correctly display the rate
+ * we will "guess" this here. A future augur update will export this in a JSON key,
+ * removing the need to guess.
+ */
+export function guessAreMutationsPerSite(scale) {
+  const maxDivergence = max(scale.domain());
+  return maxDivergence <= 5;
+}

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -115,6 +115,7 @@ export const updateBranchLabels = function updateBranchLabels(dt) {
 };
 
 export const removeBranchLabels = function removeBranchLabels() {
+  this.params.branchLabelKey = undefined;
   if ("branchLabels" in this.groups) {
     this.groups.branchLabels.selectAll("*").remove();
   }

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -72,7 +72,6 @@ PhyloTree.prototype.rectangularLayout = layouts.rectangularLayout;
 PhyloTree.prototype.scatterplotLayout = layouts.scatterplotLayout;
 PhyloTree.prototype.unrootedLayout = layouts.unrootedLayout;
 PhyloTree.prototype.radialLayout = layouts.radialLayout;
-PhyloTree.prototype.calculateRegression = layouts.calculateRegression;
 PhyloTree.prototype.setScales = layouts.setScales;
 PhyloTree.prototype.mapToScreen = layouts.mapToScreen;
 

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -69,9 +69,10 @@ PhyloTree.prototype.updateColorBy = renderers.updateColorBy;
 PhyloTree.prototype.setDistance = layouts.setDistance;
 PhyloTree.prototype.setLayout = layouts.setLayout;
 PhyloTree.prototype.rectangularLayout = layouts.rectangularLayout;
-PhyloTree.prototype.timeVsRootToTip = layouts.timeVsRootToTip;
+PhyloTree.prototype.scatterplotLayout = layouts.scatterplotLayout;
 PhyloTree.prototype.unrootedLayout = layouts.unrootedLayout;
 PhyloTree.prototype.radialLayout = layouts.radialLayout;
+PhyloTree.prototype.calculateRegression = layouts.calculateRegression;
 PhyloTree.prototype.setScales = layouts.setScales;
 PhyloTree.prototype.mapToScreen = layouts.mapToScreen;
 

--- a/src/components/tree/phyloTree/regression.js
+++ b/src/components/tree/phyloTree/regression.js
@@ -1,0 +1,54 @@
+import { sum } from "d3-array";
+import { formatDivergence, guessAreMutationsPerSite} from "./helpers";
+
+
+/**
+ * this function calculates a regression between
+ * the x and y values of terminal nodes, passing through
+ * nodes[0].
+ * It does not consider which tips are inView / visible.
+ */
+export function calculateRegressionThroughRoot(nodes) {
+  const terminalNodes = nodes.filter((d) => d.terminal);
+  const nTips = terminalNodes.length;
+  const offset = nodes[0].x;
+  const XY = sum(
+    terminalNodes.map((d) => (d.y) * (d.x - offset))
+  ) / nTips;
+  const secondMomentTime = sum(
+    terminalNodes
+      .map((d) => (d.x - offset) * (d.x - offset))
+  ) / nTips;
+  const slope = XY / secondMomentTime;
+  const intercept = -offset * slope;
+  return {slope, intercept, r2: undefined};
+}
+
+/**
+ * Calculate regression through terminal nodes which have both x & y values
+ * set. These values must be numeric.
+ * This function does not consider which tips are inView / visible.
+ */
+export function calculateRegressionWithFreeIntercept(nodes) {
+  const terminalNodesWithXY = nodes.filter((d) => d.terminal && d.x!==undefined && d.y!==undefined);
+  const nTips = terminalNodesWithXY.length;
+  const meanX = sum(terminalNodesWithXY.map((d) => d.x))/nTips;
+  const meanY = sum(terminalNodesWithXY.map((d) => d.y))/nTips;
+  const slope = sum(terminalNodesWithXY.map((d) => (d.x-meanX)*(d.y-meanY))) /
+    sum(terminalNodesWithXY.map((d) => (d.x-meanX)**2));
+  const intercept = meanY - slope*meanX;
+  const r2 = 1 - sum(terminalNodesWithXY.map((d) => (d.y - (intercept + slope*d.x))**2)) /
+    sum(terminalNodesWithXY.map((d) => (d.y - meanY)**2));
+  return {slope, intercept, r2};
+}
+
+
+export function makeRegressionText(regression, layout, yScale) {
+  if (layout==="clock") {
+    if (guessAreMutationsPerSite(yScale)) {
+      return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
+    }
+    return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
+  }
+  return `intercept = ${regression.intercept.toPrecision(3)}, slope = ${regression.slope.toPrecision(3)}, R^2 = ${regression.r2.toPrecision(3)}`;
+}

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -16,9 +16,11 @@ import { getEmphasizedColor } from "../../../util/colorHelpers";
  * @param {array} tipStroke       -- tip stroke colour for each node (set onto each node)
  * @param {array} tipFill         -- tip fill colour for each node (set onto each node)
  * @param {array|null} tipRadii   -- array of tip radius'
+ * @param {array} dateRange
+ * @param {object} scatterVariables  -- {x, y} properties to map nodes => scatterplot (only used if layout="scatter")
  * @return {null}
  */
-export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, branchStroke, tipStroke, tipFill, tipRadii, dateRange) {
+export const render = function render(svg, layout, distance, parameters, callbacks, branchThickness, visibility, drawConfidence, vaccines, branchStroke, tipStroke, tipFill, tipRadii, dateRange, scatterVariables) {
   timerStart("phyloTree render()");
   this.svg = svg;
   this.params = Object.assign(this.params, parameters);
@@ -28,7 +30,7 @@ export const render = function render(svg, layout, distance, parameters, callbac
 
   /* set x, y values & scale them to the screen */
   this.setDistance(distance);
-  this.setLayout(layout);
+  this.setLayout(layout, scatterVariables);
   this.mapToScreen();
 
   /* set nodes stroke / fill */
@@ -172,7 +174,7 @@ export const drawBranches = function drawBranches() {
   if (!("branchTee" in this.groups)) {
     this.groups.branchTee = this.svg.append("g").attr("id", "branchTee");
   }
-  if (this.layout === "clock" || this.layout === "unrooted") {
+  if (this.layout === "clock" || this.layout === "scatter" || this.layout === "unrooted") {
     this.groups.branchTee.selectAll("*").remove();
   } else {
     this.groups.branchTee

--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -1,6 +1,7 @@
 import { timerStart, timerEnd } from "../../../util/perf";
 import { NODE_VISIBLE } from "../../../util/globals";
-import { getDomId, formatDivergence } from "./helpers";
+import { getDomId } from "./helpers";
+import { makeRegressionText } from "./regression";
 import { getEmphasizedColor } from "../../../util/colorHelpers";
 /**
  * @param {d3 selection} svg      -- the svg into which the tree is drawn
@@ -53,7 +54,7 @@ export const render = function render(svg, layout, distance, parameters, callbac
   this.drawTips();
   if (this.params.branchLabelKey) this.drawBranchLabels(this.params.branchLabelKey);
   if (this.vaccines) this.drawVaccines();
-  if (this.layout === "clock" && this.distance === "num_date") this.drawRegression();
+  if (this.regression) this.drawRegression();
   this.confidencesInSVG = false;
   if (drawConfidence) this.drawConfidence();
 
@@ -244,11 +245,11 @@ export const drawRegression = function drawRegression() {
   const path = "M " + this.xScale.range()[0].toString() + " " + leftY.toString() +
     " L " + this.xScale.range()[1].toString() + " " + rightY.toString();
 
-  if (!("clockRegression" in this.groups)) {
-    this.groups.clockRegression = this.svg.append("g").attr("id", "clockRegression");
+  if (!("regression" in this.groups)) {
+    this.groups.regression = this.svg.append("g").attr("id", "regression");
   }
 
-  this.groups.clockRegression
+  this.groups.regression
     .append("path")
     .attr("d", path)
     .attr("class", "regression")
@@ -256,9 +257,12 @@ export const drawRegression = function drawRegression() {
     .style("visibility", "visible")
     .style("stroke", this.params.regressionStroke)
     .style("stroke-width", this.params.regressionWidth);
-  this.groups.clockRegression
+
+  /* Compute & draw regression text. Note that the text hasn't been created until now,
+  as we need to wait until rendering time when the scales have been calculated */
+  this.groups.regression
     .append("text")
-    .text(getRateEstimate(this.regression, this.yScale.domain()[0]))
+    .text(makeRegressionText(this.regression, this.layout, this.yScale))
     .attr("class", "regression")
     .attr("x", this.xScale.range()[1] / 2 - 75)
     .attr("y", this.yScale.range()[0] + 50)
@@ -269,8 +273,8 @@ export const drawRegression = function drawRegression() {
 };
 
 export const removeRegression = function removeRegression() {
-  if ("clockRegression" in this.groups) {
-    this.groups.clockRegression.selectAll("*").remove();
+  if ("regression" in this.groups) {
+    this.groups.regression.selectAll("*").remove();
   }
 };
 
@@ -367,16 +371,3 @@ export const branchStrokeForHover = function branchStrokeForHover(d) {
   if (!d) { return; }
   handleBranchHoverColor(d, getEmphasizedColor(d.parent.branchStroke), getEmphasizedColor(d.branchStroke));
 };
-
-
-function getRateEstimate(regression, maxDivergence) {
-  /* Prior to Jan 2020, the divergence measure was always "subs per site per year"
-    however certain datasets chaged this to "subs per year" across entire sequence.
-    This distinction is not set in the JSON, so in order to correctly display the rate
-    we will "guess" this here. A future augur update will export this in a JSON key,
-    removing the need to guess */
-  if (maxDivergence > 5) {
-    return `rate estimate: ${formatDivergence(regression.slope)} subs per year`;
-  }
-  return `rate estimate: ${regression.slope.toExponential(2)} subs per site per year`;
-}

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -74,7 +74,7 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
     args.showConfidences = true;
   }
 
-  if (newProps.layout==="scatter" && (oldProps.scatterVariables!==newProps.scatterVariables)) {
+  if ((newProps.layout==="scatter" || newProps.layout==="clock") && (oldProps.scatterVariables!==newProps.scatterVariables)) {
     args.updateLayout = true;
     args.scatterVariables = newProps.scatterVariables;
   }

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -52,7 +52,12 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
   }
 
   /* change in key used to define branch labels, tip labels */
-  if (oldProps.selectedBranchLabel !== newProps.selectedBranchLabel) {
+  if (oldProps.canRenderBranchLabels===true && newProps.canRenderBranchLabels===false) {
+    args.newBranchLabellingKey = "none";
+  } else if (
+    (oldProps.canRenderBranchLabels===false && newProps.canRenderBranchLabels===true) ||
+    (oldProps.selectedBranchLabel !== newProps.selectedBranchLabel)
+  ) {
     args.newBranchLabellingKey = newProps.selectedBranchLabel;
   }
   if (oldProps.tipLabelKey !== newProps.tipLabelKey) {

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -69,9 +69,14 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
     args.showConfidences = true;
   }
 
+  if (newProps.layout==="scatter" && (oldProps.scatterVariables!==newProps.scatterVariables)) {
+    args.updateLayout = true;
+    args.scatterVariables = newProps.scatterVariables;
+  }
   if (oldProps.layout !== newProps.layout) {
     args.newLayout = newProps.layout;
   }
+
 
   /* zoom to a clade / reset zoom to entire tree */
   if (oldTreeRedux.idxOfInViewRootNode !== newTreeRedux.idxOfInViewRootNode) {

--- a/src/components/tree/reactD3Interface/initialRender.js
+++ b/src/components/tree/reactD3Interface/initialRender.js
@@ -20,7 +20,7 @@ export const renderTree = (that, main, phylotree, props) => {
     { /* parameters (modifies PhyloTree's defaults) */
       grid: true,
       confidence: props.temporalConfidence.display,
-      branchLabelKey: props.selectedBranchLabel,
+      branchLabelKey: props.canRenderBranchLabels && props.selectedBranchLabel,
       orientation: main ? [1, 1] : [-1, 1],
       tipLabels: true,
       showTipLabels: true

--- a/src/components/tree/reactD3Interface/initialRender.js
+++ b/src/components/tree/reactD3Interface/initialRender.js
@@ -42,6 +42,7 @@ export const renderTree = (that, main, phylotree, props) => {
     treeState.nodeColors,
     treeState.nodeColors.map((col) => rgb(col).brighter([0.65]).toString()),
     treeState.tipRadii, /* might be null */
-    [props.dateMinNumeric, props.dateMaxNumeric]
+    [props.dateMinNumeric, props.dateMaxNumeric],
+    props.scatterVariables
   );
 };

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -75,6 +75,13 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.CHANGE_LAYOUT: {
+      const sv = action.scatterVariables;
+      query.scatterX = action.layout==="scatter" && state.controls.distanceMeasure!==sv.x ? sv.x : undefined;
+      query.scatterY = action.layout==="scatter" && state.controls.colorBy!==sv.y ? sv.y : undefined;
+      query.branches = (action.layout==="scatter" || action.layout==="clock") && sv.showBranches===false ? "hide" : undefined;
+      query.regression = action.layout==="scatter" && sv.showRegression===true ? "show" :
+        action.layout==="clock" && sv.showRegression===false ? "hide" :
+          undefined;
       query.l = action.layout === state.controls.defaults.layout ? undefined : action.layout;
       if (!shouldDisplayTemporalConfidence(state.controls.temporalConfidence.exists, state.controls.distanceMeasure, query.l)) {
         query.ci = undefined;

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -75,7 +75,7 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.CHANGE_LAYOUT: {
-      query.l = action.data === state.controls.defaults.layout ? undefined : action.data;
+      query.l = action.layout === state.controls.defaults.layout ? undefined : action.layout;
       if (!shouldDisplayTemporalConfidence(state.controls.temporalConfidence.exists, state.controls.distanceMeasure, query.l)) {
         query.ci = undefined;
       }

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -23,8 +23,7 @@ export const getDefaultControlsState = () => {
     filters: {},
     colorBy: defaultColorBy,
     selectedBranchLabel: "none",
-    showTransmissionLines: true,
-    scatterVariables: {x: undefined, y: undefined}
+    showTransmissionLines: true
   };
   // a default sidebarOpen status is only set via JSON, URL query
   // _or_ if certain URL keywords are triggered
@@ -50,6 +49,7 @@ export const getDefaultControlsState = () => {
     mutType: defaultMutType,
     temporalConfidence: { exists: false, display: false, on: false },
     layout: defaults.layout,
+    scatterVariables: {},
     distanceMeasure: defaults.distanceMeasure,
     dateMin,
     dateMinNumeric,

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -63,6 +63,7 @@ export const getDefaultControlsState = () => {
     colorByConfidence: { display: false, on: false },
     colorScale: undefined,
     selectedBranchLabel: "none",
+    canRenderBranchLabels: true,
     analysisSlider: false,
     geoResolution: defaults.geoResolution,
     filters: {},
@@ -122,6 +123,7 @@ const Controls = (state = getDefaultControlsState(), action) => {
     case types.CHANGE_LAYOUT:
       return Object.assign({}, state, {
         layout: action.layout,
+        canRenderBranchLabels: action.layout!=="scatter" || (action.scatterVariables && action.scatterVariables.showBranches),
         scatterVariables: action.scatterVariables || {x: undefined, y: undefined},
         /* temporal confidence can only be displayed for rectangular trees */
         temporalConfidence: Object.assign({}, state.temporalConfidence, {

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -123,8 +123,8 @@ const Controls = (state = getDefaultControlsState(), action) => {
     case types.CHANGE_LAYOUT:
       return Object.assign({}, state, {
         layout: action.layout,
-        canRenderBranchLabels: action.layout!=="scatter" || (action.scatterVariables && action.scatterVariables.showBranches),
-        scatterVariables: action.scatterVariables || {x: undefined, y: undefined},
+        canRenderBranchLabels: (action.layout!=="scatter" && action.layout!=="clock") || (action.scatterVariables && action.scatterVariables.showBranches),
+        scatterVariables: action.scatterVariables,
         /* temporal confidence can only be displayed for rectangular trees */
         temporalConfidence: Object.assign({}, state.temporalConfidence, {
           display: shouldDisplayTemporalConfidence(

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -23,7 +23,8 @@ export const getDefaultControlsState = () => {
     filters: {},
     colorBy: defaultColorBy,
     selectedBranchLabel: "none",
-    showTransmissionLines: true
+    showTransmissionLines: true,
+    scatterVariables: {x: undefined, y: undefined}
   };
   // a default sidebarOpen status is only set via JSON, URL query
   // _or_ if certain URL keywords are triggered
@@ -120,7 +121,8 @@ const Controls = (state = getDefaultControlsState(), action) => {
       return Object.assign({}, state, { selectedBranchLabel: action.value });
     case types.CHANGE_LAYOUT:
       return Object.assign({}, state, {
-        layout: action.data,
+        layout: action.layout,
+        scatterVariables: action.scatterVariables || {x: undefined, y: undefined},
         /* temporal confidence can only be displayed for rectangular trees */
         temporalConfidence: Object.assign({}, state.temporalConfidence, {
           display: shouldDisplayTemporalConfidence(

--- a/src/util/scatterplotHelpers.js
+++ b/src/util/scatterplotHelpers.js
@@ -1,20 +1,47 @@
 
 
-export function collectScatterVariables(colorings, scatterVariables) {
-
+export function collectScatterVariables(colorings, scatterVariables, validate=false) {
   // todo: genotype (special case)
   const options = Object.keys(colorings)
     .filter((key) => key!=="gt")
+    .filter((key) => colorings[key].type==="continuous") // work needed to render non-continuous scales in PhyloTree
     .map((key) => ({
       value: key,
       label: colorings[key].title || key
     }));
   options.unshift({value: "div", label: "Divergence"});
 
-  const selected = {
-    x: options.filter((o) => o.value===scatterVariables.x)[0] || undefined,
-    y: options.filter((o) => o.value===scatterVariables.y)[0] || undefined
-  };
+  let x = options.filter((o) => o.value===scatterVariables.x)[0];
+  let y = options.filter((o) => o.value===scatterVariables.y)[0];
 
+  if (validate) {
+    // if the supplied variables aren't within `options` select some that are!
+    // values can be `undefined`, this results in "scatter" being selected but the user needs to select a value
+    if (!x) x = _getFirstNonMatch(options, y);
+    if (!y) y = _getFirstNonMatch(options, x);
+  }
+
+  const selected = {x, y};
   return {options, selected};
+}
+
+export function getStartingScatterVariables(colorings, distanceMeasure, colorBy) {
+  const {selected} = collectScatterVariables(colorings, {x: distanceMeasure, y: colorBy}, true);
+  return {
+    x: selected.x && selected.x.value,
+    y: selected.y && selected.y.value,
+    showBranches: true
+  };
+}
+
+
+function _getFirstNonMatch(options, other) {
+  const availableValues = options.map((opt) => opt.value);
+  const otherValue = other && other.value;
+  for (let i=0; i<availableValues.length; i++) {
+    if (availableValues[i]!==otherValue) {
+      return options[i];
+    }
+  }
+  return undefined;
 }

--- a/src/util/scatterplotHelpers.js
+++ b/src/util/scatterplotHelpers.js
@@ -1,0 +1,20 @@
+
+
+export function collectScatterVariables(colorings, scatterVariables) {
+
+  // todo: genotype (special case)
+  const options = Object.keys(colorings)
+    .filter((key) => key!=="gt")
+    .map((key) => ({
+      value: key,
+      label: colorings[key].title || key
+    }));
+  options.unshift({value: "div", label: "Divergence"});
+
+  const selected = {
+    x: options.filter((o) => o.value===scatterVariables.x)[0] || undefined,
+    y: options.filter((o) => o.value===scatterVariables.y)[0] || undefined
+  };
+
+  return {options, selected};
+}


### PR DESCRIPTION
This adds a new layout for scatterplots and allows users to choose the x and y variables from the available colorings. The defaults are the tree metric (x-axis) and the current color-by (y-axis). Choices are limited to continuous colorings (see below). Nodes without information are hidden from view, and branches can be toggled on/off. 

As clock views are really just an instance of a scatterplot, the UI between the two is similar. Specifically, we now show toggles for both regression lines and display of branches for each layout. Regression lines for clock views are unchanged, however a new implementation is present for scatterplots which does not necessitate the regression passes through the root. Coefficients and R^2 are reported, although text formatting isn't perfect.

The relevant parameters are stored in URL queries to allow URLs to be shared (see documentation added here for details). 

![image](https://user-images.githubusercontent.com/8350992/112224490-36f2e780-8c90-11eb-91e3-5267366ac2a4.png)


There are a number of future feature improvements, which I think are best as self-isolated issues:

* Non-continuous colourings will require two large-ish pieces of work. Firstly, the d3 scale within PhyloTree has to change between `scaleLinear` and `scaleOrdinal`, which requires certain elements to re-render. Secondly, information about the variable (categories, ordering of categories etc) must be calculated and passed in to PhyloTree to calculate the appropriate coordinates. Medium priority.
* JSON `displayDefaults` extended to allow specifying of scatterplot variables. Low priority.
* Axis labelling. Low priority, but will become important when non-continuous variables are used.
* Ability to swap x & y variables. Low priority.
* Domains always consider (valid) internal nodes, and thus could be improved for views which hide the branches. Extremely low priority.


