### PR TITLE
Fix: narrative dataset filters

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -786,6 +786,7 @@ export const createStateFromQueryOrJSONs = ({
     metadata = {...oldState.metadata};
     frequencies = {...oldState.frequencies};
     controls = restoreQueryableStateToDefaults(controls);
+    controls = modifyStateViaMetadata(controls, metadata);
   }
 
   /* For the creation of state, we want to parse out URL query parameters

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -22,6 +22,7 @@ export const getDefaultControlsState = () => {
     layout: defaultLayout,
     geoResolution: defaultGeoResolution,
     filters: {},
+    filtersInFooter: [],
     colorBy: defaultColorBy,
     selectedBranchLabel: "none",
     showTransmissionLines: true
@@ -67,7 +68,8 @@ export const getDefaultControlsState = () => {
     canRenderBranchLabels: true,
     analysisSlider: false,
     geoResolution: defaults.geoResolution,
-    filters: {},
+    filters: defaults.filters,
+    filtersInFooter: defaults.filtersInFooter,
     showDownload: false,
     quickdraw: false, // if true, components may skip expensive computes.
     mapAnimationDurationInMilliseconds: 30000, // in milliseconds


### PR DESCRIPTION
When users change the slide in a narrative, the controls state gets
reset to its default state which updates the filters state to an empty
object. This leads to the bug described in #1492.

~This commit extracts the filters creation from `modifyStateViaMetadata`
into its own function so that it can be reused to recreate the filters
when users change the slide within a narrative.~

Resolves #1492.
