### PR TITLE
Limit scope of narratives search in URL

### DIFF
--- a/src/actions/loadData.js
+++ b/src/actions/loadData.js
@@ -52,7 +52,7 @@ export const loadJSONs = ({url = window.location.pathname, search = window.locat
       dispatch({type: types.DATA_INVALID}); // "resets" state
     }
     const query = queryString.parse(search);
-    if (url.includes("narratives")) {
+    if (url.includes("/narratives/")) {
       loadNarrative(dispatch, url, query);
     } else {
       warnDeprecatedQuerySyntax(dispatch, query);


### PR DESCRIPTION
### Description of proposed changes    

Changes the substring to search a given URL for narratives content to include a leading and trailing forward slash. This change limits the scope of the search in the URL to match paths like https://nextstrain.org/narratives/ and
https://nextstrain.org/community/narratives/ but to avoid trying to load as narratives datasets that happen to have the word "narratives" as a substring of their names (e.g., "nextstrain-narratives-demo_ncov_2020-03-04.json").

The following steps recreate the original issue from a clone of the Auspice repository:

```
curl "https://data.nextstrain.org/ncov_2020-03-04.json" | gzip -c -d > data/nextstrain-narratives-demo_ncov_2020-03-04.json

auspice view --datasetDir data/
```

### Testing

Tested locally with a build named `nextstrain-narratives-demo_ncov_2020-03-04.json` and with a narrative that was working before and after this change to the URL search.