### PR TITLE
add getDarkerColor() to colorHelpers to help ensure tip and legend fill colors match for categorical attributes

### DIFF
--- a/src/components/measurements/measurementsD3.js
+++ b/src/components/measurements/measurementsD3.js
@@ -5,7 +5,7 @@ import { select, event as d3event } from "d3-selection";
 import { symbol, symbolDiamond } from "d3-shape";
 import { orderBy } from "lodash";
 import { measurementIdSymbol, measurementJitterSymbol } from "../../util/globals";
-import { getBrighterColor } from "../../util/colorHelpers";
+import { getDarkerColor } from "../../util/colorHelpers";
 
 /* C O N S T A N T S */
 export const layout = {
@@ -272,9 +272,9 @@ export const drawMeasurementsSVG = (ref, svgData, handleHover) => {
 export const colorMeasurementsSVG = (ref, treeStrainColors) => {
   const svg = select(ref);
   svg.selectAll(`.${classes.rawMeasurements}`)
-    .style("stroke", (d) => treeStrainColors[d.strain].color)
+    .style("stroke", (d) => getDarkerColor(treeStrainColors[d.strain].color))
     .style("stroke-width", layout.circleStrokeWidth)
-    .style("fill", (d) => getBrighterColor(treeStrainColors[d.strain].color));
+    .style("fill", (d) => treeStrainColors[d.strain].color);
 };
 
 export const drawMeansForColorBy = (ref, svgData, treeStrainColors, handleHover) => {

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -166,8 +166,8 @@ class Legend extends React.Component {
             dispatch={this.props.dispatch}
             legendRectSize={ITEM_RECT_SIZE}
             legendSpacing={LEGEND_SPACING}
-            rectFill={rgb(this.props.colorScale.scale(d)).brighter([0.35]).toString()}
-            rectStroke={rgb(this.props.colorScale.scale(d)).toString()}
+            rectFill={rgb(this.props.colorScale.scale(d)).toString()}
+            rectStroke={rgb(this.props.colorScale.scale(d)).darker([0.35]).toString()}
             transform={this.getTransformationForLegendItem(maxNumPerColumn, i)}
             key={d}
             value={d}

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -1,4 +1,4 @@
-import { calcBranchStrokeCols, getBrighterColor } from "../../../util/colorHelpers";
+import { calcBranchStrokeCols, getDarkerColor } from "../../../util/colorHelpers";
 
 export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps, newProps) => {
   const args = {};
@@ -22,8 +22,8 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
       newProps.colorByConfidence !== oldProps.colorByConfidence)) {
     args.changeColorBy = true;
     args.branchStroke = calcBranchStrokeCols(newTreeRedux, newProps.colorByConfidence, newProps.colorBy);
-    args.tipStroke = newTreeRedux.nodeColors;
-    args.fill = newTreeRedux.nodeColors.map(getBrighterColor);
+    args.tipStroke = newTreeRedux.nodeColors.map(getDarkerColor);
+    args.fill = newTreeRedux.nodeColors;
   }
 
   /* visibility */

--- a/src/components/tree/reactD3Interface/initialRender.js
+++ b/src/components/tree/reactD3Interface/initialRender.js
@@ -1,6 +1,6 @@
 import { select } from "d3-selection";
 import 'd3-transition';
-import { calcBranchStrokeCols, getBrighterColor } from "../../../util/colorHelpers";
+import { calcBranchStrokeCols, getDarkerColor } from "../../../util/colorHelpers";
 import * as callbacks from "./callbacks";
 import { makeTipLabelFunc } from "../phyloTree/labels";
 
@@ -43,8 +43,8 @@ export const renderTree = (that, main, phylotree, props) => {
     props.temporalConfidence.on, /* drawConfidence? */
     treeState.vaccines,
     calcBranchStrokeCols(treeState, props.colorByConfidence, props.colorBy),
+    treeState.nodeColors.map(getDarkerColor),
     treeState.nodeColors,
-    treeState.nodeColors.map(getBrighterColor),
     treeState.tipRadii, /* might be null */
     [props.dateMinNumeric, props.dateMaxNumeric],
     props.scatterVariables

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -121,4 +121,4 @@ export const getEmphasizedColor = (color) => {
   return rgb(hslColor).toString();
 };
 
-export const getBrighterColor = (color) => rgb(color).brighter([0.65]).toString();
+export const getDarkerColor = (color) => rgb(color).darker([0.35]).toString();


### PR DESCRIPTION
This addresses an issue where the fill colors in the legend for categorical metadata fields do not match the fill colors of tips in the tree (but the stroke colors do match). As an example, here are two screenshots inspecting fill colors from the [live nextstrain.org deployment of auspice](https://nextstrain.org/ncov/gisaid/global/6m?d=tree&f_submitting_lab=Infectious%20Disease%20Program,%20Broad%20Institute%20of%20Harvard%20and%20MIT&p=full) as of 2022-05-03:

<img width="1811" alt="tree_tip_color_inspection" src="https://user-images.githubusercontent.com/53064/166618827-0d03c057-19cd-4eb0-8aab-c7f24e8109b9.png">
<img width="1811" alt="legend_color_inspection" src="https://user-images.githubusercontent.com/53064/166619388-43676644-728c-462e-af11-860438e81332.png">


A little difficult to pinpoint, and it may yet be a quirk of my system (macOS 11.6 w/ Chrome 100.0.4896.75), but the issue could stem from imprecision in the use of Math.pow() in the [`d3-color` `brighter()` function](https://github.com/d3/d3-color/blob/main/src/color.js#L248-L251), used by auspice in a few places. I was interested in making sure the fill colors match between the legend and the tips (for ease of "select-all->replace" actions in Inkscape or Illustrator), so rather than brighten the fill, I set the fill to the color returned from the categorical color map and use the `darken()` function from `d3-color` to darken the stroke (which also uses Math.pow(), but it's less of a problem if the stroke colors do not match exactly). This change is implemented as the new function `getDarkerColor()` in `colorHelpers.js`, which is then used to adjust the stroke color in the files where `getBrighterColor()` was previously applied to the fill.

### Description of proposed changes
add `getDarkerColor()` as the inverse of `getBrighterColor()` (and remove the latter); set legend item fill and tree tip fill colors to be the same (returned from the color map), and adjust the stroke of each via `getDarkerColor() ` to show a contrasting border, rather than by setting the fill via getBrighterColor(). This helps ensure the fill color of the legend matches the fill of associated tips

### Related issue(s)
n/a

### Testing
Inspection of legend fill and stroke colors vs tip fill and stroke colors
