### PR TITLE
Bugfix when tree zooms back too far

### DIFF
--- a/src/components/tree/reactD3Interface/callbacks.js
+++ b/src/components/tree/reactD3Interface/callbacks.js
@@ -103,8 +103,9 @@ export const onBranchClick = function onBranchClick(d) {
   }
   /* Clicking on a branch means we want to zoom into the clade defined by that branch
   _except_ when it's the "in-view" root branch, in which case we want to zoom out */
+  const observedMutations = d.that.params.orientation[0] === 1 ? this.props.tree.observedMutations : this.props.treeToo.observedMutations;
   const arrayIdxToZoomTo = (getIdxOfInViewRootNode(d.n) === d.n.arrayIdx) ?
-    getParentBeyondPolytomy(d.n, this.props.distanceMeasure).arrayIdx :
+    getParentBeyondPolytomy(d.n, this.props.distanceMeasure, observedMutations).arrayIdx :
     d.n.arrayIdx;
   if (d.that.params.orientation[0] === 1) root[0] = arrayIdxToZoomTo;
   else root[1] = arrayIdxToZoomTo;

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -175,12 +175,12 @@ class Tree extends React.Component {
     // Zoom out of main tree if index of root node is not 0
     if (this.props.tree.idxOfInViewRootNode !== 0) {
       const rootNode = this.props.tree.nodes[this.props.tree.idxOfInViewRootNode];
-      newRoot = getParentBeyondPolytomy(rootNode, this.props.distanceMeasure).arrayIdx;
+      newRoot = getParentBeyondPolytomy(rootNode, this.props.distanceMeasure, this.props.tree.observedMutations).arrayIdx;
     }
     // Also zoom out of second tree if index of root node is not 0
     if (this.props.treeToo.idxOfInViewRootNode !== 0) {
       const rootNodeToo = this.props.treeToo.nodes[this.props.treeToo.idxOfInViewRootNode];
-      newRootToo = getParentBeyondPolytomy(rootNodeToo, this.props.distanceMeasure).arrayIdx;
+      newRootToo = getParentBeyondPolytomy(rootNodeToo, this.props.distanceMeasure, this.props.treeToo.observedMutations).arrayIdx;
     }
     const root = [newRoot, newRootToo];
     this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root}));


### PR DESCRIPTION
Current behavior (from https://github.com/nextstrain/auspice/issues/1529#issuecomment-1253071116):

We want to zoom back to the parent branch, unless that branch is part of some polytomy-like structure, in which case we want to keep walking up the tree until we're beyond the polytomy. Determining whether a branch length is so small it's in a polytomy is the root of the problem here. We use a heuristic which takes the length of the branch from the root node to the rightmost node in the current view (in the example here when zoomed into B.1.1 this is 563, but the actual numerical value can differ by many orders of magnitude depending on the dataset and what zoom you're using); if a branch is less than 1/50th of this then we keep walking up the tree. In the example here, the branch for B.1.1 has length 1 and 1<563/50 so we try the next branch, B.1, which is 12 and 12>563/50 so we stop there.

New behavior:

For trees viewed with the divergence metric and with mutations defined, it is sensible (and easy) for the zoom back button ("-" button) to walk up the tree until a branch with mutations is found. This will behave nicely with the common scenario of polytomies encoded by a bifurcating tree (which often happens during coalescent reconstruction in augur refine).

The original heuristic remains for those trees where mutations are not defined on the branches. There are cleverer ways to infer the correct threshold here if we want to, but I don't think it's worth it at the moment.

Closes #1529
