### PR TITLE
[PhyloTree] branch label bugfix

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -150,9 +150,6 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
   });
 
   /* special cases not listed in classesToPotentiallyUpdate */
-  if (elemsToUpdate.has('.branchLabel') && !extras.newBranchLabellingKey) {
-    this.updateBranchLabels(transitionTime);
-  }
   if (extras.hideTipLabels) {
     this.removeTipLabels();
   } else if (elemsToUpdate.has('.tipLabel')) {
@@ -192,6 +189,8 @@ export const modifySVG = function modifySVG(elemsToUpdate, svgPropsToUpdate, tra
     if (extras.newBranchLabellingKey !== "none") {
       this.drawBranchLabels(extras.newBranchLabellingKey);
     }
+  } else if (elemsToUpdate.has('.branchLabel')) {
+    this.updateBranchLabels(transitionTime);
   }
 };
 

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -95,6 +95,9 @@ const createBranchLabelVisibility = (key, layout, totalTipsInView) => {
 };
 
 export const updateBranchLabels = function updateBranchLabels(dt) {
+  if (!this.groups.branchLabels) {
+    return;
+  }
   const visibility = createBranchLabelVisibility(
     this.params.branchLabelKey,
     this.layout,


### PR DESCRIPTION
Fixes a bug where we sometimes ask PhyloTree to update the branch labels
for a view without any branch labels, which would cause auspice
to crash.
I first tried to fix this in a80e1869956daa0c63a0bfc5f564745023263358
but that didn't cover all the situations when this could arise.

Steps which triggered the bug (found by @trvrb):
1. Go to: <auspice_server>/ncov/global?branches=hide&c=region&l=scatter&regression=show&scatterX=div&scatterY=S1_mutations
2. Change x to "Sampling date"
3. Change x back to "Divergence"