### PR TITLE
Use app.json, upgrade to `heroku-22`

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -98,6 +98,10 @@ Run `npm run lint`. If there are issues run `npm run lint:fix`.
     3. Example: `test/integration/zika.test.js`
 
 
+#### Manual testing
+
+A Heroku pipeline for this repository is connected to GitHub under the nextstrain-bot user account. The Review Apps feature facilitates manual review of changes by automatically creating a test instance from the PR source branch and adding a link to it on the GitHub PR page. These apps are based on configuration in [app.json](./app.json).
+
 ## git-lfs
 
 We use [Git Large File Storage](https://github.com/git-lfs/git-lfs) to manage certain assets.

--- a/app.json
+++ b/app.json
@@ -2,8 +2,14 @@
   "name": "auspice",
   "scripts": {},
   "env": {
-    "HOST": "0.0.0.0",
-    "NPM_CONFIG_PRODUCTION": "true"
+    "HOST": {
+      "description": "For Auspice server; see https://docs.nextstrain.org/projects/auspice/en/stable/server/index.html#deploying-via-heroku",
+      "value": "0.0.0.0"
+    },
+    "NPM_CONFIG_PRODUCTION": {
+      "description": "Runs with NODE_ENV=production; see https://devcenter.heroku.com/articles/nodejs-support#configuring-npm",
+      "value": "true"
+    }
   },
   "formation": {
     "web": {

--- a/app.json
+++ b/app.json
@@ -22,5 +22,5 @@
       "url": "heroku/nodejs"
     }
   ],
-  "stack": "heroku-18"
+  "stack": "heroku-22"
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "name": "auspice",
+  "scripts": {},
+  "env": {
+    "HOST": "0.0.0.0",
+    "NPM_CONFIG_PRODUCTION": "true"
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ],
+  "stack": "heroku-18"
+}


### PR DESCRIPTION
_(same thing as nextstrain/auspice.us#33 for this repo)_

### Description of proposed changes

Create an app.json and use it to upgrade the Heroku stack to `heroku-22`.

### Related issue(s)

_N/A_

### Testing

- [x] [Review app builds with `heroku-22`](https://dashboard.heroku.com/apps/auspice-victorlin-updat-quf3fd/activity/builds/dcea444b-a71c-4e4d-8132-67c9e72b147d)