### PR TITLE
Adjust grayscale color ramp

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -203,7 +203,7 @@ export const removeStream = (svg) => {
 };
 
 const generateColorScaleD3 = (categories, colorScale) => (d, i) =>
-  categories[i] === unassigned_label ? "rgb(190, 190, 190)" : rgb(colorScale.scale(categories[i])).toString();
+  categories[i] === unassigned_label ? "#ADB1B3" : rgb(colorScale.scale(categories[i])).toString();
 
 function handleMouseOver() {
   select(this).attr("opacity", 1);

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -11,7 +11,7 @@ import { setGenotype, orderOfGenotypeAppearance } from "./setGenotype";
 import { getTraitFromNode } from "./treeMiscHelpers";
 import { sortedDomain } from "./sortedDomain";
 
-export const unknownColor = "#AAAAAA";
+export const unknownColor = "#ADB1B3";
 
 /**
  * calculate the color scale.
@@ -130,7 +130,7 @@ export function createNonContinuousScaleFromProvidedScaleMap(colorBy, providedSc
   const extraVals = getExtraVals(t1nodes, t2nodes, colorBy, domain);
   if (extraVals.length) { // we must add these to the domain + provide a color value
     domain = domain.concat(extraVals);
-    const extraColors = createListOfColors(extraVals.length, [rgb(180, 180, 180), rgb(90, 90, 90)]);
+    const extraColors = createListOfColors(extraVals.length, ["#BDC3C6", "#868992"]);
     extraVals.forEach((val, idx) => {
       colorMap.set(val, extraColors[idx]);
     });

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -130,7 +130,7 @@ export function createNonContinuousScaleFromProvidedScaleMap(colorBy, providedSc
   const extraVals = getExtraVals(t1nodes, t2nodes, colorBy, domain);
   if (extraVals.length) { // we must add these to the domain + provide a color value
     domain = domain.concat(extraVals);
-    const extraColors = createListOfColors(extraVals.length, [rgb(192, 192, 192), rgb(32, 32, 32)]);
+    const extraColors = createListOfColors(extraVals.length, [rgb(180, 180, 180), rgb(90, 90, 90)]);
     extraVals.forEach((val, idx) => {
       colorMap.set(val, extraColors[idx]);
     });


### PR DESCRIPTION
The existing grayscale color ramp (used for values absent in an explicitly specified color scale) had values that were too dark and threw off the overall color balance. This commit narrows the grayscale color ramp to be more in line with pastel color ramp.

I mainly did this because I didn't like the aesthetics of the new clades coloring. Here it is on current Auspice `master`:

<img width="1283" alt="master" src="https://user-images.githubusercontent.com/1176109/120728509-eff45000-c491-11eb-9b69-774a218f09bf.png">

And here is this PR:

<img width="1283" alt="PR" src="https://user-images.githubusercontent.com/1176109/120728523-f5ea3100-c491-11eb-8c0b-6a8bfd603626.png">

