### PR TITLE
Upgrade react select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3054,27 +3054,6 @@
         "babel-preset-current-node-syntax": "^0.1.2"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3870,11 +3849,6 @@
           }
         }
       }
-    },
-    "classnames": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.4",
@@ -11322,14 +11296,6 @@
         "camelcase": "^5.0.0"
       }
     },
-    "react-input-autosize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
-      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -11445,29 +11411,6 @@
           "requires": {
             "@babel/runtime": "^7.8.7",
             "csstype": "^3.0.2"
-          }
-        }
-      }
-    },
-    "react-virtualized-select": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz",
-      "integrity": "sha512-u6j/EfynCB9s4Lz5GGZhNUCZHvFQdtLZws7W/Tcd/v03l19OjpQs3eYjK82iYS0FgD2+lDIBpqS8LpD/hjqDRQ==",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "prop-types": "^15.5.8",
-        "react-select": "^1.0.0-rc.2",
-        "react-virtualized": "^9.0.0"
-      },
-      "dependencies": {
-        "react-select": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
-          "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
-          "requires": {
-            "classnames": "^2.2.4",
-            "prop-types": "^15.5.8",
-            "react-input-autosize": "^2.1.2"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,6 +1124,66 @@
         "minimist": "^1.2.0"
       }
     },
+    "@emotion/babel-plugin": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+      "integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/plugin-syntax-jsx": "^7.12.13",
+        "@babel/runtime": "^7.13.10",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.2",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.0.13"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "stylis": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+          "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+        }
+      }
+    },
+    "@emotion/cache": {
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+      "requires": {
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/sheet": "^1.1.0",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "stylis": "4.0.13"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+          "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -1137,10 +1197,52 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
+    "@emotion/react": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.8.1.tgz",
+      "integrity": "sha512-XGaie4nRxmtP1BZYBXqC5JGqMYF2KRKKI7vjqNvQxyRpekVAZhb6QqrElmZCAYXH1L90lAelADSVZC4PFsrJ8Q==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/babel-plugin": "^11.7.1",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/sheet": "^1.1.0",
+        "@emotion/utils": "^1.1.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "hoist-non-react-statics": "^3.3.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+      "requires": {
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.4",
+        "@emotion/unitless": "^0.7.5",
+        "@emotion/utils": "^1.0.0",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+      "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+    },
     "@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1995,6 +2097,11 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "@types/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
@@ -2025,6 +2132,14 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/scheduler": {
@@ -2811,6 +2926,55 @@
         "glob": "^7.1.1",
         "lodash": "^4.17.10",
         "require-package-name": "^2.0.1"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -4853,7 +5017,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -6002,6 +6165,11 @@
         }
       }
     },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -6905,8 +7073,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -9289,8 +9456,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -9393,8 +9559,7 @@
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "linspace": {
       "version": "1.0.1",
@@ -10387,7 +10552,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       },
@@ -10395,8 +10559,7 @@
         "callsites": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-          "dev": true
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
@@ -10504,6 +10667,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pathval": {
       "version": "1.1.1",
@@ -11193,13 +11361,39 @@
       }
     },
     "react-select": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
-      "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.2.tgz",
+      "integrity": "sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==",
       "requires": {
-        "classnames": "^2.2.4",
-        "prop-types": "^15.5.8",
-        "react-input-autosize": "^2.1.2"
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.1.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^3.0.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+          "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "react-side-effect": {
@@ -11264,6 +11458,18 @@
         "prop-types": "^15.5.8",
         "react-select": "^1.0.0-rc.2",
         "react-virtualized": "^9.0.0"
+      },
+      "dependencies": {
+        "react-select": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.3.0.tgz",
+          "integrity": "sha512-g/QAU1HZrzSfxkwMAo/wzi6/ezdWye302RGZevsATec07hI/iSxcpB1hejFIp7V63DJ8mwuign6KmB3VjdlinQ==",
+          "requires": {
+            "classnames": "^2.2.4",
+            "prop-types": "^15.5.8",
+            "react-input-autosize": "^2.1.2"
+          }
+        }
       }
     },
     "read-pkg": {
@@ -13979,6 +14185,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yaml-front-matter": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-i18next": "^11.3.3",
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.6",
-    "react-select": "^1.0.0-rc.5",
+    "react-select": "^5.2.2",
     "react-tooltip": "^4.2.10",
     "react-virtualized-select": "^3.1.3",
     "redux": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "react-redux": "^7.2.6",
     "react-select": "^5.2.2",
     "react-tooltip": "^4.2.10",
-    "react-virtualized-select": "^3.1.3",
+    "react-virtualized": "^9.22.3",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.5",

--- a/src/components/controls/choose-branch-labelling.js
+++ b/src/components/controls/choose-branch-labelling.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 
 import { CHANGE_BRANCH_LABEL } from "../../actions/types";
 import { SidebarSubtitle } from "./styles";
 import { controlsWidth } from "../../util/globals";
+import CustomSelect from "./customSelect";
 
 @connect((state) => ({
   selected: state.controls.selectedBranchLabel,
@@ -27,7 +27,7 @@ class ChooseBranchLabelling extends React.Component {
           {t("sidebar:Branch Labels")}
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             value={selectOptions.filter(({value}) => value === this.props.selected)}
             options={selectOptions}
             isClearable={false}

--- a/src/components/controls/choose-branch-labelling.js
+++ b/src/components/controls/choose-branch-labelling.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 
 import { CHANGE_BRANCH_LABEL } from "../../actions/types";
@@ -20,6 +20,7 @@ class ChooseBranchLabelling extends React.Component {
   render() {
     if (!this.props.canRenderBranchLabels) return null;
     const { t } = this.props;
+    const selectOptions = this.props.available.map((x) => ({value: x, label: x}));
     return (
       <div style={{paddingTop: 5}}>
         <SidebarSubtitle>
@@ -27,11 +28,11 @@ class ChooseBranchLabelling extends React.Component {
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
           <Select
-            value={this.props.selected}
-            options={this.props.available.map((x) => ({value: x, label: x}))}
-            clearable={false}
-            searchable={false}
-            multi={false}
+            value={selectOptions.filter(({value}) => value === this.props.selected)}
+            options={selectOptions}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={this.change}
           />
         </div>

--- a/src/components/controls/choose-dataset-select.js
+++ b/src/components/controls/choose-dataset-select.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { MAP_ANIMATION_PLAY_PAUSE_BUTTON } from "../../actions/types";
 import { changePage } from "../../actions/navigation";
@@ -19,14 +19,15 @@ class ChooseDatasetSelect extends React.Component {
     this.props.dispatch(changePage({path: newPath}));
   }
   render() {
+    const selectOptions = this.props.options || [];
     return (
       <div style={{width: controlsWidth, fontSize: 14}}>
         <Select
-          value={this.props.selected}
-          options={this.props.options || []}
-          clearable={false}
-          searchable={false}
-          multi={false}
+          value={selectOptions.filter(({value}) => value === this.props.selected)}
+          options={selectOptions}
+          isClearable={false}
+          isSearchable={false}
+          isMulti={false}
           onChange={(opt) => {
             if (opt.value !== this.props.selected) {
               this.changeDataset(`/${opt.value}`);

--- a/src/components/controls/choose-dataset-select.js
+++ b/src/components/controls/choose-dataset-select.js
@@ -1,10 +1,9 @@
 import React from "react";
-import Select from "react-select";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { MAP_ANIMATION_PLAY_PAUSE_BUTTON } from "../../actions/types";
 import { changePage } from "../../actions/navigation";
 import { controlsWidth } from "../../util/globals";
-
+import CustomSelect from "./customSelect";
 
 class ChooseDatasetSelect extends React.Component {
   changeDataset(newPath) {
@@ -22,7 +21,7 @@ class ChooseDatasetSelect extends React.Component {
     const selectOptions = this.props.options || [];
     return (
       <div style={{width: controlsWidth, fontSize: 14}}>
-        <Select
+        <CustomSelect
           value={selectOptions.filter(({value}) => value === this.props.selected)}
           options={selectOptions}
           isClearable={false}

--- a/src/components/controls/choose-explode-attr.js
+++ b/src/components/controls/choose-explode-attr.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 
 import { explodeTree } from "../../actions/tree";
 import { SidebarSubtitle } from "./styles";
 import { controlsWidth } from "../../util/globals";
+import CustomSelect from "./customSelect";
 
 /**
  * The available traits to split a tree on are taken as the non-continuous colorings.
@@ -41,7 +41,7 @@ class ChooseExplodeAttr extends React.Component {
           {"[experimental] " + t("sidebar:Explode tree by")}
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             value={selectOptions.filter(({value}) => value === this.props.selected)}
             options={selectOptions}
             isClearable={false}

--- a/src/components/controls/choose-explode-attr.js
+++ b/src/components/controls/choose-explode-attr.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 
 import { explodeTree } from "../../actions/tree";
@@ -34,6 +34,7 @@ class ChooseExplodeAttr extends React.Component {
   render() {
     if (!this.props.showThisUI) return null;
     const { t } = this.props;
+    const selectOptions = this.gatherAttrs();
     return (
       <div style={{paddingTop: 5}}>
         <SidebarSubtitle>
@@ -41,11 +42,11 @@ class ChooseExplodeAttr extends React.Component {
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
           <Select
-            value={this.props.selected}
-            options={this.gatherAttrs()}
-            clearable={false}
-            searchable={false}
-            multi={false}
+            value={selectOptions.filter(({value}) => value === this.props.selected)}
+            options={selectOptions}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={this.change}
           />
         </div>

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import styled, { withTheme } from 'styled-components';
 import { withTranslation } from 'react-i18next';
-import Select from "react-select";
 import * as icons from "../framework/svg-icons";
 import { controlsWidth } from "../../util/globals";
 import { collectAvailableScatterVariables} from "../../util/scatterplotHelpers";
 import { SidebarSubtitle, SidebarButton } from "./styles";
 import { changeLayout } from "../../actions/layout";
 import Toggle from "./toggle";
+import CustomSelect from "./customSelect";
 
 
 const RectangularTreeIcon = withTheme(icons.RectangularTree);
@@ -48,7 +48,7 @@ class ChooseLayout extends React.Component {
         <ScatterVariableContainer>
           <ScatterAxisName>x</ScatterAxisName>
           <ScatterSelectContainer>
-            <Select
+            <CustomSelect
               {...miscSelectProps}
               value={options.filter(({value}) => value === selectedX.value)}
               onChange={(value) => this.props.dispatch(changeLayout({x: value.value, xLabel: value.label}))}
@@ -59,7 +59,7 @@ class ChooseLayout extends React.Component {
         <ScatterVariableContainer>
           <ScatterAxisName>y</ScatterAxisName>
           <ScatterSelectContainer>
-            <Select
+            <CustomSelect
               {...miscSelectProps}
               value={options.filter(({value}) => value === selectedY.value)}
               onChange={(value) => this.props.dispatch(changeLayout({y: value.value, yLabel: value.label}))}

--- a/src/components/controls/choose-layout.js
+++ b/src/components/controls/choose-layout.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from "react-redux";
 import styled, { withTheme } from 'styled-components';
 import { withTranslation } from 'react-i18next';
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import * as icons from "../framework/svg-icons";
 import { controlsWidth } from "../../util/globals";
 import { collectAvailableScatterVariables} from "../../util/scatterplotHelpers";
@@ -41,7 +41,7 @@ class ChooseLayout extends React.Component {
     const options = collectAvailableScatterVariables(this.props.colorings, this.props.colorBy);
     const selectedX = options.filter((o) => o.value===this.props.scatterVariables.x)[0];
     const selectedY = options.filter((o) => o.value===this.props.scatterVariables.y)[0];
-    const miscSelectProps = {options, clearable: false, searchable: false, multi: false, valueKey: "label"};
+    const miscSelectProps = {options, isClearable: false, isSearchable: false, isMulti: false};
 
     return (
       <>
@@ -50,7 +50,7 @@ class ChooseLayout extends React.Component {
           <ScatterSelectContainer>
             <Select
               {...miscSelectProps}
-              value={selectedX}
+              value={options.filter(({value}) => value === selectedX.value)}
               onChange={(value) => this.props.dispatch(changeLayout({x: value.value, xLabel: value.label}))}
             />
           </ScatterSelectContainer>
@@ -61,7 +61,7 @@ class ChooseLayout extends React.Component {
           <ScatterSelectContainer>
             <Select
               {...miscSelectProps}
-              value={selectedY}
+              value={options.filter(({value}) => value === selectedY.value)}
               onChange={(value) => this.props.dispatch(changeLayout({y: value.value, yLabel: value.label}))}
             />
           </ScatterSelectContainer>

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Select from "react-select";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
 
@@ -7,7 +6,7 @@ import { loadSecondTree } from "../../actions/loadData";
 import { REMOVE_TREE_TOO } from "../../actions/types";
 import { controlsWidth } from "../../util/globals";
 import { SidebarSubtitle } from "./styles";
-
+import CustomSelect from "./customSelect";
 
 @connect((state) => {
   return {
@@ -46,7 +45,7 @@ class ChooseSecondTree extends React.Component {
           {t("sidebar:Second Tree")}
         </SidebarSubtitle>
         <div key={"treetooselect"} style={{width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             name="selectTreeToo"
             id="selectTreeToo"
             value={selectOptions.filter(({value}) => value === this.props.showTreeToo)}

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
 
@@ -38,6 +38,8 @@ class ChooseSecondTree extends React.Component {
 
     if (this.props.showTreeToo) options.unshift("REMOVE");
 
+    const selectOptions = options.map((opt) => ({value: opt, label: opt}));
+
     return (
       <div>
         <SidebarSubtitle spaceAbove>
@@ -47,11 +49,11 @@ class ChooseSecondTree extends React.Component {
           <Select
             name="selectTreeToo"
             id="selectTreeToo"
-            value={this.props.showTreeToo}
-            options={options.map((opt) => ({value: opt, label: opt}))}
-            clearable={false}
-            searchable={false}
-            multi={false}
+            value={selectOptions.filter(({value}) => value === this.props.showTreeToo)}
+            options={selectOptions}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={(opt) => {
               if (opt.value === "REMOVE") {
                 this.props.dispatch({type: REMOVE_TREE_TOO});

--- a/src/components/controls/choose-tip-label.js
+++ b/src/components/controls/choose-tip-label.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 import { CHANGE_TIP_LABEL_KEY } from "../../actions/types";
 import { SidebarSubtitle } from "./styles";
 import { controlsWidth, strainSymbol } from "../../util/globals";
+import CustomSelect from "./customSelect";
 
 @connect((state) => ({
   selected: state.controls.tipLabelKey,
@@ -23,7 +23,7 @@ class ChooseTipLabel extends React.Component {
           {t("sidebar:Tip Labels")}
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             value={this.props.options.filter(({value}) => value === this.props.selected)}
             // Select can't handle Symbols, so we have to convert to string for them
             getOptionValue={(option) => option.value.toString()}

--- a/src/components/controls/choose-tip-label.js
+++ b/src/components/controls/choose-tip-label.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { withTranslation } from 'react-i18next';
 import { CHANGE_TIP_LABEL_KEY } from "../../actions/types";
 import { SidebarSubtitle } from "./styles";
@@ -24,12 +24,13 @@ class ChooseTipLabel extends React.Component {
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
           <Select
-            value={findSelectedValue(this.props.selected, this.props.options)}
+            value={this.props.options.filter(({value}) => value === this.props.selected)}
+            // Select can't handle Symbols, so we have to convert to string for them
+            getOptionValue={(option) => option.value.toString()}
             options={this.props.options}
-            clearable={false}
-            searchable={false}
-            valueKey="label"
-            multi={false}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={this.change}
           />
         </div>
@@ -55,12 +56,4 @@ export function collectAvailableTipLabelOptions(colorings) {
         return {value: key, label: value.title};
       })
   ];
-}
-
-/**
- * Find the currently selected option.
- * <Select> can't handle Symbols so we need to write our own algorithm.
- */
-function findSelectedValue(selected, options) {
-  return options.filter((o) => o.value===selected)[0];
 }

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from 'prop-types';
 import { connect } from "react-redux";
-import Select from "react-select";
 import { debounce } from "lodash";
 import { sidebarField } from "../../globalStyles";
 import { controlsWidth, nucleotide_gene } from "../../util/globals";
 import { changeColorBy } from "../../actions/colors";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { isColorByGenotype, decodeColorByGenotype, encodeColorByGenotype, decodePositions } from "../../util/getGenotype";
+import CustomSelect from "./customSelect";
 
 /* the reason why we have colorBy as state (here) and in redux
    is for the case where we select genotype, then wait for the
@@ -147,7 +147,7 @@ class ColorBy extends React.Component {
   gtGeneSelect() {
     const gtGeneOptions = this.getGtGeneOptions();
     return (
-      <Select
+      <CustomSelect
         name="selectGenotype"
         id="selectGenotype"
         placeholder="gene…"
@@ -208,7 +208,7 @@ class ColorBy extends React.Component {
 
     return (
       <div style={styles.base} id="selectColorBy">
-        <Select
+        <CustomSelect
           name="selectColorBy"
           value={colorOptions.filter(({value}) => value === this.state.colorBySelected)}
           options={colorOptions}

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from 'prop-types';
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { debounce } from "lodash";
 import { sidebarField } from "../../globalStyles";
 import { controlsWidth, nucleotide_gene } from "../../util/globals";
@@ -151,11 +151,11 @@ class ColorBy extends React.Component {
         name="selectGenotype"
         id="selectGenotype"
         placeholder="gene…"
-        value={this.state.geneSelected}
+        value={gtGeneOptions.filter(({value}) => value === this.state.geneSelected)}
         options={gtGeneOptions}
-        clearable={false}
-        searchable
-        multi={false}
+        isClearable={false}
+        isSearchable
+        isMulti={false}
         onChange={(opt) => {
           this.setState({ geneSelected: opt.value });
         }}
@@ -210,11 +210,11 @@ class ColorBy extends React.Component {
       <div style={styles.base} id="selectColorBy">
         <Select
           name="selectColorBy"
-          value={this.state.colorBySelected}
+          value={colorOptions.filter(({value}) => value === this.state.colorBySelected)}
           options={colorOptions}
-          clearable={false}
-          searchable
-          multi={false}
+          isClearable={false}
+          isSearchable
+          isMulti={false}
           onChange={(opt) => {
             this.replaceState({ colorBySelected: opt.value });
           }}

--- a/src/components/controls/customSelect.js
+++ b/src/components/controls/customSelect.js
@@ -1,0 +1,64 @@
+import React from "react";
+import Select, { components } from "react-select";
+
+/**
+ * The DropdownIndicator must be a custom component because the new version
+ * of react-select uses an SVG as the dropdown arrow that must be replaced.
+ *
+ * Uses the css from v1 of react-select to create the filled dropdown
+ * icon. See `Select-arrow` class in
+ * https://github.com/JedWatson/react-select/blob/v1.x/dist/react-select.css
+ */
+const DropdownIndicator = (props) => {
+  const dropDownArrowStyle = {
+    borderColor: "#999 transparent transparent",
+    borderStyle: "solid",
+    borderWidth: "5px 5px 2.5px",
+    display: "inline-block",
+    height: 0,
+    width: 0,
+    position: "relative"
+  };
+
+  return (
+    <components.DropdownIndicator {...props}>
+      <span style={dropDownArrowStyle} />
+    </components.DropdownIndicator>
+  );
+};
+
+const customSelectComponents = {
+  IndicatorSeparator: () => null,
+  DropdownIndicator
+};
+
+// Uses the react-select styles API to customize component styles
+// See https://react-select.com/styles for more details
+export const customSelectStyles = {
+  menu: (base) => ({ ...base, marginTop: 0}),
+  placeholder: (base) => ({ ...base, color: "#aaa"})
+};
+
+const CustomSelect = (props) => {
+  // Merge our custom components with passed components but
+  // passed components can override our default custom components
+  const newComponents = {
+    ...customSelectComponents,
+    ...props.components
+  };
+
+  // Merge our custom styles with passed styles but passed styles can override
+  // our default custom styles
+  const newStyles = {
+    ...customSelectStyles,
+    ...props.styles
+  };
+
+  const newProps = {...props, components: newComponents, styles: newStyles};
+
+  return (
+    <Select {...newProps}/>
+  );
+};
+
+export default CustomSelect;

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -7,6 +7,7 @@ import { collectGenotypeStates } from "../../util/treeMiscHelpers";
 import { applyFilter } from "../../actions/tree";
 import { removeAllFieldFilters, toggleAllFieldFilters, applyMeasurementFilter } from "../../actions/measurements";
 import { FilterBadge } from "../info/filterBadge";
+import { customSelectStyles } from "./customSelect";
 import { SidebarSubtitle } from "./styles";
 import VirtualizedMenuList from "./virtualizedMenuList";
 
@@ -162,6 +163,7 @@ class FilterData extends React.Component {
           isMulti={false}
           components={{ DropdownIndicator: null, MenuList: VirtualizedMenuList }}
           onChange={this.selectionMade}
+          styles={customSelectStyles}
         />
         {inUseFilters.length ? (
           <>

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import "react-select/dist/react-select.css";
-import "react-virtualized-select/styles.css";
-import Select from "react-virtualized-select";
+import AsyncSelect from "react-select/async";
 import { debounce } from 'lodash';
 import { controlsWidth, isValueValid, strainSymbol, genotypeSymbol} from "../../util/globals";
 import { collectGenotypeStates } from "../../util/treeMiscHelpers";
@@ -141,7 +139,7 @@ class FilterData extends React.Component {
     // options only need to be calculated a single time per render, and by adding a debounce
     // to `loadOptions` we don't slow things down by comparing queries to a large number of options
     const options = this.makeOptions();
-    const loadOptions = debounce((input, callback) => callback(null, {options}), DEBOUNCE_TIME);
+    const loadOptions = debounce((input, callback) => callback(options), DEBOUNCE_TIME);
     const filterOption = (option, filter) => filter.toLowerCase().split(" ").every((word) => option.label.toLowerCase().includes(word));
     const styles = this.getStyles();
     const inUseFilters = this.summariseFilters();
@@ -151,19 +149,17 @@ class FilterData extends React.Component {
     const divKey = String(Object.keys(this.props.activeFilters).length);
     return (
       <div style={styles.base} key={divKey}>
-        <Select
-          async
+        <AsyncSelect
           name="filterQueryBox"
           placeholder="Type filter query here..."
-          value={undefined}
-          arrowRenderer={null}
+          value={null}
+          defaultOptions
           loadOptions={loadOptions}
           filterOption={filterOption}
-          ignoreAccents={false}
-          clearable={false}
-          searchable
-          multi={false}
-          valueKey="label"
+          isClearable={false}
+          isSearchable
+          isMulti={false}
+          components={{ DropdownIndicator: null }}
           onChange={this.selectionMade}
         />
         {inUseFilters.length ? (

--- a/src/components/controls/filter.js
+++ b/src/components/controls/filter.js
@@ -8,6 +8,7 @@ import { applyFilter } from "../../actions/tree";
 import { removeAllFieldFilters, toggleAllFieldFilters, applyMeasurementFilter } from "../../actions/measurements";
 import { FilterBadge } from "../info/filterBadge";
 import { SidebarSubtitle } from "./styles";
+import VirtualizedMenuList from "./virtualizedMenuList";
 
 const DEBOUNCE_TIME = 200;
 
@@ -159,7 +160,7 @@ class FilterData extends React.Component {
           isClearable={false}
           isSearchable
           isMulti={false}
-          components={{ DropdownIndicator: null }}
+          components={{ DropdownIndicator: null, MenuList: VirtualizedMenuList }}
           onChange={this.selectionMade}
         />
         {inUseFilters.length ? (

--- a/src/components/controls/geo-resolution.js
+++ b/src/components/controls/geo-resolution.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select";
 import { withTranslation } from "react-i18next";
 
 import { controlsWidth } from "../../util/globals";
 import { CHANGE_GEO_RESOLUTION } from "../../actions/types";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { SidebarSubtitle } from "./styles";
+import CustomSelect from "./customSelect";
 
 @connect((state) => {
   return {
@@ -35,7 +35,7 @@ class GeoResolution extends React.Component {
           {t("sidebar:Geographic resolution")}
         </SidebarSubtitle>
         <div style={{marginBottom: 10, width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             name="selectGeoResolution"
             id="selectGeoResolution"
             value={geoResolutionOptions.filter(({value}) => value === this.props.geoResolution)}

--- a/src/components/controls/geo-resolution.js
+++ b/src/components/controls/geo-resolution.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { withTranslation } from "react-i18next";
 
 import { controlsWidth } from "../../util/globals";
@@ -38,11 +38,11 @@ class GeoResolution extends React.Component {
           <Select
             name="selectGeoResolution"
             id="selectGeoResolution"
-            value={this.props.geoResolution}
+            value={geoResolutionOptions.filter(({value}) => value === this.props.geoResolution)}
             options={geoResolutionOptions}
-            clearable={false}
-            searchable={false}
-            multi={false}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={(opt) => {this.changeGeoResolution(opt.value);}}
           />
         </div>

--- a/src/components/controls/language.js
+++ b/src/components/controls/language.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { withTranslation } from "react-i18next";
 import i18n from "i18next";
 
@@ -63,6 +63,7 @@ class Language extends React.Component {
 
   render() {
     const { t } = this.props;
+    const selectOptions = this.getlanguageOptions();
     return (
       <>
         <SidebarSubtitle spaceAbove>
@@ -72,11 +73,11 @@ class Language extends React.Component {
           <Select
             name="selectLanguage"
             id="selectLanguage"
-            value={this.props.language}
-            options={this.getlanguageOptions()}
-            clearable={false}
-            searchable={false}
-            multi={false}
+            value={selectOptions.filter(({value}) => value === this.props.language)}
+            options={selectOptions}
+            isClearable={false}
+            isSearchable={false}
+            isMulti={false}
             onChange={(opt) => {this.changeLanguage(opt.value);}}
           />
         </div>

--- a/src/components/controls/language.js
+++ b/src/components/controls/language.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { connect } from "react-redux";
-import Select from "react-select";
 import { withTranslation } from "react-i18next";
 import i18n from "i18next";
 
@@ -8,6 +7,7 @@ import { controlsWidth } from "../../util/globals";
 import { analyticsControlsEvent } from "../../util/googleAnalytics";
 import { SidebarSubtitle } from "./styles";
 import { CHANGE_LANGUAGE } from "../../actions/types";
+import CustomSelect from "./customSelect";
 
 @connect((state) => {
   return {
@@ -70,7 +70,7 @@ class Language extends React.Component {
           {t("sidebar:Language")}
         </SidebarSubtitle>
         <div style={{paddingBottom: 100, width: controlsWidth, fontSize: 14}}>
-          <Select
+          <CustomSelect
             name="selectLanguage"
             id="selectLanguage"
             value={selectOptions.filter(({value}) => value === this.props.language)}

--- a/src/components/controls/measurementsOptions.js
+++ b/src/components/controls/measurementsOptions.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { isEqual } from "lodash";
-import Select from "react-select/lib/Select";
+import Select from "react-select";
 import { changeMeasurementsCollection } from "../../actions/measurements";
 import {
   CHANGE_MEASUREMENTS_DISPLAY,
@@ -58,11 +58,11 @@ const MeasurementsOptions = () => {
         <Select
           name="measurementsCollections"
           id="measurementsCollections"
-          value={collection.key}
+          value={collectionOptions.filter(({value}) => value === collection.key)}
           options={collectionOptions}
-          clearable={false}
-          searchable={false}
-          multi={false}
+          isClearable={false}
+          isSearchable={false}
+          isMulti={false}
           onChange={(opt) => {
             dispatch(changeMeasurementsCollection(opt.value));
           }}
@@ -75,11 +75,11 @@ const MeasurementsOptions = () => {
         <Select
           name="measurementsGroupings"
           id="measurementsGroupings"
-          value={groupBy}
+          value={groupingOptions.filter(({value}) => value === groupBy)}
           options={groupingOptions}
-          clearable={false}
-          searchable={false}
-          multi={false}
+          isClearable={false}
+          isSearchable={false}
+          isMulti={false}
           onChange={(opt) => {
             dispatch({
               type: CHANGE_MEASUREMENTS_GROUP_BY,

--- a/src/components/controls/measurementsOptions.js
+++ b/src/components/controls/measurementsOptions.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { isEqual } from "lodash";
-import Select from "react-select";
 import { changeMeasurementsCollection } from "../../actions/measurements";
 import {
   CHANGE_MEASUREMENTS_DISPLAY,
@@ -12,6 +11,7 @@ import {
 import { controlsWidth } from "../../util/globals";
 import { SidebarSubtitle, SidebarButton } from "./styles";
 import Toggle from "./toggle";
+import CustomSelect from "./customSelect";
 
 /**
  * React Redux selector function that takes the key and title for the
@@ -55,7 +55,7 @@ const MeasurementsOptions = () => {
         {"Collections"}
       </SidebarSubtitle>
       <div style={{ marginBottom: 10, width: controlsWidth, fontSize: 14}}>
-        <Select
+        <CustomSelect
           name="measurementsCollections"
           id="measurementsCollections"
           value={collectionOptions.filter(({value}) => value === collection.key)}
@@ -72,7 +72,7 @@ const MeasurementsOptions = () => {
         {"Group By"}
       </SidebarSubtitle>
       <div style={{ marginBottom: 10, width: controlsWidth, fontSize: 14}}>
-        <Select
+        <CustomSelect
           name="measurementsGroupings"
           id="measurementsGroupings"
           value={groupingOptions.filter(({value}) => value === groupBy)}

--- a/src/components/controls/virtualizedMenuList.js
+++ b/src/components/controls/virtualizedMenuList.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { List } from "react-virtualized/dist/es/List";
+import { isEqual } from "lodash";
+import { controlsWidth } from "../../util/globals";
+
+/**
+ * A virtualized list expected to be used to replace the MenuList
+ * component in `react-select`
+ */
+const VirtualizedMenuList = ({ children, maxHeight, focusedOption }) => {
+  /**
+   * If the focused option is outside of the currently displayed options, we
+   * need to create the scrollToIndex so that the List can be forced to scroll
+   * to display the focused option.
+   */
+  let scrollToIndex;
+  if (children instanceof Array) {
+    const focusedOptionIndex = children.findIndex((option) => (
+      isEqual(focusedOption, option.props.data)
+    ));
+    if (focusedOptionIndex >= 0) {
+      scrollToIndex = focusedOptionIndex;
+    }
+  }
+
+  const rowRenderer = ({ index, key, style }) => (
+    <div key={key} style={style}>{children[index]}</div>
+  );
+
+  return (
+    <List
+      height={maxHeight}
+      rowHeight={40}
+      rowRenderer={rowRenderer}
+      rowCount={children.length || 0}
+      width={controlsWidth}
+      scrollToIndex={scrollToIndex}
+    />
+  );
+};
+
+export default VirtualizedMenuList;

--- a/src/components/controls/virtualizedMenuList.js
+++ b/src/components/controls/virtualizedMenuList.js
@@ -1,13 +1,26 @@
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import { List } from "react-virtualized/dist/es/List";
+import { CellMeasurer, CellMeasurerCache } from "react-virtualized/dist/es/CellMeasurer";
 import { isEqual } from "lodash";
 import { controlsWidth } from "../../util/globals";
+
+const DEFAULT_ROW_HEIGHT = 40;
+const getOptionKeys = (options) => options.map((option) => option.key);
 
 /**
  * A virtualized list expected to be used to replace the MenuList
  * component in `react-select`
  */
 const VirtualizedMenuList = ({ children, maxHeight, focusedOption }) => {
+  const listRef = useRef(null);
+  const options = useRef(null);
+  const cache = useRef(
+    new CellMeasurerCache({
+      fixedWidth: true,
+      defaultHeight: DEFAULT_ROW_HEIGHT
+    })
+  );
+
   /**
    * If the focused option is outside of the currently displayed options, we
    * need to create the scrollToIndex so that the List can be forced to scroll
@@ -23,16 +36,62 @@ const VirtualizedMenuList = ({ children, maxHeight, focusedOption }) => {
     }
   }
 
-  const rowRenderer = ({ index, key, style }) => (
-    <div key={key} style={style}>{children[index]}</div>
+  /**
+   * When the children options have changed, the cache has to be manually cleared
+   * and the list has to recompute the row heights to correctly display the
+   * new options.
+   * See answer from react-virtualized maintainer @bvaughn at
+   * https://stackoverflow.com/a/43837929
+   */
+  useLayoutEffect(() => {
+    const newOptions = children instanceof Array ? getOptionKeys(children) : children;
+    if (!isEqual(options.current, newOptions)) {
+      cache.current.clearAll();
+      listRef.current.recomputeRowHeights();
+      options.current = newOptions;
+    }
+  }, [children]);
+
+  /**
+   * Wraps each option in a CellMeasurer which measures the row height based
+   * on the contents of the option and passes this height to the parent List
+   * component via the cache
+   */
+  const rowRenderer = ({ index, key, parent, style }) => (
+    <CellMeasurer
+      cache={cache.current}
+      columnIndex={0}
+      key={key}
+      parent={parent}
+      rowIndex={index}
+    >
+      <div style={style}>
+        {children instanceof Array ? children[index] : children}
+      </div>
+    </CellMeasurer>
+
   );
+
+  /**
+   * Because the individual row heights are measured and cached on render,
+   * this is just a best guess of the list height.
+   * There can be a delay in the list height changing if there is a rapid
+   * change of the children options.
+   */
+  const calcListHeight = () => {
+    const currentRowHeights = Object.values(cache.current._rowHeightCache);
+    const totalRowHeight = currentRowHeights.reduce((a, b) => a + b, 0);
+    return totalRowHeight === 0 ? maxHeight : Math.min(maxHeight, totalRowHeight);
+  };
 
   return (
     <List
-      height={maxHeight}
-      rowHeight={40}
+      ref={listRef}
+      height={calcListHeight()}
+      deferredMeasurementCache={cache.current}
+      rowHeight={cache.current.rowHeight}
       rowRenderer={rowRenderer}
-      rowCount={children.length || 0}
+      rowCount={children.length || 1}
       width={controlsWidth}
       scrollToIndex={scrollToIndex}
     />


### PR DESCRIPTION
Upgrades our `react-select` package to version 5.2.2 and replaces the `react-virtualized-select` package with our own virtualized menu list built with `react-virtualized` components. 

Note that the upgrade of `react-select` did include style changes. I did not dig into the style changes, but please let me know if we want the styles to match the old version.

Resolves #1467 and ##1453.
