### PR TITLE
Allow temporal scales

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -197,8 +197,9 @@ const getTraitsToDisplay = (node) => {
 const Trait = ({node, trait, colorings, isTerminal}) => {
   let value = getTraitFromNode(node, trait);
   const confidence = getTraitFromNode(node, trait, {confidence: true});
+  const isTemporal = colorings[trait]?.type==="temporal";
 
-  if (typeof value === "number") {
+  if (typeof value === "number" && !isTemporal) {
     if (!Number.isInteger(value)) {
       value = Number.parseFloat(value).toPrecision(3);
     }
@@ -215,6 +216,12 @@ const Trait = ({node, trait, colorings, isTerminal}) => {
   const name = (colorings && colorings[trait] && colorings[trait].title) ?
     colorings[trait].title :
     trait;
+
+  /* case where the colorScale is temporal */
+  if (isTemporal && typeof value === "number") {
+    return item(name, numericToCalendar(value));
+  }
+
   const url = getUrlFromNode(node, trait);
   if (url) {
     return <Link title={name} url={url} value={value}/>;

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -107,10 +107,15 @@ const ColorBy = ({node, colorBy, colorByConfidence, colorScale, colorings}) => {
   const name = (colorings && colorings[colorBy] && colorings[colorBy].title) ?
     colorings[colorBy].title :
     colorBy;
+  const value = getTraitFromNode(node, colorBy);
+
+  /* case where the colorScale is temporal */
+  if (colorScale.scaleType==="temporal" && typeof value === "number") {
+    return <InfoLine name={`${name}:`} value={numericToCalendar(value)}/>;
+  }
 
   /* helper function to avoid code duplication */
   const showCurrentColorByWithoutConfidence = () => {
-    const value = getTraitFromNode(node, colorBy);
     return isValueValid(value) ?
       <InfoLine name={`${name}:`} value={value}/> :
       null;

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -138,7 +138,7 @@ class Legend extends React.Component {
       return this.props.colorScale.legendLabels.get(label);
     }
     /* depending on the colorBy, we display different labels! */
-    if (this.props.colorBy === "num_date") {
+    if (this.props.colorBy === "num_date" || this.props.colorScale.scaleType==="temporal") {
       const legendValues = this.props.colorScale.visibleLegendValues;
       if (
         (legendValues[legendValues.length-1] - legendValues[0] > 10) && /* range spans more than 10 years */


### PR DESCRIPTION
This implements a feature I've long wanted & it does it the quick and
easy way: by requiring that the value already be numeric! In the future
it'd be nice to allow `YYYY-MM-DD` values, but that's for another PR (and
comes with its own complexities regarding ambiguity). 

This PR is related to https://github.com/nextstrain/augur/pull/969 and an example output is available at https://github.com/nextstrain/monkeypox/pull/57

This was part of #1519 (ill remove this commit from that PR when I revisit it)