### PR TITLE
categorise mutations

### DIFF
--- a/src/components/tree/infoPanels/MutationTable.js
+++ b/src/components/tree/infoPanels/MutationTable.js
@@ -1,0 +1,131 @@
+import React from "react";
+import styled from 'styled-components';
+import { getBranchMutations, getTipChanges } from "../../../util/treeMiscHelpers";
+
+
+const Button = styled.button`
+  border: 0px;
+  background-color: inherit;
+  cursor: pointer;
+  outline: 0;
+  text-decoration: underline;
+  font-size: 16px;
+  padding: 0px 0px;
+`;
+
+const mutSortFn = (a, b) => {
+  const [aa, bb] = [parseInt(a.slice(1, -1), 10), parseInt(b.slice(1, -1), 10)];
+  return aa<bb ? -1 : 1;
+};
+
+const Heading = styled.p`
+  margin-top: 12px;
+  margin-bottom: 4px;
+`;
+const SubHeading = styled.span`
+  padding-right: 8px;
+`;
+const MutationList = styled.span`
+`;
+const MutationLine = styled.p`
+  margin: 0px 0px 4px 0px;
+  font-weight: 300;
+  font-size: 16px;
+`;
+const TableFirstColumn = styled.td`
+  font-weight: 500;
+  white-space: nowrap;
+  vertical-align: baseline;
+`;
+const ListOfMutations = ({title, muts}) => (
+  <MutationLine>
+    <SubHeading key={title}>{title}</SubHeading>
+    <MutationList>{muts.sort(mutSortFn).join(", ")}</MutationList>
+  </MutationLine>
+);
+
+const mutCategoryLookup = {
+  unique: "Unique",
+  changes: "Changes",
+  homoplasies: "Homoplasies",
+  reversionsToRoot: "Reversions to root",
+  gaps: "Gaps",
+  ns: "Ns "
+};
+
+/**
+ * Returns a TSV-style string of all mutations / changes
+ */
+const mutationsToTsv = (categorisedMutations, geneSortFn) =>
+  Object.keys(categorisedMutations).sort(geneSortFn).map((gene) =>
+    Object.keys(mutCategoryLookup)
+      .filter((key) => (key in categorisedMutations[gene] && categorisedMutations[gene][key].length))
+      .map((key) =>
+        `${gene}\t${key}\t${categorisedMutations[gene][key].sort(mutSortFn).join(", ")}`
+      )
+  ).flat()
+  .join("\n");
+
+/**
+ * Returns a table row element for the (categorised) mutations for the given gene
+ * @returns {(ReactComponent|null)}
+ */
+const displayGeneMutations = (gene, mutsPerCat) => {
+  /* check if any categories have entries for us to display */
+  if (Object.values(mutsPerCat).filter((lst) => lst.length).length === 0) {
+    return null;
+  }
+  return (
+    <tr key={gene}>
+      <TableFirstColumn>{gene==="nuc" ? "Nt" : gene}</TableFirstColumn>
+      <td>
+        {Object.entries(mutCategoryLookup).map(([key, name]) => (
+          (key in mutsPerCat && mutsPerCat[key].length) ?
+            (<ListOfMutations
+              key={name}
+              title={`${name} (${mutsPerCat[key].length}):`}
+              muts={mutsPerCat[key]}
+            />) :
+            null
+        ))}
+      </td>
+    </tr>
+  );
+};
+
+export const MutationTable = ({node, geneSortFn, isTip, observedMutations}) => {
+  const categorisedMutations = isTip ?
+    getTipChanges(node) :
+    getBranchMutations(node, observedMutations);
+
+  if (Object.keys(categorisedMutations).length===0) {
+    return (
+      <Heading>
+        {isTip ? `No sequence changes observed` : `No mutations observed on branch`}
+      </Heading>
+    );
+  }
+
+  return (
+    <>
+      <Heading>
+        {isTip ? `Sequence changes observed (from root):` : `Mutations observed on branch:`}
+      </Heading>
+      <table>
+        <tbody>
+          {Object.keys(categorisedMutations).sort(geneSortFn).map(
+            (gene) => displayGeneMutations(gene, categorisedMutations[gene], isTip)
+          )}
+          <tr>
+            <td/>
+            <td>
+              <Button onClick={() => {navigator.clipboard.writeText(mutationsToTsv(categorisedMutations, geneSortFn));}}>
+                {`Click to copy all ${isTip ? 'changes' : 'mutations'} to clipboard as TSV`}
+              </Button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
+};

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -191,6 +191,7 @@ class Tree extends React.Component {
           colorScale={this.props.colorScale}
           colorings={this.props.metadata.colorings}
           geneSortFn={this.state.geneSortFn}
+          observedMutations={this.props.tree.observedMutations}
           panelDims={{width: this.props.width, height: this.props.height, spaceBetweenTrees}}
           t={t}
         />

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -197,6 +197,7 @@ class Tree extends React.Component {
         <NodeClickedPanel
           clearSelectedNode={this.clearSelectedNode}
           selectedNode={this.state.selectedNode}
+          observedMutations={this.props.tree.observedMutations}
           colorings={this.props.metadata.colorings}
           geneSortFn={this.state.geneSortFn}
           t={t}

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -22,6 +22,7 @@ export const getDefaultTreeState = () => {
     idxOfInViewRootNode: 0,
     visibleStateCounts: {},
     totalStateCounts: {},
+    observedMutations: {},
     availableBranchLabels: [],
     selectedStrain: undefined,
     selectedClade: undefined

--- a/src/util/treeJsonProcessing.js
+++ b/src/util/treeJsonProcessing.js
@@ -117,6 +117,29 @@ const appendParentsToTree = (root) => {
   }
 };
 
+/**
+ * Collects all mutations on the tree
+ * @param  {Node[]} nodesArray
+ * @return {Object}
+ *         keys are mutations in gene:fromPosTo format (e.g. nuc:A123T)
+ *         values are integers representing occurrences on tree
+ * @todo   The original remit of this function was for homoplasy detection.
+ *         If storing all the mutations becomes an issue, we may be able use an array
+ *         of mutations observed more than once.
+ */
+const collectObservedMutations = (nodesArray) => {
+  const mutations = {};
+  nodesArray.forEach((n) => {
+    if (!n.branch_attrs || !n.branch_attrs.mutations) return;
+    Object.entries(n.branch_attrs.mutations).forEach(([gene, muts]) => {
+      muts.forEach((mut) => {
+        mutations[`${gene}:${mut}`] ? mutations[`${gene}:${mut}`]++ : (mutations[`${gene}:${mut}`] = 1);
+      });
+    });
+  });
+  return mutations;
+};
+
 export const treeJsonToState = (treeJSON) => {
   appendParentsToTree(treeJSON);
   const nodesArray = flattenTree(treeJSON);
@@ -126,7 +149,8 @@ export const treeJsonToState = (treeJSON) => {
     return (v && (Object.keys(v).length > 1 || Object.keys(v)[0] !== "serum"));
   });
   const availableBranchLabels = processBranchLabelsInPlace(nodesArray);
+  const observedMutations = collectObservedMutations(nodesArray);
   return Object.assign({}, getDefaultTreeState(), {
-    nodes, vaccines, availableBranchLabels, loaded: true
+    nodes, vaccines, observedMutations, availableBranchLabels, loaded: true
   });
 };

--- a/test/treeHelpers.test.js
+++ b/test/treeHelpers.test.js
@@ -1,5 +1,6 @@
 import { getUrlFromNode, getAccessionFromNode, getBranchMutations } from "../src/util/treeMiscHelpers";
 import { treeJsonToState } from "../src/util/treeJsonProcessing";
+import { parseIntervalsOfNsOrGaps } from "../src/components/tree/infoPanels/MutationTable";
 
 /**
  * `dummyTree` is a simple tree with three tips: tipX-Z
@@ -126,4 +127,19 @@ describe('Extract various values from node_attrs', () => {
       .toStrictEqual({accession: "MK049251", url: undefined}); // invalid URL
   });
 
+});
+
+test("Parse intervals of gaps or Ns", () => {
+  expect(parseIntervalsOfNsOrGaps(["T200N", "T100N", "C101N", "G102N"]))
+    .toStrictEqual(
+      [{start: 100, end: 102, count: 3, char: 'N'}, {start: 200, end: 200, count: 1, char: 'N'}]
+    );
+  expect(parseIntervalsOfNsOrGaps(["T5N", "T3N", "C1N", "G7N"]))
+    .toStrictEqual(
+      [{start: 1, end: 1, count: 1, char: 'N'}, {start: 3, end: 3, count: 1, char: 'N'}, {start: 5, end: 5, count: 1, char: 'N'}, {start: 7, end: 7, count: 1, char: 'N'}]
+    );
+  expect(parseIntervalsOfNsOrGaps(["T5-", "T3-", "C4-", "G7-", "G8-"]))
+    .toStrictEqual(
+      [{start: 3, end: 5, count: 3, char: '-'}, {start: 7, end: 8, count: 2, char: '-'}]
+    );
 });


### PR DESCRIPTION
### Description of proposed changes    

See #1444 for context & commit messages for further info. Or just look at the examples 😉 


### Testing
Unit tests added, as well as interactive testing

### Examples



**Branch Hover**
I've grouped nucleotide mutations on branch hover, as I find it super useful for exploring the tree to see if mutations are homoplasic or reversions to the root (i.e. potentially backfilled). In the interest of keeping the size of the info-box manageable, I've kept the AA mutations unchanged. 

![image](https://user-images.githubusercontent.com/8350992/151496106-ba832e42-f8d9-4925-9709-b0af79c5ff93.png)

---

**Branch (shift+)click**
Branches group mutations into unique vs homoplasies vs gaps vs Ns. They also report which are reversions to the root. Gaps and Ns are grouped into intervals.
![image](https://user-images.githubusercontent.com/8350992/151490655-0f36c03a-bce7-4e59-9078-68d58033d0f7.png)
![image](https://user-images.githubusercontent.com/8350992/151490723-b3568ced-f9ae-44f8-8761-d937a4491ec1.png)

---

**Tip hover**
When hovering over tips we no longer report the mutations on the branch leading to the tip, rather we report a summary of changes w.r.t the root. If you want to see the mutations on the branch leading to the tip, then you can still hover on the branch to see them.

![image](https://user-images.githubusercontent.com/8350992/151491358-9e1a03f3-820e-49f2-a87b-61d03c861d7d.png)


---

**Tip click**
When clicking on a tip we list those changes between the root and this sample:
![image](https://user-images.githubusercontent.com/8350992/151491390-f1843ee2-9ba0-45af-96a7-608d5e4637d3.png)





### Questions

* Should we restrict homoplasies to those which occur on non-terminal branches? 
    * If so, if viewing a terminal branch with mutation X, which occurs on another non-terminal branch Y, would we classify this as a homoplasy? (we wouldn't when viewing branch Y)
* Branch on-hover for AA mutations is unchanged - is there interest in grouping these? If so, how can we do it without using too much space?


### Further work

I purposefully didn't spend a huge amount of time tweaking the aesthetics of the changes here, as I plan to incorporate the nextclade / CoVariants badges shortly. 
