### PR TITLE
[tree] button to go back to previous zoom

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { withTranslation } from "react-i18next";
-import { FaSearchMinus } from "react-icons/fa";
+import { FaSearchMinus, FaReply } from "react-icons/fa";
 import { updateVisibleTipsAndBranchThicknesses } from "../../actions/tree";
 import Card from "../framework/card";
 import Legend from "./legend/legend";
@@ -10,6 +10,7 @@ import HoverInfoPanel from "./infoPanels/hover";
 import TipClickedPanel from "./infoPanels/click";
 import { changePhyloTreeViaPropsComparison } from "./reactD3Interface/change";
 import * as callbacks from "./reactD3Interface/callbacks";
+import { StyledTooltip } from "../controls/styles";
 import { tabSingle, darkGrey, lightGrey } from "../../globalStyles";
 import { renderTree } from "./reactD3Interface/initialRender";
 import Tangle from "./tangle";
@@ -109,6 +110,8 @@ class Tree extends React.Component {
     const treeIsZoomed = this.props.tree.idxOfInViewRootNode !== 0 ||
       this.props.treeToo.idxOfInViewRootNode !== 0;
 
+    const treeCanReturnToPreviousZoom = !!this.props.tree.idxOfInViewRootNodeHistory.length;
+
     return {
       treeButtonsDiv: {
         zIndex: 100,
@@ -137,6 +140,17 @@ class Tree extends React.Component {
         color: treeIsZoomed ? darkGrey : lightGrey,
         pointerEvents: treeIsZoomed ? "auto" : "none",
         marginRight: "4px"
+      },
+      revertTreeZoomButton: {
+        zIndex: 100,
+        display: "inline-block",
+        cursor: treeCanReturnToPreviousZoom ? "pointer" : "auto",
+        color: treeCanReturnToPreviousZoom ? darkGrey : lightGrey,
+        pointerEvents: treeCanReturnToPreviousZoom ? "auto" : "none",
+        marginRight: "4px"
+      },
+      helpTooltip: {
+        textTransform: "none"
       }
     };
   };
@@ -158,6 +172,10 @@ class Tree extends React.Component {
       root: [this.props.tree.idxOfFilteredRoot, this.props.treeToo.idxOfFilteredRoot]
     }));
   };
+
+  revertTreeZoom = () => {
+    this.props.dispatch(updateVisibleTipsAndBranchThicknesses({revertTreeZoom: true}));
+  }
 
   zoomBack = () => {
     let newRoot, newRootToo;
@@ -224,6 +242,20 @@ class Tree extends React.Component {
         }
         {this.props.narrativeMode ? null : (
           <div style={{...styles.treeButtonsDiv}}>
+            { this.props.showTreeToo ?
+              null :
+              (<button
+                style={{...tabSingle, ...styles.revertTreeZoomButton, ...styles.helpTooltip}}
+                onClick={this.revertTreeZoom}
+                data-tip
+                data-for="revertTreeZoom"
+              >
+                <FaReply/>
+                <StyledTooltip place="bottom" type="dark" effect="solid" id="revertTreeZoom">
+                  Go back to the previous zoom state
+                </StyledTooltip>
+              </button>)
+            }
             <button
               style={{...tabSingle, ...styles.zoomOutButton}}
               onClick={this.zoomBack}

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -20,6 +20,7 @@ export const getDefaultTreeState = () => {
     vaccines: false,
     version: 0,
     idxOfInViewRootNode: 0,
+    idxOfInViewRootNodeHistory: [],
     visibleStateCounts: {},
     totalStateCounts: {},
     availableBranchLabels: [],
@@ -52,6 +53,9 @@ const Tree = (state = getDefaultTreeState(), action) => {
         visibleStateCounts: countTraitsAcrossTree(state.nodes, action.stateCountAttrs, action.visibility, true),
         selectedStrain: action.selectedStrain
       };
+      if (action.idxOfInViewRootNodeHistory) {
+        newStates.idxOfInViewRootNodeHistory = action.idxOfInViewRootNodeHistory;
+      }
       return Object.assign({}, state, newStates);
     case types.UPDATE_TIP_RADII:
       return Object.assign({}, state, {


### PR DESCRIPTION
The ability to return to the previous zoom level is useful when
exploring trees in detail, especially when combined with the
magnifying glass (which zooms out).

A hover info box has been added to convey the functionality of this
icon.

The implementation involving multiple trees is conceptually more
complicated, as I don't want us to return to the previous zoom state
in each tree. (This is similar to the magnifiying glass icon, which
zooms out in both trees.) The best solution is probably tree-specific
UI. For now, this functionality is only surfaced if we are viewing a
single tree.
