### PR TITLE
Stop storing an unused "weight" property from tip frequencies

### DIFF
--- a/src/util/processFrequencies.js
+++ b/src/util/processFrequencies.js
@@ -128,8 +128,7 @@ export const processFrequenciesJSON = (rawJSON, tree, controls) => {
       }
       data.push({
         idx: n.arrayIdx,
-        values: rawJSON[n.name].frequencies,
-        weight: rawJSON[n.name].weight
+        values: rawJSON[n.name].frequencies
       });
     });
 


### PR DESCRIPTION
This property was introduced with the original frequencies work¹ as an
anticipated need², but it was never used.  Omit it for now to avoid
carrying around unnecessary baggage; it can be added back in the future
easily if its time comes.

I uncovered this while authoring a JSON Schema for the tip-frequencies
format.³

¹ In PR https://github.com/nextstrain/auspice/pull/497 as a7bda1e.
² https://github.com/nextstrain/augur/pull/83#issuecomment-367405686
³ https://github.com/nextstrain/augur/pull/852