### PR TITLE
Allow manual trigger of CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
       - master
       - release
   pull_request:
+  workflow_dispatch:
 name: ci
 jobs:
   build:


### PR DESCRIPTION
### Description of proposed changes

This enables manually running the CI workflow on branches without PRs.

### Related issue(s)

In line with https://github.com/nextstrain/cli/commit/fab709a2f45fc74afe2a15038e877e4dd58ae222 and https://github.com/nextstrain/augur/commit/b3601eb2a7e9514a48af226d878d3bcf6aca83b2.

### Testing

_N/A_