### PR TITLE
consistent legend and tip (fill) colours

### DIFF
--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -4,6 +4,7 @@ import { rgb } from "d3-color";
 import LegendItem from "./item";
 import { headerFont, darkGrey } from "../../../globalStyles";
 import { fastTransitionDuration, months } from "../../../util/globals";
+import { getBrighterColor } from "../../../util/colorHelpers";
 import { numericToCalendar } from "../../../util/dateHelpers";
 import { isColorByGenotype, decodeColorByGenotype } from "../../../util/getGenotype";
 import { TOGGLE_LEGEND } from "../../../actions/types";
@@ -166,7 +167,7 @@ class Legend extends React.Component {
             dispatch={this.props.dispatch}
             legendRectSize={ITEM_RECT_SIZE}
             legendSpacing={LEGEND_SPACING}
-            rectFill={rgb(this.props.colorScale.scale(d)).brighter([0.35]).toString()}
+            rectFill={getBrighterColor(this.props.colorScale.scale(d))}
             rectStroke={rgb(this.props.colorScale.scale(d)).toString()}
             transform={this.getTransformationForLegendItem(maxNumPerColumn, i)}
             key={d}


### PR DESCRIPTION
This resolves a (very very old!) bug described by @tomkinsc in
https://github.com/nextstrain/auspice/pull/1504 where the RGB values of
the legend fill were slightly different to the corresponding tip-fill.

The legend lightened by 0.35 whereas the tips lightened by 0.65. This
difference wasn't obvious (I don't think anyone noticed it with human
eyes) but it certainly resulted in different RGB values:

legend: `rgb(hex).brighter([0.35]).toString()`
tip:    `getBrighterColor(hex) -> rgb(color).brighter([0.65]).toString()`

This commit modifies the legend to use the helper function so all
brightening is performed in one place.
