### PR TITLE
Feat/undeletions

### DIFF
--- a/src/components/tree/infoPanels/MutationTable.js
+++ b/src/components/tree/infoPanels/MutationTable.js
@@ -85,6 +85,7 @@ const mutCategoryLookup = {
   changes: "Changes",
   homoplasies: "Homoplasies",
   reversionsToRoot: "Reversions to root",
+  undeletions: "Undeletions",
   gaps: "Gaps",
   ns: "Ns "
 };
@@ -121,7 +122,7 @@ const displayGeneMutations = (gene, mutsPerCat) => {
               key={name}
               name={name}
               muts={mutsPerCat[key]}
-              displayAsIntervals={key==="gaps" || key==="ns"}
+              displayAsIntervals={key==="gaps" || key==="ns" || key==='undeletions'}
               isNuc={gene==="nuc"}
             />) :
             null

--- a/src/components/tree/infoPanels/MutationTable.js
+++ b/src/components/tree/infoPanels/MutationTable.js
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from 'styled-components';
+import { FaInfoCircle } from "react-icons/fa";
 import { getBranchMutations, getTipChanges } from "../../../util/treeMiscHelpers";
-
+import { StyledTooltip } from "../../controls/styles";
 
 const Button = styled.button`
   border: 0px;
@@ -132,6 +133,49 @@ const displayGeneMutations = (gene, mutsPerCat) => {
   );
 };
 
+const InfoContainer = styled.span`
+  padding-left: 10px;
+  cursor: help;
+  color: #888;
+`;
+
+const branchMutationInfo = (<div>
+  A summary of mutations inferred to have occurred on this branch.
+  Mutations are grouped into one of the following (mutually exclusive) categories,
+  with the first matching category used:
+
+  <ol>
+    <li>Undeletions: a change from a &apos;-&apos; character to a base; beware that these are often bioinformatics artifacts</li>
+    <li>Gaps: A change to a &apos;-&apos; character, indicating a missing base; these can indicate deletions but sometimes areas of no coverage are filled with gaps</li>
+    <li>Ns: Typically due to lack of sequence coverage or ambiguity at this position (Nucleotides only)</li>
+    <li>Homoplasies: a mutation that has also been observed elsewhere on the tree</li>
+    <li>Unique: Mutations which are only observed on this branch</li>
+  </ol>
+
+  Reversions to Root is an additional category which highlights those mutations which return the state to that of the root.
+  Mutations in this category will also appear one of the five categories listed above.
+  <p/>
+  Gaps and Ns are grouped into intervals, as they frequently occur in succession.
+  Click below to copy all changes to clipboard to see the full list.
+</div>);
+
+const tipChangesInfo = (<div>
+  A summary of sequence changes between the root and the selected tip.
+  Changes are grouped into one of the following (mutually exclusive) categories,
+  with the first matching category used:
+
+  <ol>
+    <li>Gaps: A change to a &apos;-&apos; character, indicating a missing base; these can indicate deletions but sometimes areas of no coverage are filled with gaps</li>
+    <li>Ns: Typically due to lack of sequence coverage or ambiguity at this position (Nucleotides only)</li>
+    <li>Reversions to root: The tip state is the same as the root state, however this has changed and been reverted along the way</li>
+    <li>Changes: The tip state differs from the root state</li>
+  </ol>
+
+  Gaps and Ns are grouped into intervals, as they frequently occur in succession.
+  Click below to copy all changes to clipboard to see the full list.
+</div>);
+
+
 export const MutationTable = ({node, geneSortFn, isTip, observedMutations}) => {
   const categorisedMutations = isTip ?
     getTipChanges(node) :
@@ -148,8 +192,16 @@ export const MutationTable = ({node, geneSortFn, isTip, observedMutations}) => {
   return (
     <>
       <Heading>
-        {isTip ? `Sequence changes observed (from root):` : `Mutations observed on branch:`}
+        {isTip ? `Sequence changes observed (from root)` : `Mutations observed on branch`}
+        <InfoContainer data-tip data-for="seqChangesInfo">
+          <FaInfoCircle/>
+        </InfoContainer>
       </Heading>
+
+      <StyledTooltip place="bottom" type="light" effect="solid" id="seqChangesInfo">
+        {isTip ? tipChangesInfo : branchMutationInfo}
+      </StyledTooltip>
+
       <table>
         <tbody>
           {Object.keys(categorisedMutations).sort(geneSortFn).map(

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -209,6 +209,10 @@ const BranchMutations = ({node, geneSortFn, observedMutations, t}) => {
       const value = `${parseIntervalsOfNsOrGaps(categorisedMutations.nuc.gaps).length} regions, ${categorisedMutations.nuc.gaps.length}bp.`;
       elements.push(<InfoLine name='Gaps:' value={value} key="nuc_gaps"/>);
     }
+    if (categorisedMutations.nuc.undeletions.length) {
+      const value = `${parseIntervalsOfNsOrGaps(categorisedMutations.nuc.undeletions).length} regions, ${categorisedMutations.nuc.undeletions.length}bp.`;
+      elements.push(<InfoLine name='Undeletions:' value={value} key="nuc_undeletions"/>);
+    }
     if (categorisedMutations.nuc.ns.length) {
       const value = `${parseIntervalsOfNsOrGaps(categorisedMutations.nuc.ns).length} regions, ${categorisedMutations.nuc.ns.length}bp.`;
       elements.push(<InfoLine name='Ns:' value={value} key="nuc_ns"/>);

--- a/test/treeHelpers.test.js
+++ b/test/treeHelpers.test.js
@@ -1,4 +1,4 @@
-import { getUrlFromNode, getAccessionFromNode, getBranchMutations } from "../src/util/treeMiscHelpers";
+import { getUrlFromNode, getAccessionFromNode, getBranchMutations, categoriseSeqChanges } from "../src/util/treeMiscHelpers";
 import { treeJsonToState } from "../src/util/treeJsonProcessing";
 import { parseIntervalsOfNsOrGaps } from "../src/components/tree/infoPanels/MutationTable";
 
@@ -98,6 +98,28 @@ describe('Parse and summarise mutations', () => {
         reversionsToRoot: ["B100A"]
       }
     });
+  });
+
+  test("Tip mutations are correctly categorised", () => {
+
+    expect(categoriseSeqChanges({nuc: []}))
+      .toEqual({
+        nuc: {gaps: [], ns: [], reversionsToRoot: [], changes: []}
+      });
+
+    expect(categoriseSeqChanges({nuc: {
+      100: ['A', 'N'], // typical unknown base due to low coverage
+      101: ['A', '-'], // typical gap
+      102: ['A', 'T'], // typical change
+      103: ['A', 'A'], // typical reversion to root
+      104: ['-', 'T'], // strange, but can happen via `augur ancestral` when ref (root) seq has been pruned
+      105: ['-', '-'], // stranger, but occurs when we have situations like the above
+      106: ['N', 'N']
+    }}))
+      .toEqual({
+        nuc: {gaps: ["A101-", "-105-"], ns: ["A100N", "N106N"], reversionsToRoot: ["A103A"], changes: ["A102T", "-104T"]}
+      });
+
   });
 });
 

--- a/test/treeHelpers.test.js
+++ b/test/treeHelpers.test.js
@@ -18,7 +18,7 @@ const dummyTree = treeJsonToState({
   children: [
     {
       name: "node1",
-      branch_attrs: {mutations: {GENE: ["A100B", "C200D", "E300F"]}},
+      branch_attrs: {mutations: {GENE: ["A100B", "C200D", "E300F", "A400-"]}},
       children: [
         { // start 1st child of node1
           name: "node1.1",
@@ -34,7 +34,7 @@ const dummyTree = treeJsonToState({
         },
         { // 3rd child of node1
           name: "tipZ",
-          branch_attrs: {mutations: {GENE: ["F300G", "B100A"]}}
+          branch_attrs: {mutations: {GENE: ["F300G", "B100A", "-400A"]}}
         }
       ]
     }
@@ -47,6 +47,8 @@ describe('Parse and summarise mutations', () => {
     // is part of treeJsonToState so we are testing it indirectly
     expect(dummyTree.observedMutations)
       .toEqual({ // exactly equal all Obj keys and values
+        "GENE:A400-": 1,
+        "GENE:-400A": 1,
         "GENE:A100B": 1,
         "GENE:C200D": 1,
         "GENE:E300F": 1,
@@ -65,7 +67,8 @@ describe('Parse and summarise mutations', () => {
       GENE: {
         unique: ["A100B", "C200D", "E300F"],
         homoplasies: [],
-        gaps: [],
+        gaps: ["A400-"],
+        undeletions: [],
         reversionsToRoot: []
       }
     });
@@ -78,7 +81,21 @@ describe('Parse and summarise mutations', () => {
         unique: ["D200C"],
         homoplasies: ["F300G"],
         gaps: [],
+        undeletions: [],
         reversionsToRoot: ["D200C"]
+      }
+    });
+    const branch_tipZ = getBranchMutations(
+      getNodeByName(dummyTree.nodes, "tipZ"),
+      dummyTree.observedMutations
+    );
+    expect(branch_tipZ).toEqual({
+      GENE: {
+        unique: ["B100A"],
+        homoplasies: ["F300G"],
+        gaps: [],
+        undeletions: ["-400A"],
+        reversionsToRoot: ["B100A"]
       }
     });
   });


### PR DESCRIPTION
Closes #1537, which has context on the rational for this PR.
Closes #1469

Undeletions (can we think of a better word than "undeletion"?!?) on branches are split out into a separate category and grouped into intervals, like so: 
![image](https://user-images.githubusercontent.com/8350992/190339542-e1d1d9c0-7795-4ac5-b013-4f69f2d10ce3.png)

This is not done for tips, as these don't report mutations but rather changes between the root and the tip. While undeletions can be present here, it's rarer and I don't think any of our core builds would have this. See the tests introduced in 9fa12980602327e5bf23a22ac981c244504e8345 for examples of this.

The third commit adds a info-popup detailing what the different categories are and how mutations are grouped into them.

![image](https://user-images.githubusercontent.com/8350992/190340339-0cde3280-8f8a-41d1-9151-7c347b229ab2.png)
![image](https://user-images.githubusercontent.com/8350992/190340365-bac2e254-7a7f-4364-833e-dc0a93e65b42.png)




