### PR TITLE
Measurements improvements

### DIFF
--- a/src/components/measurements/hoverPanel.js
+++ b/src/components/measurements/hoverPanel.js
@@ -4,7 +4,7 @@ import { InfoLine } from "../tree/infoPanels/hover";
 
 const HoverPanel = ({hoverData}) => {
   if (hoverData === null) return null;
-  const { mouseX, mouseY, containerId, data } = hoverData;
+  const { hoverTitle, mouseX, mouseY, containerId, data } = hoverData;
   const panelStyle = {
     position: "absolute",
     minWidth: 200,
@@ -54,6 +54,9 @@ const HoverPanel = ({hoverData}) => {
   return (
     <div style={panelStyle}>
       <div className={"tooltip"} style={infoPanelStyles.tooltip}>
+        <div style={infoPanelStyles.tooltipHeading}>
+          {hoverTitle}
+        </div>
         {[...data.entries()].map(([field, value]) => {
           return (
             <InfoLine key={field} name={`${field}:`} value={value} />

--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -261,8 +261,23 @@ const Measurements = ({height, width, showLegend}) => {
 
   const [title, setTitle] = useState("Measurements");
 
+  const getCardTitleStyle = () => {
+    /**
+     * Additional styles of Card title forces it to be in one line and display
+     * ellipsis if the title is too long to prevent the long title from pushing
+     * the Card into the next line when viewing in grid mode
+     */
+    return {
+      width,
+      display: "block",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+      textOverflow: "ellipsis"
+    };
+  };
+
   return (
-    <Card title={title}>
+    <Card title={title} titleStyles={getCardTitleStyle()}>
       {measurementsLoaded &&
         (measurementsError ?
           <Flex style={{ height, width}} direction="column" justifyContent="center">

--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -19,7 +19,8 @@ import {
   colorMeasurementsSVG,
   changeMeasurementsDisplay,
   svgContainerDOMId,
-  toggleDisplay
+  toggleDisplay,
+  addHoverPanelToMeasurementsAndMeans
 } from "./measurementsD3";
 
 /**
@@ -201,13 +202,14 @@ const MeasurementsPlot = ({height, width, showLegend, setPanelTitle}) => {
   // Draw SVG from scratch
   useEffect(() => {
     clearMeasurementsSVG(d3Ref.current);
-    drawMeasurementsSVG(d3Ref.current, svgData, handleHover);
-  }, [svgData, handleHover]);
+    drawMeasurementsSVG(d3Ref.current, svgData);
+  }, [svgData]);
 
   // Color the SVG & redraw color-by means when SVG is re-drawn or when colors have changed
   useEffect(() => {
     colorMeasurementsSVG(d3Ref.current, treeStrainColors);
-    drawMeansForColorBy(d3Ref.current, svgData, treeStrainColors, handleHover);
+    drawMeansForColorBy(d3Ref.current, svgData, treeStrainColors);
+    addHoverPanelToMeasurementsAndMeans(d3Ref.current, handleHover);
   }, [svgData, treeStrainColors, handleHover]);
 
   // Display raw/mean measurements when SVG is re-drawn, colors have changed, or display has changed

--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -20,7 +20,8 @@ import {
   changeMeasurementsDisplay,
   svgContainerDOMId,
   toggleDisplay,
-  addHoverPanelToMeasurementsAndMeans
+  addHoverPanelToMeasurementsAndMeans,
+  addColorByAttrToGroupingLabel
 } from "./measurementsD3";
 
 /**
@@ -212,6 +213,7 @@ const MeasurementsPlot = ({height, width, showLegend, setPanelTitle}) => {
 
   // Color the SVG & redraw color-by means when SVG is re-drawn or when colors have changed
   useEffect(() => {
+    addColorByAttrToGroupingLabel(d3Ref.current, treeStrainColors);
     colorMeasurementsSVG(d3Ref.current, treeStrainColors);
     drawMeansForColorBy(d3Ref.current, svgData, treeStrainColors);
     addHoverPanelToMeasurementsAndMeans(d3Ref.current, handleHover, treeStrainColors);

--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -65,25 +65,22 @@ const treeStrainPropertySelector = (state) => {
     // Only store properties of terminal strain nodes
     if (!node.hasChildren) {
       treeStrainVisibility[node.name] = tree.visibility[index];
-      // Only store colors for visible strains since only measurmeents
-      // for visible strains will be displayed
-      if (isVisible(tree.visibility[index])) {
-        /*
-        * If the color scale is continuous, we want to group by the legend value
-        * instead of the specific strain attribute in order to combine all values
-        * within the legend bounds into a single group.
-        */
-        let attribute = getTipColorAttribute(node, colorScale);
-        if (colorScale.continuous) {
-          const matchingLegendValue = colorScale.visibleLegendValues
-            .find((legendValue) => determineLegendMatch(legendValue, node, colorScale));
-          if (matchingLegendValue !== undefined) attribute = matchingLegendValue;
-        }
-        treeStrainColors[node.name] = {
-          attribute,
-          color: tree.nodeColors[index]
-        };
+      /*
+      * If the color scale is continuous, we want to group by the legend value
+      * instead of the specific strain attribute in order to combine all values
+      * within the legend bounds into a single group.
+      */
+      let attribute = getTipColorAttribute(node, colorScale);
+      if (colorScale.continuous) {
+        const matchingLegendValue = colorScale.visibleLegendValues
+          .find((legendValue) => determineLegendMatch(legendValue, node, colorScale));
+        if (matchingLegendValue !== undefined) attribute = matchingLegendValue;
       }
+      treeStrainColors[node.name] = {
+        attribute,
+        color: tree.nodeColors[index]
+      };
+
     }
     return treeStrainProperty;
   }, intitialTreeStrainProperty);

--- a/src/components/measurements/measurementsD3.js
+++ b/src/components/measurements/measurementsD3.js
@@ -24,12 +24,12 @@ export const layout = {
   thresholdStroke: "#DDD",
   subplotFill: "#adb1b3",
   subplotFillOpacity: "0.15",
-  diamondSize: 25,
-  standardDeviationStroke: 2,
+  diamondSize: 50,
+  standardDeviationStroke: 3,
   overallMeanColor: "#000",
   yAxisTickSize: 6,
-  yAxisColorByLineHeight: 7,
-  yAxisColorByLineStrokeWidth: 2
+  yAxisColorByLineHeight: 9,
+  yAxisColorByLineStrokeWidth: 4
 };
 // Display overall mean at the center of each subplot
 layout['overallMeanYValue'] = layout.subplotHeight / 2;

--- a/src/components/measurements/measurementsD3.js
+++ b/src/components/measurements/measurementsD3.js
@@ -27,7 +27,9 @@ export const layout = {
   diamondSize: 25,
   standardDeviationStroke: 2,
   overallMeanColor: "#000",
-  yAxisTickSize: 6
+  yAxisTickSize: 6,
+  yAxisColorByLineHeight: 7,
+  yAxisColorByLineStrokeWidth: 2
 };
 // Display overall mean at the center of each subplot
 layout['overallMeanYValue'] = layout.subplotHeight / 2;
@@ -35,6 +37,7 @@ layout['overallMeanYValue'] = layout.subplotHeight / 2;
 const classes = {
   xAxis: "measurementXAxis",
   yAxis: "measurementYAxis",
+  yAxisColorByLabel: "measurementYAxisColorByLabel",
   threshold: "measurementThreshold",
   subplot: "measurementSubplot",
   subplotBackground: "measurementSubplotBackground",
@@ -364,4 +367,37 @@ export const addHoverPanelToMeasurementsAndMeans = (ref, handleHover, treeStrain
       handleHover(d, dataType, clientX, clientY, colorByAttr);
     })
     .on("mouseout.hoverPanel", () => handleHover(null));
+};
+
+export const addColorByAttrToGroupingLabel = (ref, treeStrainColors) => {
+  const svg = select(ref);
+  // Remove all previous color-by labels for the y-axis
+  svg.selectAll(`.${classes.yAxisColorByLabel}`).remove();
+  // Loop through the y-axis labels to check if they have a corresponding color-by
+  svg.selectAll(`.${classes.yAxis}`).select(".tick")
+    .each((_, i, elements) => {
+      const groupingLabel = select(elements[i]);
+      const groupingValue = groupingLabel.text();
+      const groupingValueColorBy = treeStrainColors[groupingValue];
+      if (groupingValueColorBy) {
+        // Get the current label width to add colored line and text relative to the width
+        const labelWidth = groupingLabel.node().getBoundingClientRect().width;
+        groupingLabel.append("line")
+          .attr("class", classes.yAxisColorByLabel)
+          .attr("x1", -layout.yAxisTickSize)
+          .attr("x2", -labelWidth)
+          .attr("y1", layout.yAxisColorByLineHeight)
+          .attr("y2", layout.yAxisColorByLineHeight)
+          .attr("stroke-width", layout.yAxisColorByLineStrokeWidth)
+          .attr("stroke", groupingValueColorBy.color);
+
+        groupingLabel.append("text")
+          .attr("class", classes.yAxisColorByLabel)
+          .attr("x", labelWidth * -0.5)
+          .attr("dy", layout.yAxisColorByLineHeight * 2 + layout.yAxisColorByLineStrokeWidth)
+          .attr("text-anchor", "middle")
+          .attr("fill", "currentColor")
+          .text(`(${groupingValueColorBy.attribute})`);
+      }
+    });
 };

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -11,7 +11,7 @@ import { parseIntervalsOfNsOrGaps } from "./MutationTable";
 
 export const InfoLine = ({name, value, padBelow=false}) => {
   const renderValues = () => {
-    if (!value) return null;
+    if (!value && value !== 0) return null;
     if (Array.isArray(value)) {
       return value.map((v) => (
         <div key={v} style={{fontWeight: "300", marginLeft: "0em"}}>

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -4,9 +4,8 @@ import { rgb } from "d3-color";
 import LegendItem from "./item";
 import { headerFont, darkGrey } from "../../../globalStyles";
 import { fastTransitionDuration, months } from "../../../util/globals";
-import { getBrighterColor } from "../../../util/colorHelpers";
+import { getBrighterColor, getColorByTitle } from "../../../util/colorHelpers";
 import { numericToCalendar } from "../../../util/dateHelpers";
-import { isColorByGenotype, decodeColorByGenotype } from "../../../util/getGenotype";
 import { TOGGLE_LEGEND } from "../../../actions/types";
 
 const ITEM_RECT_SIZE = 15;
@@ -61,22 +60,12 @@ class Legend extends React.Component {
     const rowPos = rowIdx * (ITEM_RECT_SIZE + LEGEND_SPACING);
     return `translate(${colPos},${rowPos})`;
   }
-  getTitleString() {
-    if (isColorByGenotype(this.props.colorBy)) {
-      const genotype = decodeColorByGenotype(this.props.colorBy);
-      return genotype.aa
-        ? `Genotype at ${genotype.gene} site ${genotype.positions.join(", ")}`
-        : `Nucleotide at position ${genotype.positions.join(", ")}`;
-    }
-    return this.props.colorings[this.props.colorBy] === undefined ?
-      "" : this.props.colorings[this.props.colorBy].title;
-  }
 
   getTitleWidth() {
     // This is a hack because we can't use getBBox in React.
     // Lots of work to get measured width of DOM element.
     // Works fine, but will need adjusting if title font is changed.
-    return 15 + 5.3 * this.getTitleString().length;
+    return 15 + 5.3 * getColorByTitle(this.props.colorings, this.props.colorBy).length;
   }
 
   toggleLegend() {
@@ -101,7 +90,7 @@ class Legend extends React.Component {
             backgroundColor: "#fff"
           }}
         >
-          {this.getTitleString()}
+          {getColorByTitle(this.props.colorings, this.props.colorBy)}
         </text>
       </g>
     );

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -122,3 +122,20 @@ export const getEmphasizedColor = (color) => {
 };
 
 export const getBrighterColor = (color) => rgb(color).brighter([0.65]).toString();
+
+/**
+ * Return the display title for the selected colorBy
+ * @param {obj} colorings an object of available colorings
+ * @param {string} colorBy the select colorBy
+ * @returns {string} the display title for the colorBY
+ */
+export const getColorByTitle = (colorings, colorBy) => {
+  if (isColorByGenotype(colorBy)) {
+    const genotype = decodeColorByGenotype(colorBy);
+    return genotype.aa
+      ? `Genotype at ${genotype.gene} site ${genotype.positions.join(", ")}`
+      : `Nucleotide at position ${genotype.positions.join(", ")}`;
+  }
+  return colorings[colorBy] === undefined ?
+    "" : colorings[colorBy].title;
+};


### PR DESCRIPTION
### Description of proposed changes
Small improvements to the measurements panel that includes:
- truncate long panel titles to prevent panel from being pushed to new line in grid mode
- allow "0" values for display in hover panel
- add color-by attribute as title to hover panel
- scale y-axis label to fit 
- add color-by attribute to the y-axis labels if available (e.g. reference strains)

### Related issue(s)
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Partially addresses #1463 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
