### PR TITLE
Travis CI: Remove install of AWS CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 - '16'
 install:
 - npm install
-- pip install --user awscli
 script:
 - npm run build
 after_success:


### PR DESCRIPTION
No longer needed since "Update release instructions, docs" (f6a576db),
which removed the release/deploy step that uploaded to S3.
