### PR TITLE
Remove metadata download from GISAID datasets

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -23,6 +23,18 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
   const filePrefix = getFilePrefix();
   const temporal = distanceMeasure === "num_date";
 
+  /* set gisaidProvenance based on supplied JSON metadata */
+  let gisaidProvenance = false;
+  if ("dataProvenance" in metadata) {
+    for (const source of metadata.dataProvenance) {
+      if ("name" in source) {
+        if (source.name.toUpperCase() === "GISAID") {
+          gisaidProvenance = true;
+        }
+      }
+    }
+  }
+
   return (
     <>
       <div style={{fontWeight: 500, marginTop: "0px", marginBottom: "20px"}}>
@@ -43,12 +55,22 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         icon={<RectangularTreeIcon width={iconWidth} selected />}
         onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal})}
       />
-      <Button
-        name="Metadata (TSV)"
-        description={`Per-sample metadata (n = ${selectedTipsCount}).`}
-        icon={<MetaIcon width={iconWidth} selected />}
-        onClick={() => helpers.strainTSV(dispatch, filePrefix, tree.nodes, metadata.colorings, tree.visibility)}
-      />
+      {gisaidProvenance && (
+        <Button
+          name="Acknowledgments (TSV)"
+          description={`Per-sample acknowledgments (n = ${selectedTipsCount}).`}
+          icon={<MetaIcon width={iconWidth} selected />}
+          onClick={() => helpers.acknowledgmentsTSV(dispatch, filePrefix, tree.nodes, metadata.colorings, tree.visibility)}
+        />
+      )}
+      {!gisaidProvenance && (
+        <Button
+          name="Metadata (TSV)"
+          description={`Per-sample metadata (n = ${selectedTipsCount}).`}
+          icon={<MetaIcon width={iconWidth} selected />}
+          onClick={() => helpers.strainTSV(dispatch, filePrefix, tree.nodes, metadata.colorings, tree.visibility)}
+        />
+      )}
       {helpers.areAuthorsPresent(tree) && (
         <Button
           name="Author Metadata (TSV)"

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -257,6 +257,73 @@ export const strainTSV = (dispatch, filePrefix, nodes, colorings, nodeVisibiliti
   dispatch(infoNotification({message: `Metadata exported to ${filename}`}));
 };
 
+/**
+ * Create & write a TSV file where each row is a strain in the tree,
+ * but only include the following fields:
+ * - strain
+ * - gisaid_epi_isl
+ * - genbank_accession
+ * - originating_lab
+ * - submitting_lab
+ * - author
+ * Only visible nodes (tips) will be included in the file.
+ */
+export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, colorings, nodeVisibilities) => {
+
+  /* traverse the tree & store tip information. We cannot write this out as we go as we don't know
+  exactly which header fields we want until the tree has been traversed. */
+  const tipTraitValues = {};
+  const headerFields = ["strain"];
+
+  for (const [i, node] of nodes.entries()) {
+    if (node.hasChildren) continue; /* we only consider tips */
+
+    if (nodeVisibilities[i] !== NODE_VISIBLE || !node.inView) {
+      continue;
+    }
+
+    tipTraitValues[node.name] = {strain: node.name};
+    if (!node.node_attrs) continue; /* if this is not set then we don't have any node info! */
+
+    /* collect values of relevant traits */
+    const traitsToExport = ["gisaid_epi_isl", "genbank_accession", "originating_lab", "submitting_lab"];
+    for (const traitName of traitsToExport) {
+      const traitValue = getTraitFromNode(node, traitName);
+      if (traitValue) {
+        if (!headerFields.includes(traitName)) headerFields.push(traitName);
+        tipTraitValues[node.name][traitName] = traitValue;
+      }
+    }
+
+    /* handle `author` specially */
+    const fullAuthorInfo = getFullAuthorInfoFromNode(node);
+    if (fullAuthorInfo) {
+      const traitName = "author";
+      if (!headerFields.includes(traitName)) headerFields.push(traitName);
+      tipTraitValues[node.name][traitName] = fullAuthorInfo.value;
+      if (isPaperURLValid(fullAuthorInfo)) {
+        tipTraitValues[node.name][traitName] += ` (${fullAuthorInfo.paper_url})`;
+      }
+    }
+
+  }
+
+  /* turn the information into a string to be written */
+  const linesToWrite = [headerFields.join("\t")];
+  for (const data of Object.values(tipTraitValues)) {
+    const thisLine = [];
+    for (const trait of headerFields) {
+      thisLine.push(data[trait] || "");
+    }
+    linesToWrite.push(thisLine.join("\t"));
+  }
+
+  /* write out information we've collected */
+  const filename = `${filePrefix}_acknowledgements.tsv`;
+  write(filename, MIME.tsv, linesToWrite.join("\n"));
+  dispatch(infoNotification({message: `Acknowledgments exported to ${filename}`}));
+};
+
 export const exportTree = ({dispatch, filePrefix, tree, isNewick, temporal, colorings, colorBy}) => {
   try {
     const fName = `${filePrefix}_${temporal?'timetree':'tree'}.${isNewick?'nwk':'nexus'}`;
@@ -517,4 +584,3 @@ export const entropyTSV = (dispatch, filePrefix, entropy, mutType) => {
   write(filename, MIME.tsv, lines.join("\n"));
   dispatch(infoNotification({message: `Diversity data exported to ${filename}`}));
 };
-


### PR DESCRIPTION
### Description of proposed changes    

This commit uses `dataProvenance` in `metadata` to identify datasets using "GISAID" data. For these datasets, the full metadata download is swapped to an "acknowledgments" download that only includes the following fields:
 - `strain`
 - `gisaid_epi_isl`
 - `genbank_accession`
 - `originating_lab`
 - `submitting_lab`
 - `author`

This should fulfill GISAID's request to not allow download of metadata table from data sourced from GISAID.

### Testing

This has been tested locally and downloaded TSVs examined. Testing was done on datasets that are specified with GISAID provenance vs datasets without.

