### PR TITLE
narratives: Set max-width on images in the main (right-hand) panel

### DIFF
--- a/src/components/narrative/MainDisplayMarkdown.js
+++ b/src/components/narrative/MainDisplayMarkdown.js
@@ -92,6 +92,7 @@ const Container = styled.div`
     margin-right: 30px;
     margin-top: 2px;
     margin-bottom: 2px;
+    max-width: 100%;
   }
 
   table, th, td {


### PR DESCRIPTION
This prevents wide or high-resolution images from exceeding the panel's
width, which is important for visibility, especially since the main
panel doesn't scroll horizontally.