### PR TITLE
Warn (not error) for duplicated nodes

### DIFF
--- a/src/util/treeJsonProcessing.js
+++ b/src/util/treeJsonProcessing.js
@@ -24,12 +24,12 @@ const processNodes = (nodes) => {
     very hard-to-interpret Auspice errors which we can improve by dectecting problems early */
     if (!d.name) {
       d.name = pseudoRandomName();
-      console.error(`Tree node without a name detected. This dataset is not valid. Using the name '${d.name}' and continuing...`);
+      console.warn(`Tree node without a name detected. Using the name '${d.name}' and continuing...`);
     }
     if (nodeNamesSeen.has(d.name)) {
       const prev = d.name;
       d.name = `${d.name}_${pseudoRandomName()}`;
-      console.error(`Tree node detected with a duplicate name. This dataset is not valid. Changing '${prev}' to '${d.name}' and continuing...`);
+      console.warn(`Tree node detected with a duplicate name. Changing '${prev}' to '${d.name}' and continuing...`);
     }
     nodeNamesSeen.add(d.name);
   });


### PR DESCRIPTION
We can handle trees with duplicated / missing node names, and there are datasets which legitimately use this, so these are warnings not errors.

Closes #1541

P.S. I'll merge this now as it's a very minor change & #1541 has been an issue for ~20 days without comments. 