### PR TITLE
narratives: Load YAML frontmatter safely

### DIFF
--- a/src/util/parseNarrative.js
+++ b/src/util/parseNarrative.js
@@ -11,12 +11,12 @@
 
 /* eslint no-param-reassign: off */
 
-const { loadFront } = require('yaml-front-matter');
+const { safeLoadFront } = require('yaml-front-matter');
 const queryString = require("query-string");
 
 
 const parseMarkdownNarrativeFile = (fileContents, markdownParser) => {
-  const frontMatter = loadFront(fileContents);
+  const frontMatter = safeLoadFront(fileContents);
 
   if (Object.keys(frontMatter).length === 1) {
     const notMarkdownError = new Error();


### PR DESCRIPTION
Prevents deserializing potentially unsafe data types from user input.

yaml-front-matter uses js-yaml 3.x, which is unsafe by default, hence
the "safe" mode. js-yaml 4.x is safe by default, but not used here.
