### PR TITLE
Make GitHub release when releasing new version

### DIFF
--- a/releaseNewVersion.sh
+++ b/releaseNewVersion.sh
@@ -2,9 +2,9 @@
 
 # VARIABLES
 read -r -d '' purposeMsg <<'EOF'
-Bumping Auspice version & deploying to Heroku
+Releasing a new Auspice version
 
-This script attempts to do 9 things. It will exit if any steps fail...
+This script attempts to do 10 things. It will exit if any steps fail...
 (1) checkout master & ensure it is up to date with github
 (2) increment Version number (in `src/version.js` and `package.json`) by prompting the user
 (3) add a title with the version number to the CHANGELOG
@@ -12,8 +12,9 @@ This script attempts to do 9 things. It will exit if any steps fail...
 (5) checkout `release` branch from github (will fail if it exists locally)
 (6) merge master -> release
 (7) tag release with new version
-(8) push release branch to github (this triggers Travis CI to build, upload and trigger Heroku deploy)
+(8) push release branch to github (this triggers GitHub Actions CI to build and publish to npm)
 (9) checkout `master` and remove local `release` branch
+(10) Create a GitHub Release
 
 EOF
 
@@ -37,6 +38,9 @@ if git rev-parse --verify --quiet release
     echo "release branch already exists locally - fatal"
     exit 2
 fi
+
+# exit early if user is not authenticated with the GitHub CLI (or doesn't have it)
+gh auth status
 
 # step 1: check master is up to date with github
 step="1"
@@ -99,9 +103,14 @@ git tag -a v${newVersion} -m "${msg}"
 step="8"
 git push --follow-tags origin release
 
-# step 10: go back to master & delete release branch (locally)
+# step 9: go back to master & delete release branch (locally)
 step="9"
 git checkout master
 git branch -d release
 
-echo -e "\nScript completed. $msg (version ${newVersion}) pushed to github:release and github:master\n"
+echo -e "\n$msg (version ${newVersion}) pushed to github:release and github:master"
+echo -e "\nThe 'CI' GitHub Action will automatically publish this version to npm"
+echo -e "\nNow attempting to make a GitHub release (https://github.com/nextstrain/auspice/releases). If this step fails please do this manually."
+
+# Step 10: create a release based off the tag with content from the changlog
+node scripts/extract-release-notes.js | gh release create v${newVersion} -t "Auspice ${newVersion}" --notes-file -

--- a/scripts/extract-release-notes.js
+++ b/scripts/extract-release-notes.js
@@ -1,0 +1,30 @@
+/* Simple script to extract latest release notes from CHANGELOG.md
+ * Based on @ivan-aksamentov's https://github.com/nextstrain/nextclade/blob/613637e1305cf742e13dbe073976257365ca14dd/scripts/extract-release-notes.py
+ * It is intended to be run as part of releaseNewVersion.sh
+ */
+
+const fs = require('fs');
+
+function main() {
+  const releaseNotes = [];
+  const content = fs.readFileSync('./CHANGELOG.md', {encoding: 'utf8'}).split("\n");
+  let insideReleaseBlock = false;
+  for (let i=0; i<content.length; i++) {
+    if (!insideReleaseBlock && content[i].startsWith("## version")) {
+      insideReleaseBlock = true;
+      continue;
+    }
+    if (insideReleaseBlock) {
+      if (content[i].startsWith("## version")) {
+        break; // next release found
+      }
+      if (!releaseNotes.length && content[i]==="") {
+        continue; // skip leading empty lines
+      }
+      releaseNotes.push(content[i]);
+    }
+  }
+  console.log(releaseNotes.join("\n")); // eslint-disable-line no-console
+}
+
+main();


### PR DESCRIPTION
This follows the example set by Nextclade (@ivan-aksamentov) and should
result in https://github.com/nextstrain/auspice/releases staying
up-to-date. Note that this does not replace `npm` as the typical
way to install new auspice versions.

P.S. Slack discussion [here](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1653653815905769)