### PR TITLE
Drag-n-drop metadata shows in second tree

### DIFF
--- a/src/actions/filesDropped/metadata.js
+++ b/src/actions/filesDropped/metadata.js
@@ -203,11 +203,14 @@ function processLatLongs(newNodeAttrs, latLongKeys, rows, fileName) {
 }
 
 function checkDataForErrors(dispatch, getState, newNodeAttrs, newColorings, ignoredFields, fileName) {
-  const {controls, tree} = getState();
+  const {controls, tree, treeToo} = getState();
   const [droppedColorings, droppedNodes] = [new Set(), new Set()];
 
-  /* restrict the newNodeAttrs to nodes which are actually in the tree! */
+  /* restrict the newNodeAttrs to nodes which are actually in the tree(s) */
   const nodeNamesInTree = new Set(tree.nodes.map((n) => n.name)); // can be internal nodes
+  if (Array.isArray(treeToo.nodes)) {
+    treeToo.nodes.forEach((node) => nodeNamesInTree.add(node.name));
+  }
   for (const name of Object.keys(newNodeAttrs)) {
     if (!nodeNamesInTree.has(name)) {
       droppedNodes.add(name);

--- a/src/reducers/tree.js
+++ b/src/reducers/tree.js
@@ -1,4 +1,5 @@
 import { countTraitsAcrossTree } from "../util/treeCountingHelpers";
+import { addNodeAttrs } from "../util/treeMiscHelpers";
 import * as types from "../actions/types";
 
 /* A version increase (i.e. props.version !== nextProps.version) necessarily implies
@@ -68,15 +69,8 @@ const Tree = (state = getDefaultTreeState(), action) => {
     case types.TREE_TOO_DATA:
       return action.tree;
     case types.ADD_EXTRA_METADATA:
-      // modify the node data in place, which will not trigger any redux updates
-      state.nodes.forEach((node) => {
-        if (action.newNodeAttrs[node.name]) {
-          if (!node.node_attrs) node.node_attrs = {};
-          for (const [attrName, attrData] of Object.entries(action.newNodeAttrs[node.name])) {
-            node.node_attrs[attrName] = attrData;
-          }
-        }
-      });
+      // add data into `nodes` in-place, so no redux update will be triggered if you only listen to `nodes`
+      addNodeAttrs(state.nodes, action.newNodeAttrs);
       // add the new colorings to visibleStateCounts & totalStateCounts so that they can function as filters
       return {
         ...state,

--- a/src/reducers/treeToo.js
+++ b/src/reducers/treeToo.js
@@ -4,13 +4,14 @@ import { getDefaultTreeState } from "./tree";
 that the tree is loaded as they are set on the same action */
 
 const treeToo = (state = getDefaultTreeState(), action) => {
+
+  /* There are only a few actions we should always listen for, as they can change
+  the presence / absence of the second tree */
   switch (action.type) {
     case types.DATA_INVALID:
       return Object.assign({}, state, {
         loaded: false
       });
-    case types.REMOVE_TREE_TOO:
-      return getDefaultTreeState();
     case types.URL_QUERY_CHANGE_WITH_COMPUTED_STATE: /* fallthrough */
     case types.CLEAN_START:
       if (action.treeToo) {
@@ -19,6 +20,19 @@ const treeToo = (state = getDefaultTreeState(), action) => {
       return getDefaultTreeState();
     case types.TREE_TOO_DATA:
       return action.treeToo;
+    default:
+      // no default case
+  }
+
+  /* All other actions can only modify an existing tree, so if one doesn't exist then
+  return early */
+  if (!state.loaded) {
+    return state;
+  }
+
+  switch (action.type) {
+    case types.REMOVE_TREE_TOO:
+      return getDefaultTreeState();
     case types.CHANGE_DATES_VISIBILITY_THICKNESS: /* fall-through */
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS:
       if (action.tangleTipLookup) {

--- a/src/reducers/treeToo.js
+++ b/src/reducers/treeToo.js
@@ -1,4 +1,5 @@
 import * as types from "../actions/types";
+import { addNodeAttrs } from "../util/treeMiscHelpers";
 import { getDefaultTreeState } from "./tree";
 /* A version increase (i.e. props.version !== nextProps.version) necessarily implies
 that the tree is loaded as they are set on the same action */
@@ -61,6 +62,10 @@ const treeToo = (state = getDefaultTreeState(), action) => {
           nodeColorsVersion: action.version
         });
       }
+      return state;
+    case types.ADD_EXTRA_METADATA:
+      // add data into `nodes` in-place, so no redux update will be triggered if you only listen to `nodes`
+      addNodeAttrs(state.nodes, action.newNodeAttrs);
       return state;
     default:
       return state;

--- a/src/util/treeMiscHelpers.js
+++ b/src/util/treeMiscHelpers.js
@@ -284,3 +284,21 @@ export const sortByGeneOrder = (genomeAnnotations) => {
     return 0;
   };
 };
+
+/**
+ * Add extra per-node attrs into the `nodes` data structure. Key clashes will result in the
+ * new data overwriting the existing data
+ * @param {Array} nodes d
+ * @param {Object} newAttrs
+ * @returns undefined - modifies the `nodes` param in-place
+ */
+export const addNodeAttrs = (nodes, newAttrs) => {
+  nodes.forEach((node) => {
+    if (newAttrs[node.name]) {
+      if (!node.node_attrs) node.node_attrs = {};
+      for (const [attrName, attrData] of Object.entries(newAttrs[node.name])) {
+        node.node_attrs[attrName] = attrData;
+      }
+    }
+  });
+};


### PR DESCRIPTION
Tips present only in the second tree will be correctly coloured, and
appear in the legend. However there are two (long-standing) bugs /
shortcomings related to the second tree which are relevant here:

1. Trait values which only appear in tips in the second tree will not be
available as filtering options (they will be correctly shown on the tree
and in the legend, however).

2. The tip-counts, as they appear in the header, only consider the main
(left) tree. For instance, if you have a metadata CSV with information
on 100 tips in the left tree, and 150 tips in the right tree (and 100
are in both), and you filter to the strains which appear in the dropped
CSV (the colouring is the same name as the file). The header will now
indicate "Showing 100 of XXX genomes", despite the fact that all 150
strains in the second tree are displayed.

Both of these bugs are not specific to drag-n-drop metadata, the same
situations happen with any colouring / filter.

Closes https://github.com/nextstrain/auspice/issues/1488
