### PR TITLE
[bugfix] generate colour scales for 37 values

### DIFF
--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -339,7 +339,7 @@ function createDiscreteScale(domain, type) {
   let colorList;
   if (type==="ordinal" || type==="categorical") {
     /* TODO: use different colours! */
-    colorList = domain.length <= colors.length ?
+    colorList = domain.length < colors.length ?
       colors[domain.length].slice() :
       colors[colors.length - 1].slice();
   }


### PR DESCRIPTION
Our colour-scale generation logic contained a bug where we couldn't
have domains of length 37 (off-by-one error).

Closes https://github.com/nextstrain/auspice/issues/1354
