### PR TITLE
Show labels for subtree root nodes

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -85,6 +85,11 @@ const createBranchLabelVisibility = (key, layout, totalTipsInView) => (d) => {
   if (d.n.tipCount > magicTipFractionToShowBranchLabel * totalTipsInView) {
     return "visible";
   }
+  /* if the label is on the root of a subtree then always show it
+  (unless the label is "aa" as these can be very long) */
+  if (key!=='aa' && (d.n.name===d.n.parent.name || d.n.parent.name==="__ROOT")) {
+    return "visible";
+  }
   return "hidden";
 };
 


### PR DESCRIPTION
This commit is related to the recent PR #1501 which hid (non-aa) labels
depending on their in-view tip-fraction. Here if the label is on the
root of a subtree then we always show it (unless the label is "aa" as
these can be very long).

Without this change, when exploding by "emerging lineage" only BA.1.1 would be labelled in the following screenshot (when not exploded, then only BA.1.1 is labelled, as per #1501)

![image](https://user-images.githubusercontent.com/8350992/165663459-2514f1ff-0060-4a6d-aa74-2d01fc0545ba.png)
![image](https://user-images.githubusercontent.com/8350992/165663480-af79912e-2d21-41ef-9152-9e8f620d8528.png)
