### PR TITLE
Styling adjustments to footer text

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -20,39 +20,43 @@ const FooterStyles = styled.div`
   color: rgb(136, 136, 136);
   line-height: 1.4;
 
+  p {
+    font-weight: 300;
+  }
+
   h1 {
     font-weight: 700;
-    font-size: 2.2em;
+    font-size: 2.50em;
     margin: 0.2em 0;
   }
 
   h2 {
     font-weight: 600;
-    font-size: 2em;
+    font-size: 2.15em;
     margin: 0.2em 0;
   }
 
   h3 {
     font-weight: 500;
-    font-size: 1.8em;
+    font-size: 1.70em;
     margin: 0.2em 0;
   }
 
   h4 {
     font-weight: 500;
-    font-size: 1.6em;
+    font-size: 1.25em;
     margin: 0.1em 0;
   }
 
   h5 {
     font-weight: 500;
-    font-size: 1.4em;
+    font-size: 1.0em;
     margin: 0.1em 0;
   }
 
   h6 {
     font-weight: 500;
-    font-size: 1.2em;
+    font-size: 0.85em;
     margin: 0.1em 0;
   }
 


### PR DESCRIPTION
### Description of proposed changes    

This is a simple update to the CSS styling of the page footer specified in `footer.js`. This is motivated by display of long Markdown description in `open` builds. Here is resulting display prior to this update:

<img width="975" alt="before" src="https://user-images.githubusercontent.com/1176109/123890012-622e4800-d90b-11eb-91ec-3c69a2c3034a.png">

And here is the resulting display after this update:

<img width="975" alt="after" src="https://user-images.githubusercontent.com/1176109/123890030-69555600-d90b-11eb-9167-9faff32c7674.png">

I don't think the main paragraph text was ever meant to be slightly bold. It has `font-weight: 300` specified under `FooterStyles`. However, because it wasn't specified under `p` the main paragraph text was getting set as `font-weight: 400`.

I borrowed the font sizing in the section headers from bedford.io, where I preferred to give more of a dynamic range compared to default CSS. In this case, I thought the `#####` to be much too large without providing the styling.

### Testing

Tested locally.
