### PR TITLE
Update footer styling to better display tables

### DIFF
--- a/src/components/framework/footer.js
+++ b/src/components/framework/footer.js
@@ -26,6 +26,14 @@ const FooterStyles = styled.div`
     font-weight: 300;
   }
 
+  ol {
+    font-weight: 300;
+  }
+
+  ul {
+    font-weight: 300;
+  }
+
   h1 {
     font-weight: 700;
     font-size: 2.50em;
@@ -120,6 +128,28 @@ const FooterStyles = styled.div`
     margin-right: 30px;
     margin-top: 2px;
     margin-bottom: 2px;
+  }
+
+  table {
+    font-weight: 300;
+    margin-bottom: 1rem;
+
+    th,
+    td {
+      text-align: left;
+      padding: 0.45rem;
+      vertical-align: top;
+      border-top: 1px solid #dee2e6;
+    }
+
+    thead th {
+      vertical-align: bottom;
+      border-bottom: 2px solid #dee2e6;
+    }
+
+    tbody + tbody {
+      border-top: 2px solid #dee2e6;
+    }
   }
 
 `;


### PR DESCRIPTION
### Description of proposed changes

This commit borrows from simple Bootstrap styling of tables. It also fixes an issue with lists in having a different font weight than paragraph text.

This was motivated by recent work on https://github.com/nextstrain/ncov/pull/910 and wanting to display a table of links. Before this PR, the table would render as:

<img width="1078" alt="before" src="https://user-images.githubusercontent.com/1176109/164816129-6c5fc295-a474-407a-9c2a-f644aa1f7985.png">

After this PR, this same table renders as:

<img width="1078" alt="after" src="https://user-images.githubusercontent.com/1176109/164816288-c477653b-3533-444a-9891-b65b9926f4af.png">

### Related issue(s)

Related to https://github.com/nextstrain/ncov/pull/910

### Testing
Tested locally.

