### PR TITLE
WIP: experimental support for linking tips to datasets

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -169,6 +169,7 @@ class Tree extends React.Component {
           tip={this.state.selectedTip}
           colorings={this.props.metadata.colorings}
           t={t}
+          dispatch={this.props.dispatch}
         />
         {this.props.showTangle && this.state.tree && this.state.treeToo ? (
           <Tangle

--- a/src/globalStyles.js
+++ b/src/globalStyles.js
@@ -265,6 +265,11 @@ export const infoPanelStyles = {
     minWidth: 130,
     verticalAlign: "top"
   },
+  link: {
+    color: "#5097BA",
+    cursor: "pointer",
+    fontWeight: 400
+  },
   break: {
     marginBottom: "10px"
   }


### PR DESCRIPTION
Following on from https://github.com/nextstrain/auspice/pull/1308
which allowed node attrs to be links, this allows them to load
different datasets.

The code here isn't well tested, but provides a starting point
for linking together trees.
