### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
 - npm run build
 after_success:
-- if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "release" ]]; then
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "release" && "$TRAVIS_NODE_VERSION" == "14" ]]; then
     npm run rebuild-docker-image;
     npm config set //registry.npmjs.org/:_authToken="$NPM_TOKEN";
     npm publish;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: node_js
 sudo: false
 dist: bionic
 node_js:
-- '10'
 - '12'
+- '14'
+- '16'
 install:
 - npm install
 - pip install --user awscli

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": ">=10.8.0 <=13.14",
-    "npm": ">=6.2"
+    "node": ">=12 <=16",
+    "npm": ">=6.9"
   },
   "bin": {
     "auspice": "./auspice.js"


### PR DESCRIPTION
The npm Auspice 2.29.0 release had integrity shasum errors:

```sh
# reported by npm publish running on TravisCI (node.js 10)                               
npm notice integrity:     sha512-zeNaSDrnIgvH6[...]PA0JfybEzP8Ig==
# reported by npm view auspice@2.29.0 after publishing
.integrity: sha512-27B/yNAPP1/vmSoqdBb3g1EMXJW/FLGFWSlTSBl7dDLksHAabqWOYP14aDWF5p4jUuvUNsT20O6G4b3pRcxRAg==
```

Looking through the TravisCI logs it became clear we were running `npm publish` for both versions of Node.js we ran TravisCI on, which resulted in one failure each time we released such as

```
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/auspice - You cannot publish over the previously published versions: 2.29.0.
```

This PR updates the Node.js versions we run CI on (v10 is no longer maintained), and only runs `npm publish` when building under v14. It is not clear whether this is related to the integrity shasum errors, or if they were stochastic (or some other 🐛 ).
