### PR TITLE
docs: Correct note about CORS

### DIFF
--- a/docs/customise-client/api.md
+++ b/docs/customise-client/api.md
@@ -129,8 +129,7 @@ By default, the client makes API requests ([as detailed here](requests.md)) to "
 This is using the default server address of "/charon".
 This can be changed by specifying `serverAddress` in the customisation JSON.
 
-> Note that currently you can't specify a different domain due to CORS headers.
-This may well be a simple fix -- please get in touch if you can help here!
+> Note that if you specify a `serverAddress` on a different origin (protocol + domain + port) than Auspice, the server will need to send CORS headers to permit the requests from Auspice.
 
 ---
 


### PR DESCRIPTION
In terms of permitting cross-origin requests with the various
CORS-related headers, what matters is the configuration of the
responding origin.  There's nothing the requesting origin (i.e. Auspice
here) can do itself.
