### PR TITLE
Remove support for Node.js version 12, add 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 title: Changelog
 ---
 
+* Remove support for Node.js version 12. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
+* Add support for Node.js version 18 and NPM version 9. ([#1560](https://github.com/nextstrain/auspice/pull/1560))
+
 ## version 2.44.0 - 2023/03/02
 
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "^12 || ^14 || ^16",
+    "node": "^12 || ^14 || ^16 || ^18",
     "npm": "^7 || ^8"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "^12 || ^14 || ^16 || ^18",
+    "node": "^14 || ^16 || ^18",
     "npm": "^7 || ^8"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
     "node": "^14 || ^16 || ^18",
-    "npm": "^7 || ^8"
+    "npm": "^7 || ^8 || ^9"
   },
   "bin": {
     "auspice": "./auspice.js"


### PR DESCRIPTION
### Description of proposed changes

See commit messages.

### Related issue(s)

- Closes #1553

### Tasks

- [x] First merge https://github.com/nextstrain/auspice/pull/1520 since [webpack 4 does not support Node.js v18](https://github.com/webpack/webpack/issues/14532) without the [`--openssl-legacy-provider` option](https://nodejs.org/api/cli.html#--openssl-legacy-provider).
- [ ] Post-release: Update nodejs requirement on the [bioconda recipe](https://github.com/bioconda/bioconda-recipes/blob/-/recipes/auspice/meta.yaml)

### Testing

- [x] Ran with Node.js v18 locally and the example zika dataset seems to work fine
- [ ] Checks pass