### PR TITLE
Show/hide non-AA branch labels according to tip count

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -78,11 +78,7 @@ const branchLabelFontWeight = (key) => {
  */
 const createBranchLabelVisibility = (key, layout, totalTipsInView) => (d) => {
   if (d.visibility !== NODE_VISIBLE) return "hidden";
-  if (key!=="aa") return "visible";
-  const magicTipFractionToShowBranchLabel = 0.05;
-  if (layout !== "rect") {
-    return "hidden";
-  }
+  const magicTipFractionToShowBranchLabel = 0.03;
   /* if the number of _visible_ tips descending from this node are over the
   magicTipFractionToShowBranchLabel (c/w the total number of _visible_ and
   _inView_ tips then display the label */


### PR DESCRIPTION
### Description of proposed changes

This is a simple change that causes non "aa" branch labels to use current behavior of "aa" branch labels. This causes label visibility to be dynamically determined based on the size of the subtending clade relative to total in view tips.

There have been a lot of "clade" labels that appear in the middle of the tree and are not meaningful.

Previous behavior:

<img width="1126" alt="previous-1" src="https://user-images.githubusercontent.com/1176109/162597529-4ae4ffaf-8f5c-4a2e-8c85-3d5bebc3a5e8.png">

Updated behavior:

<img width="1126" alt="updated-1" src="https://user-images.githubusercontent.com/1176109/162597543-4f8c65e3-d88d-4642-9a82-cf1bf6b9bb08.png">

I think much cleaner. Zooming appropriately expands visibility.

### Testing

I've tested locally and with Heroku review app with a variety of SARS-CoV-2 trees and flu trees.