### PR TITLE
Scatterplots can display node order

### DIFF
--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -167,6 +167,14 @@ export function guessAreMutationsPerSite(scale) {
 }
 
 /**
+ * Is the node a subtree root node? (implies that we have either exploded trees or
+ * the dataset has multiple subtrees to display)
+ * @param {ReduxTreeNode} n
+ * @returns {bool}
+ */
+const isSubtreeRoot = (n) => (n.parent.name === "__ROOT" && n.parentInfo.original);
+
+/**
  * Gets the parent node to be used for stem / branch calculation.
  * Most of the time this is the same as `d.n.parent` however it is not in the
  * case of the root nodes for subtrees (e.g. exploded trees).
@@ -174,9 +182,7 @@ export function guessAreMutationsPerSite(scale) {
  * @returns {Node}
  */
 export const stemParent = (n) => {
-  return (n.parent.name === "__ROOT" && n.parentInfo.original) ?
-    n.parentInfo.original :
-    n.parent;
+  return isSubtreeRoot(n) ? n.parentInfo.original : n.parent;
 };
 
 
@@ -193,6 +199,6 @@ export const nodeOrdering = (nodes) => {
     .reduce((acc, val) => ((val ?? 0) > acc ? val : acc), 0);
   return (d) => ([
     maxVal - d.displayOrder,
-    maxVal - stemParent(d.n).shell.displayOrder
+    isSubtreeRoot(d.n) ? undefined : (maxVal - d.n.parent.shell.displayOrder)
   ]);
 };

--- a/src/components/tree/phyloTree/helpers.js
+++ b/src/components/tree/phyloTree/helpers.js
@@ -165,3 +165,34 @@ export function guessAreMutationsPerSite(scale) {
   const maxDivergence = max(scale.domain());
   return maxDivergence <= 5;
 }
+
+/**
+ * Gets the parent node to be used for stem / branch calculation.
+ * Most of the time this is the same as `d.n.parent` however it is not in the
+ * case of the root nodes for subtrees (e.g. exploded trees).
+ * @param {Node} n
+ * @returns {Node}
+ */
+export const stemParent = (n) => {
+  return (n.parent.name === "__ROOT" && n.parentInfo.original) ?
+    n.parentInfo.original :
+    n.parent;
+};
+
+
+/**
+ * Returns a function which itself gets the order of the node and that of its parent.
+ * This is not strictly the same as the `displayOrder` the scatterplot axis
+ * renders increasing values going upwards (i.e. from the bottom to top of screen)
+ * whereas the rectangular tree renders zero at the top and goes downwards
+ * @param {Array<PhyloNode>} nodes
+ * @returns {function} which takes a single argument of type <PhyloNode>
+ */
+export const nodeOrdering = (nodes) => {
+  const maxVal = nodes.map((d) => d.displayOrder)
+    .reduce((acc, val) => ((val ?? 0) > acc ? val : acc), 0);
+  return (d) => ([
+    maxVal - d.displayOrder,
+    maxVal - stemParent(d.n).shell.displayOrder
+  ]);
+};

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -5,6 +5,7 @@ import scaleLinear from "d3-scale/src/linear";
 import {point as scalePoint} from "d3-scale/src/band";
 import { timerStart, timerEnd } from "../../../util/perf";
 import { getTraitFromNode, getDivFromNode } from "../../../util/treeMiscHelpers";
+import { stemParent, nodeOrdering } from "./helpers";
 
 /**
  * assigns the attribute this.layout and calls the function that
@@ -48,20 +49,6 @@ export const setLayout = function setLayout(layout, scatterVariables) {
   timerEnd("setLayout");
 };
 
-
-/**
- * Gets the parent node to be used for stem / branch calculation.
- * Most of the time this is the same as `d.n.parent` however it is not in the
- * case of the root nodes for subtrees (e.g. exploded trees).
- * @param {Node} n
- * @returns {Node}
- */
-const stemParent = (n) => {
-  return (n.parent.name === "__ROOT" && n.parentInfo.original) ?
-    n.parentInfo.original :
-    n.parent;
-};
-
 /**
  * assignes x,y coordinates for a rectancular layout
  * @return {null}
@@ -92,7 +79,9 @@ export const scatterplotLayout = function scatterplotLayout() {
     return;
   }
 
-  const getDisplayOrderPair = (d) => ([d.displayOrder, stemParent(d.n).shell.displayOrder]);
+  const getDisplayOrderPair = (this.scatterVariables.x==="displayOrder" || this.scatterVariables.y==="displayOrder") ?
+    nodeOrdering(this.nodes) :
+    undefined;
 
   this.nodes.forEach((d) => {
     // set x and parent X values

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -92,6 +92,8 @@ export const scatterplotLayout = function scatterplotLayout() {
     return;
   }
 
+  const getDisplayOrderPair = (d) => ([d.displayOrder, stemParent(d.n).shell.displayOrder]);
+
   this.nodes.forEach((d) => {
     // set x and parent X values
     if (this.scatterVariables.x==="div") {
@@ -100,6 +102,8 @@ export const scatterplotLayout = function scatterplotLayout() {
     } else if (this.scatterVariables.x==="gt") {
       d.x = d.n.currentGt;
       d.px = stemParent(d.n).currentGt;
+    } else if (this.scatterVariables.x==="displayOrder") {
+      [d.x, d.px] = getDisplayOrderPair(d);
     } else {
       d.x = getTraitFromNode(d.n, this.scatterVariables.x);
       d.px = getTraitFromNode(stemParent(d.n), this.scatterVariables.x);
@@ -111,6 +115,8 @@ export const scatterplotLayout = function scatterplotLayout() {
     } else if (this.scatterVariables.y==="gt") {
       d.y = d.n.currentGt;
       d.py = stemParent(d.n).currentGt;
+    } else if (this.scatterVariables.y==="displayOrder") {
+      [d.y, d.py] = getDisplayOrderPair(d);
     } else {
       d.y = getTraitFromNode(d.n, this.scatterVariables.y);
       d.py = getTraitFromNode(stemParent(d.n), this.scatterVariables.y);

--- a/src/util/scatterplotHelpers.js
+++ b/src/util/scatterplotHelpers.js
@@ -18,6 +18,7 @@ export function collectAvailableScatterVariables(colorings, colorBy) {
   } else {
     options = options.filter((o) => o.value!=="gt");
   }
+  options.unshift({value: "displayOrder", label: "Node ordering in tree"});
   options.unshift({value: "div", label: "Divergence"});
 
   return options;
@@ -96,7 +97,8 @@ export function getFirstMatchingScatterVariable(options, tryTheseFirst, notThisV
  */
 export function addScatterAxisInfo(scatterVariables, axis, controls, tree, metadata) {
   const axisVar = scatterVariables[axis];
-  if (["div", "num_date"].includes(axisVar) || metadata.colorings[axisVar].type==="continuous") {
+  const knownContinuousKeys = ["div", "num_date", "displayOrder"];
+  if (knownContinuousKeys.includes(axisVar) || metadata.colorings[axisVar].type==="continuous") {
     scatterVariables[`${axis}Continuous`] = true;
     scatterVariables[`${axis}Domain`] = undefined;
     return scatterVariables;


### PR DESCRIPTION
See commits for details and [this internal slack thread](https://bedfordlab.slack.com/archives/CSKMU6YUC/p1647966053814009)

### Screenshots:

Node ordering vs time essentially recreates the rectangular tree

![image](https://user-images.githubusercontent.com/8350992/159600287-e64bf2b3-09ae-4561-a505-7f4447c6c78f.png)


Node ordering vs antigenic advance

![image](https://user-images.githubusercontent.com/8350992/159600315-980977dd-9334-4944-8d83-f4ebd42e3c3b.png)

vs S1 mutations

![image](https://user-images.githubusercontent.com/8350992/159600451-01c85f16-6731-4e37-9934-c568d857778b.png)


Comparing with categorical traits which haven't "evolved" across the tree isn't so useful

![image](https://user-images.githubusercontent.com/8350992/159600521-dc989fcc-5c25-46a9-90e8-f92ed7de0f7d.png)

vs logistic growth produces what looks like subtrees, but this is because most nodes don't have this annotated, so we are only drawing a subset of nodes, and branches only appear when both parent+child have values

![image](https://user-images.githubusercontent.com/8350992/159600656-71b55f3a-cdae-46d0-914e-821eb7bf81f0.png)

Exploded trees aren't quite right, as the thin branches here shouldn't be rendered (they're not a real branch, it's an artefact of how we store subtrees). I'll take a look at this now.

![image](https://user-images.githubusercontent.com/8350992/159600787-159f0df4-17eb-4108-8a6c-12b3133f1cf5.png)


