### PR TITLE
Enable search for Color By

### DIFF
--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -213,7 +213,7 @@ class ColorBy extends React.Component {
           value={this.state.colorBySelected}
           options={colorOptions}
           clearable={false}
-          searchable={false}
+          searchable
           multi={false}
           onChange={(opt) => {
             this.replaceState({ colorBySelected: opt.value });


### PR DESCRIPTION
### Description of proposed changes

This makes the Color By dropdown searchable as the list gets longer.

Enhancement proposed by @trvrb, implementation from @joverlee521

There are more non-searchable `Select`s, would it be appropriate to enable elsewhere? https://github.com/nextstrain/auspice/search?q=searchable%3D%7Bfalse%7D