### PR TITLE
Clip tree to improve visibility of axes

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -219,6 +219,7 @@ export const modifySVGInStages = function modifySVGInStages(elemsToUpdate, svgPr
   /* STEP 2: move tips */
   const step2 = () => {
     if (!--inProgress) { /* decrement counter. When hits 0 run block */
+      this.setClipMask();
       const updateTips = createUpdateCall(".tip", svgPropsToUpdate);
       genericSelectAndModify(this.svg, ".tip", updateTips, transitionTimeMoveTips);
       setTimeout(step3, transitionTimeMoveTips);
@@ -370,6 +371,9 @@ export const change = function change({
   }
 
   /* Finally, actually change the SVG elements themselves */
+  if (svgHasChangedDimensions) {
+    this.setClipMask();
+  }
   const extras = { removeConfidences, showConfidences, newBranchLabellingKey };
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   extras.hideTipLabels = animationInProgress;

--- a/src/components/tree/phyloTree/defaultParams.js
+++ b/src/components/tree/phyloTree/defaultParams.js
@@ -11,7 +11,6 @@ export const createDefaultParams = () => ({
   tickLabelFill: darkGrey,
   minorTicks: 4,
   orientation: [1, 1],
-  margins: {left: 30, right: 15, top: 10, bottom: 40},
   showGrid: true,
   fillSelected: "#A73",
   radiusSelected: 5,

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -409,7 +409,7 @@ export const addGrid = function addGrid() {
         .style("fill", this.params.tickLabelFill)
         .style("text-anchor", "middle")
         .attr("x", Math.abs(this.xScale.range()[1]-this.xScale.range()[0]) / 2)
-        .attr("y", this.yScale.range()[1] + this.params.margins.bottom - 6);
+        .attr("y", parseInt(this.svg.attr("height"), 10) - 1);
   }
   if (yAxisLabel) {
     this.groups.axisText
@@ -453,7 +453,7 @@ export const showTemporalSlice = function showTemporalSlice() {
   const rightHandTree = this.params.orientation[0] === -1;
   const rootXPos = this.xScale(this.nodes[0].x);
   let totalWidth = rightHandTree ? this.xScale.range()[0] : this.xScale.range()[1];
-  totalWidth += (this.params.margins.left + this.params.margins.right);
+  totalWidth += (this.margins.left + this.margins.right);
 
   /* the gray region between the root (ish) and the minimum date */
   if (Math.abs(xWindow[0]-rootXPos) > minPxThreshold) { /* don't render anything less than this num of px */
@@ -488,13 +488,13 @@ export const showTemporalSlice = function showTemporalSlice() {
 
   /* the gray region between the maximum selected date and the last tip */
   let xStart_endRegion = xWindow[1]; // starting X coordinate of the "end" rectangle
-  let width_endRegion = totalWidth - this.params.margins.right - xWindow[1];
+  let width_endRegion = totalWidth - this.margins.right - xWindow[1];
 
-  let transform_endRegion = `translate(${totalWidth - this.params.margins.right},0) scale(-1,1)`;
+  let transform_endRegion = `translate(${totalWidth - this.margins.right},0) scale(-1,1)`;
   // With a right hand tree, the coordinate system flips (right to left)
   if (rightHandTree) {
-    xStart_endRegion = this.params.margins.right;
-    width_endRegion = xWindow[1] - this.params.margins.right;
+    xStart_endRegion = this.margins.right;
+    width_endRegion = xWindow[1] - this.margins.right;
     transform_endRegion = `translate(${xStart_endRegion},0)`;
   }
 

--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -33,10 +33,10 @@ const addSVGGroupsIfNeeded = (groups, svg) => {
       .attr('class', 'temporalWindowEnd');
   }
   if (!("majorGrid" in groups)) {
-    groups.majorGrid = svg.append("g").attr("id", "majorGrid");
+    groups.majorGrid = svg.append("g").attr("id", "majorGrid").attr("clip-path", "url(#treeClip)");
   }
   if (!("minorGrid" in groups)) {
-    groups.minorGrid = svg.append("g").attr("id", "minorGrid");
+    groups.minorGrid = svg.append("g").attr("id", "minorGrid").attr("clip-path", "url(#treeClip)");
   }
   if (!("gridText" in groups)) {
     groups.gridText = svg.append("g").attr("id", "gridText");

--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -130,7 +130,7 @@ export const drawBranchLabels = function drawBranchLabels(key) {
   const visibility = createBranchLabelVisibility(key, this.layout, this.zoomNode.n.tipCount);
 
   if (!("branchLabels" in this.groups)) {
-    this.groups.branchLabels = this.svg.append("g").attr("id", "branchLabels");
+    this.groups.branchLabels = this.svg.append("g").attr("id", "branchLabels").attr("clip-path", "url(#treeClip)");
   }
   this.groups.branchLabels
     .selectAll(".branchLabel")

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -490,7 +490,10 @@ export const mapToScreen = function mapToScreen() {
   timerEnd("mapToScreen");
 };
 
+const JITTER_MIN_STEP_SIZE = 50; // pixels
+
 function padCategoricalScales(domain, scale) {
+  if (scale.step() > JITTER_MIN_STEP_SIZE) return scale.padding(0.5); // balanced padding when we can jitter
   if (domain.length<=4) return scale.padding(0.4);
   if (domain.length<=6) return scale.padding(0.3);
   if (domain.length<=10) return scale.padding(0.2);
@@ -502,7 +505,7 @@ function padCategoricalScales(domain, scale) {
  */
 function jitter(axis, scale, nodes) {
   const step = scale.step();
-  if (step < 50) return; // don't jitter if there's little space between bands
+  if (scale.step() <= JITTER_MIN_STEP_SIZE) return;
   const rand = []; // pre-compute a small set of pseudo random numbers for speed
   for (let i=1e2; i--;) {
     rand.push((Math.random()-0.5)*step*0.5); // occupy 50%

--- a/src/components/tree/phyloTree/phyloTree.js
+++ b/src/components/tree/phyloTree/phyloTree.js
@@ -55,6 +55,7 @@ PhyloTree.prototype.render = renderers.render;
 PhyloTree.prototype.clearSVG = renderers.clearSVG;
 
 /* D R A W I N G    F U N C T I O N S */
+PhyloTree.prototype.setClipMask = renderers.setClipMask;
 PhyloTree.prototype.drawTips = renderers.drawTips;
 PhyloTree.prototype.drawBranches = renderers.drawBranches;
 PhyloTree.prototype.drawVaccines = renderers.drawVaccines;


### PR DESCRIPTION
This (essentially) clips branches, tips and grids to the range of the
{x,y} scales in order to prevent branches / tips from obscuring the axes

This works well on the scatterplots I've thrown at it, but a bit more testing is needed. I haven't tested the slowdown (if any) which I'll do before merging.

The display of y-axis tick labels is another area of improvement to make for scatterplots