### PR TITLE
Swap to "experimental" icon for exploded trees sidebar option

### DIFF
--- a/src/components/controls/choose-explode-attr.js
+++ b/src/components/controls/choose-explode-attr.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
-import { FaWrench } from "react-icons/fa";
-
+import { ImLab } from "react-icons/im";
+import { FaInfoCircle } from "react-icons/fa";
 import { explodeTree } from "../../actions/tree";
-import { SidebarSubtitle } from "./styles";
+import { SidebarSubtitleFlex, StyledTooltip, SidebarIconContainer } from "./styles";
 import { controlsWidth } from "../../util/globals";
 import CustomSelect from "./customSelect";
 
@@ -34,14 +34,26 @@ class ChooseExplodeAttr extends React.Component {
   }
   render() {
     if (!this.props.showThisUI) return null;
-    const { t } = this.props;
+    const { t, tooltip, mobile } = this.props;
     const selectOptions = this.gatherAttrs();
     return (
       <div style={{paddingTop: 5}}>
-        <SidebarSubtitle>
-          <FaWrench style={{ marginRight: "5px" }}/>
-          {t("sidebar:Explode Tree By")}
-        </SidebarSubtitle>
+        <SidebarSubtitleFlex data-tip data-for="explode_tree">
+          <span>
+            <ImLab style={{ marginRight: "5px" }}/>
+            {t("sidebar:Explode Tree By")}
+          </span>
+          {tooltip && !mobile && (
+            <>
+              <SidebarIconContainer data-tip data-for="select-explode">
+                <FaInfoCircle/>
+              </SidebarIconContainer>
+              <StyledTooltip place="bottom" type="dark" effect="solid" id="select-explode">
+                {tooltip}
+              </StyledTooltip>
+            </>
+          )}
+        </SidebarSubtitleFlex>
         <div style={{width: controlsWidth, fontSize: 14}}>
           <CustomSelect
             value={selectOptions.filter(({value}) => value === this.props.selected)}

--- a/src/components/controls/choose-explode-attr.js
+++ b/src/components/controls/choose-explode-attr.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { withTranslation } from 'react-i18next';
+import { FaWrench } from "react-icons/fa";
 
 import { explodeTree } from "../../actions/tree";
 import { SidebarSubtitle } from "./styles";
@@ -27,7 +28,7 @@ class ChooseExplodeAttr extends React.Component {
       .filter(([key]) => key !== "gt")
       .map(([key, value]) => ({value: key, label: value.title || key}));
     if (this.props.selected) {
-      options.unshift({value: undefined, label: "Reconstruct"});
+      options.unshift({value: undefined, label: "None"});
     }
     return options;
   }
@@ -38,7 +39,8 @@ class ChooseExplodeAttr extends React.Component {
     return (
       <div style={{paddingTop: 5}}>
         <SidebarSubtitle>
-          {"[experimental] " + t("sidebar:Explode tree by")}
+          <FaWrench style={{ marginRight: "5px" }}/>
+          {t("sidebar:Explode Tree By")}
         </SidebarSubtitle>
         <div style={{width: controlsWidth, fontSize: 14}}>
           <CustomSelect

--- a/src/components/controls/controls.js
+++ b/src/components/controls/controls.js
@@ -21,7 +21,8 @@ import ToggleTangle from "./toggle-tangle";
 import Language from "./language";
 import { ControlsContainer } from "./styles";
 import FilterData, {FilterInfo} from "./filter";
-import {TreeOptionsInfo, MapOptionsInfo, AnimationOptionsInfo, PanelOptionsInfo, FrequencyInfo, MeasurementsOptionsInfo} from "./miscInfoText";
+import {TreeOptionsInfo, MapOptionsInfo, AnimationOptionsInfo, PanelOptionsInfo,
+  ExplodeTreeInfo, FrequencyInfo, MeasurementsOptionsInfo} from "./miscInfoText";
 import { AnnotatedHeader } from "./annotatedHeader";
 import MeasurementsOptions from "./measurementsOptions";
 
@@ -45,7 +46,7 @@ function Controls({mapOn, frequenciesOn, measurementsOn, mobileDisplay}) {
       <AnnotatedHeader title={t("sidebar:Tree Options")} tooltip={TreeOptionsInfo} mobile={mobileDisplay}/>
       <ChooseLayout />
       <ChooseMetric />
-      <ChooseExplodeAttr />
+      <ChooseExplodeAttr tooltip={ExplodeTreeInfo} mobile={mobileDisplay} />
       <ChooseBranchLabelling />
       <ChooseTipLabel />
       <ChooseSecondTree />

--- a/src/components/controls/miscInfoText.js
+++ b/src/components/controls/miscInfoText.js
@@ -47,3 +47,11 @@ export const MeasurementsOptionsInfo = (
     Change collection of measurements and various display options for the collection.
   </>
 );
+
+export const ExplodeTreeInfo = (
+  <>This functionality is experimental and should be treated with caution!
+    <br/>Exploding a tree by trait X means that for each branch where the trait changes value, we will
+    prune off the branch and create a separate (sub)tree.
+    It works best when the trait doesn&apos;t change value too frequently.
+  </>
+);

--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -66,6 +66,18 @@ export const SidebarSubtitle = styled.div`
   color: ${(props) => props.theme.color};
 `;
 
+export const SidebarSubtitleFlex = styled(SidebarSubtitle)`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const SidebarIconContainer = styled.span`
+  padding-right: 3px;
+  font-size: 16px;
+  cursor: help;
+  color: #888;
+`;
+
 /* React Select is a lot of work to style
  * I can't yet get it working with styled components
  * We import the theme here, rather than accessing it via the <ThemeProvider>

--- a/src/components/controls/styles.js
+++ b/src/components/controls/styles.js
@@ -78,32 +78,6 @@ export const SidebarIconContainer = styled.span`
   color: #888;
 `;
 
-/* React Select is a lot of work to style
- * I can't yet get it working with styled components
- * We import the theme here, rather than accessing it via the <ThemeProvider>
- */
-// const customReactSelectStyles = {
-//   container: (provided, state) => {
-//     console.log(provided);
-//     return {
-//       ...provided,
-//       height: "20px"
-//     };
-//   },
-//   control: (provided, state) => {
-//     return {
-//       ...provided,
-//       color: "yellow",
-//       backgroundColor: "pink",
-//       borderColor: "red",
-//       height: "20px"
-//     };
-//   }
-// };
-// export const Select = (props) => (
-//   <ReactSelect styles={customReactSelectStyles} {...props}/>
-// );
-
 export const StyledTooltip = styled(ReactTooltip)`
   max-width: 30vh;
   white-space: normal;


### PR DESCRIPTION
### Description of proposed changes

This swaps the previous use of "[experimental]" in the "Explode tree by" sidebar option to a cleaner looking icon. I chose a wrench, thinking that this best represents work in progress.

![Screen Shot 2022-03-16 at 1 58 59 PM](https://user-images.githubusercontent.com/1176109/158689909-bc50217a-9edb-4b5b-b88c-53d6fe3175c5.png)

### Testing
I've tested locally, but it should be a small enough change that it should be safe.