### PR TITLE
ci: Add token to use GitHub CLI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,3 +89,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: gh workflow run ci.yml --repo nextstrain/docker-base
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}


### PR DESCRIPTION
### Description of proposed changes

The usage of `gh workflow run` was untested until the release of 2.37.1. The first time using it revealed additional authentication is needed for this step to work properly (#1508). This change adds the necessary environment variable to authenticate to GitHub CLI ([doc](https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows)).

Other things done outside of PR changes:

1. Logged in to GitHub as `nextstrain-bot`.
2. Created a new Personal Access Token named `org secret: GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH` with `public_repo` scope, expiring 2023-01-01.
3. Went to https://github.com/organizations/nextstrain/settings/secrets/actions.
4. Created a new secret `GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH` available to repos: augur, auspice, test-github-actions.

### Related issue(s)

- Fixes #1508

### Testing

1. Created a test workflow over at https://github.com/nextstrain/test-github-actions/commit/f9c45e413eb1eae7a2fde3b5749e2b1f2b4074bd
2. Re-ran while tweaking the token scope until I got a successful command with minimal scope.