### PR TITLE
Fix clip mask bug

### DIFF
--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -384,10 +384,6 @@ export const change = function change({
     elemsToUpdate.add('.tipLabel'); /* will trigger d3 commands as required */
   }
 
-  /* Finally, actually change the SVG elements themselves */
-  if (svgHasChangedDimensions) {
-    this.setClipMask();
-  }
   const extras = { removeConfidences, showConfidences, newBranchLabellingKey };
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
   extras.hideTipLabels = animationInProgress;

--- a/src/components/tree/phyloTree/layouts.js
+++ b/src/components/tree/phyloTree/layouts.js
@@ -347,6 +347,8 @@ export const mapToScreen = function mapToScreen() {
 
   /* construct & set the range of the x & y scales */
   this.setScales();
+  /* update the clip mask accordingly */
+  this.setClipMask();
 
   let nodesInDomain = this.nodes.filter((d) => d.inView && d.y!==undefined && d.x!==undefined);
   // scatterplots further restrict nodes used for domain calcs - if not rendering branches,


### PR DESCRIPTION
The clip-mask uses the scale ranges and thus is prone to getting out-
of-sync, as described in https://github.com/nextstrain/auspice/issues/1512.
This commit should mitigate such bugs at the expense of regenerating
the mask more often.

Closes https://github.com/nextstrain/auspice/issues/1512

