### PR TITLE
Remove scrollbar in PanelsContainer when no scrolling is possible

### DIFF
--- a/src/components/main/styles.js
+++ b/src/components/main/styles.js
@@ -11,7 +11,7 @@ export const PanelsContainer = styled.div`
   height: ${(props) => props.height+"px"};
   width: ${(props) => props.width+"px"};
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   left: ${(props) => props.left+"px"};
 `;
 


### PR DESCRIPTION
### Description of proposed changes    
Removes scrollbar in the `PanelsContainer` component when the window's height is enough to show the entire content.

### Related issue(s)
Fixes #1438  

### Testing
Build from this fork, go to `/ncov/gisaid/global?branchLabel=none&c=GISAID_clade&d=tree&p=full&sidebar=closed` with adequate window height (> 700px should be fine) and the scrollbar should be hidden. The scrollbar should be shown when scrolling is needed.