### PR TITLE
Inactivate tips when no longer focused

### DIFF
--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -125,5 +125,5 @@ export const clearSelectedTip = function clearSelectedTip(d) {
     .attr("r", (dd) => dd["r"]);
   this.setState({selectedTip: null, hovered: null});
   /* restore the tip visibility! */
-  this.props.dispatch(applyFilter("remove", strainSymbol, [d.n.name]));
+  this.props.dispatch(applyFilter("inactivate", strainSymbol, [d.n.name]));
 };


### PR DESCRIPTION
Selecting a tip (and the corresponding info panel modal) is intrinsically linked to setting a single active "sample" filter. When clicking away from this modal the filter was removed.

This caused issues in the situation where "a tip is selected under a filter, then you click on that tip to see more information, when you click away to close the box, the filter is removed."

The solution here is to inactivate the sample filters when removing the info panel. This has the benefit (bug?) of keeping a history of clicked tips in the form of inactive filters. (Note that all strain filters can be removed by a single click in the sidebar filter badge.)

Closes https://github.com/nextstrain/auspice/issues/1357

@emmahodcroft could you test this out? There are alternative (harder) solutions where we keep track of whether a clicked tip was previously an inactive filter or not if we want to pursue that. However this PR, in conjunction with #1371, could potentially make @eharkins & Moira's job easier via the following workflow:

1. Click on every outlier tip. Each click will open a tip-info panel, so click outside of that to remove it each time.
2. Notice that all the clicked tips are now inactive filters
3. Click on the "eye" icon in the filter badge in the sidebar for "samples", which will make all these inactive sample filters active. 

