### PR TITLE
Update nextstrain.org test PR author and title

### DIFF
--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -28,10 +28,12 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.JAMES_PAT }}
+          token: ${{ secrets.NEXTSTRAIN_BOT_PAT }}
           branch: "auspice-pr-${{ github.event.pull_request.number }}"
           commit-message: "[testing only] upgrade auspice to ${{ env.auspice_commit }}"
-          title: 'Test auspice PR ${{ github.event.pull_request.number }}'
+          author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
+          committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
+          title: '[bot] Test auspice PR ${{ github.event.pull_request.number }}'
           body: |
             This PR has been created to test Auspice from [PR ${{ github.event.pull_request.number }}](https://github.com/nextstrain/auspice/pull/${{ github.event.pull_request.number }})
 

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -33,7 +33,7 @@ jobs:
           commit-message: "[testing only] upgrade auspice to ${{ env.auspice_commit }}"
           author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
           committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
-          title: '[bot] Test auspice PR ${{ github.event.pull_request.number }}'
+          title: '[bot] [DO NOT MERGE] Test auspice PR ${{ github.event.pull_request.number }}'
           body: |
             This PR has been created to test Auspice from [PR ${{ github.event.pull_request.number }}](https://github.com/nextstrain/auspice/pull/${{ github.event.pull_request.number }})
 


### PR DESCRIPTION
Currently, the [test PRs](https://github.com/nextstrain/nextstrain.org/pulls?q=is%3Apr+Test+auspice+PR) are created under @jameshadfield's personal account. Changes:

- Use @nextstrain-bot account
- Prefix PR title with `[bot] [DO NOT MERGE]`