### PR TITLE
[bugfix] Initialize `filtersInFooter` for all datasets

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -219,6 +219,7 @@ const modifyStateViaMetadata = (state, metadata) => {
     });
   } else {
     console.warn("JSON did not include any filters");
+    state.filtersInFooter = [];
   }
   state.filters[strainSymbol] = [];
   state.filters[genotypeSymbol] = []; // this doesn't necessitate that mutations are defined


### PR DESCRIPTION
This fixes a bug noticed in auspice.us [1] where certain
datasets would not have the `controls.filtersInFooter` state set,
causing a crash when metadata was dropped on. Type / prop checking
would have alerted us to this.

[1] https://github.com/nextstrain/auspice/issues/1304

Closes #1304