### PR TITLE
docs: Install nextstrain.sphinx.theme extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx_markdown_tables',
     'sphinxarg.ext',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - sphinx
   - pip
   - pip:
-    - nextstrain-sphinx-theme>=2020.2
+    - nextstrain-sphinx-theme>=2022.5
     - sphinx-markdown-tables
     - sphinx-argparse


### PR DESCRIPTION
## Description of proposed changes

The new extension has sphinx_copybutton pre-installed and configured. This change enables it here.
This also makes it easier to configure other extensions across multiple docs projects.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [ ] copy button works on RTD preview build