### PR TITLE
docs: Update Node.js references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We recommend using a conda environment, but this is not the only way.
 Create and activate a [conda](https://docs.conda.io) environment:
 
 ```bash
-conda create --name auspice nodejs=12
+conda create --name auspice nodejs=14
 conda activate auspice
 ```
 

--- a/docs/introduction/install.md
+++ b/docs/introduction/install.md
@@ -12,7 +12,7 @@
 
 ## Prerequisites
 Auspice is a JavaScript program, and requires [Node.js](https://nodejs.org/) to be installed on your system.
-We've had success running a range of different node versions between 10.8 and 13.
+Refer to `engines.node` in [package.json](https://github.com/nextstrain/auspice/blob/-/package.json) for currently supported versions.
 
 We highly recommend using [Conda](https://conda.io/docs/) to manage environments, i.e. use Conda to create an environment with Node.js installed where you can use Auspice.
 It's possible to use other methods, but this documentation presupposes that you have Conda installed.

--- a/docs/introduction/install.md
+++ b/docs/introduction/install.md
@@ -24,7 +24,7 @@ You can also use the Windows Subsystem Linux for a fuller Linux environment.
 
 ## Create a Conda Environment
 ```bash
-conda create --name auspice nodejs=12
+conda create --name auspice nodejs=14
 conda activate auspice
 ```
 

--- a/docs/narratives/create-pdf.md
+++ b/docs/narratives/create-pdf.md
@@ -22,7 +22,7 @@ If you've followed the [auspice install instructions](https://docs.nextstrain.or
 If not, you can create the necessary conda environment via:
 
 ```bash
-conda create --name auspice nodejs=12
+conda create --name auspice nodejs=14
 ```
 
 Install Decktape via:


### PR DESCRIPTION
### Description of proposed changes

The current docs are unclear about which versions of Node.js are supported, and recommend an outdated version for installation.

### Related issue(s)

_N/A_

### Testing

- [x] Preview of changes looks good