### PR TITLE
Continous color scale improvements

### DIFF
--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -139,6 +139,9 @@ class Legend extends React.Component {
   }
 
   styleLabelText(label) {
+    if (this.props.colorScale.legendLabels && this.props.colorScale.legendLabels.has(label)) {
+      return this.props.colorScale.legendLabels.get(label);
+    }
     /* depending on the colorBy, we display different labels! */
     if (this.props.colorBy === "num_date") {
       const legendValues = this.props.colorScale.visibleLegendValues;

--- a/src/util/tipRadiusHelpers.js
+++ b/src/util/tipRadiusHelpers.js
@@ -4,19 +4,18 @@ import { getTraitFromNode } from "../util/treeMiscHelpers";
 
 /**
 * equates a single tip and a legend element
-* exact match is required for categorical qunantities such as genotypes, regions
-* continuous variables need to fall into the interal (lower_bound[leg], leg]
-* @param selectedLegendItem - value of the selected tip attribute (numeric or string)
-* @param node - node (tip) in question
-* @param legendBoundsMap - if falsey, then exact match required. Else contains bounds for match.
-* @param colorScale - used to get the value of the attribute being used for colouring
+* exact match is required for categorical quantities such as genotypes, regions
+* continuous variables need to fall into the interval (lower_bound, upper_bound]
+* @param {string|number} selectedLegendItem e.g. "USA" or 2021
+* @param {object} node - node (tip) in question
+* @param {object} colorScale - used to get the value of the attribute being used for colouring
 * @returns bool
 */
 const determineLegendMatch = (selectedLegendItem, node, colorScale) => {
   const nodeAttr = getTipColorAttribute(node, colorScale);
   if (colorScale.continuous) {
     return (nodeAttr <= colorScale.legendBounds[selectedLegendItem][1]) &&
-           (nodeAttr >= colorScale.legendBounds[selectedLegendItem][0]);
+           (nodeAttr > colorScale.legendBounds[selectedLegendItem][0]);
   }
   return nodeAttr === selectedLegendItem;
 };

--- a/test/colorScales.test.js
+++ b/test/colorScales.test.js
@@ -1,4 +1,4 @@
-import { unknownColor, createScaleFromProvidedScaleMap } from "../src/util/colorScale";
+import { unknownColor, createNonContinuousScaleFromProvidedScaleMap } from "../src/util/colorScale";
 
 const crypto = require("crypto");
 
@@ -7,7 +7,7 @@ const crypto = require("crypto");
 test("Test that a JSON-provided scale results in nodes using the correct colours", () => {
   const nodes = makeNodes(50, {country: ['A', 'B', 'D', undefined]});
   const providedScale = [['A', 'AMBER'], ['B', 'BLUE'], ['C', "CYAN"]];
-  const {colorScale} = createScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);
+  const {colorScale} = createNonContinuousScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);
   expect(colorScale('A')).toEqual("AMBER");
   expect(colorScale('B')).toEqual("BLUE");
   expect(colorScale('C')).toEqual("CYAN"); // Note that 'C' is in the colorMap, even though it is not defined on tree
@@ -18,7 +18,7 @@ test("Test that a JSON-provided scale results in nodes using the correct colours
 test("Test that a misformatted JSON-provided scale throws an error", () => {
   const nodes = makeNodes(50, {country: ['A', 'B', 'D', undefined]});
   const providedScale = {A: 'AMBER', B: 'BLUE', C: "CYAN"};
-  expect(() => {createScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);})
+  expect(() => {createNonContinuousScaleFromProvidedScaleMap("country", providedScale, nodes, undefined);})
     .toThrow(/has defined a scale which wasn't an array/);
 });
 


### PR DESCRIPTION
Extends the dataset JSON to allow continuous colorings to provide a scale, which we interpolate between to get the colour scheme, and custom legend data, which allows controlover the values in the scale which we use as legend elements, the displayed text, and the range of values which each entry covers.

Closes https://github.com/nextstrain/ncov/issues/617

---

Following examples available via https://staging.nextstrain.org/ncov_global_custom-continuous-colouring.json

**Custom legend stops**

```json
      {
        "key": "S1_mutations",
        "title": "S1 mutations",
        "type": "continuous",
        "legend": [
          {"value": 0},
          {"value": 2},
          {"value": 4},
          {"value": 6},
          {"value": 8},
          {"value": 10},
          {"value": 12},
          {"value": 14}
        ]
      },
```

![image](https://user-images.githubusercontent.com/8350992/116356468-64aeeb80-a84f-11eb-9156-d648f8eadbe9.png)
_Left: this PR, Right: current master_

**Custom scale, legend stops, values and bounds**

```json
      {
        "key": "logistic_growth",
        "title": "Logistic growth",
        "type": "continuous",
        "scale": [
          [-30, "#253494"],
          [-15, "#2c7fb8"],
          [-0.11, "#7fcdbb"],
          [-0.1, "#d0d0d0"],
          [0.1, "#d0d0d0"],
          [0.11, "#fed976"],
          [10, "#bd0026"]
        ],
        "legend": [
          {"value": -15, "display": "<-10%/year",    "bounds": [-30,-10]},
          {"value": -5,  "display": "-10 - 0%/year", "bounds": [-10,-0.01]},
          {"value": 0,   "display": "no change",     "bounds": [-0.01, 0.01]},
          {"value": 1.5, "display": "0 - 3%/year",   "bounds": [0.01, 3]},
          {"value": 4.5, "display": "3 - 6%/year",   "bounds": [3, 6]},
          {"value": 7,   "display": ">6%/year",      "bounds": [6,20]}
        ]
      },
```

![image](https://user-images.githubusercontent.com/8350992/116356536-81e3ba00-a84f-11eb-9250-41202a1cf151.png)

_Left: this PR, Right: current master_