### PR TITLE
fix: prevent crash on unexpected gisaid_epi_isl

### DIFF
--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -60,11 +60,12 @@ const AccessionAndUrl = ({node}) => {
   let gisaid_epi_isl_url = null;
   let genbank_accession_url = null;
   if (isValueValid(gisaid_epi_isl)) {
-    const gisaid_epi_isl_number = gisaid_epi_isl.split("_")[2];
-    // slice has to count from the end of the string rather than the beginning to deal with EPI ISLs of different lengths, eg
-    // https://www.epicov.org/acknowledgement/67/98/EPI_ISL_406798.json
-    // https://www.epicov.org/acknowledgement/99/98/EPI_ISL_2839998.json
-    if (gisaid_epi_isl_number.length > 4) {
+    const gisaid_accession_regex = new RegExp('EPI_ISL_[0-9]{5,}');
+    if (gisaid_accession_regex.test(gisaid_epi_isl)) {
+      const gisaid_epi_isl_number = gisaid_epi_isl.split("_")[2];
+      // slice has to count from the end of the string rather than the beginning to deal with EPI ISLs of different lengths, eg
+      // https://www.epicov.org/acknowledgement/67/98/EPI_ISL_406798.json
+      // https://www.epicov.org/acknowledgement/99/98/EPI_ISL_2839998.json
       gisaid_epi_isl_url = "https://www.epicov.org/acknowledgement/" + gisaid_epi_isl_number.slice(-4, -2) + "/" + gisaid_epi_isl_number.slice(-2) + "/" + gisaid_epi_isl + ".json";
     } else {
       gisaid_epi_isl_url = "https://gisaid.org";


### PR DESCRIPTION
### Description of proposed changes
In cases where the `gisaid_epi_isl` value does not fit the expected
format with two underscores ("EPI_ISL_\<number\>"), Auspice crashes when
you click on a tip with an error:
```
TypeError: Cannot read properties of undefined (reading 'length')
```
This commit adds a check to verify the `gisaid_epi_isl` value matches
our expected format with the regex. The regex specifies that the
accession number must be at least 5 digits so that it can be sliced
to create the proper URL.

### Testing
I ran into this crash when I was testing if we can add seasonal flu GISAID accessions to the acknowledgement's table by changing the `accession` attribute to `gisaid_epi_isl`. The seasonal flu accessions are the sequence segment accessions instead of the virus isolate accessions, so it did not fit the expected format for `gisaid_epi_isl`. If you go to the https://next.nextstrain.org/staging/with-gisaid-accession/flu/seasonal/h3n2/ha/2y and click on a tip, the app crashes. 

This change prevents the crash in my local testing with the same JSON and properly adds the default `https://gisaid.org` URL. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
