### PR TITLE
Restore nextstrain.org PRs

### DIFF
--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -1,45 +1,68 @@
 name: "Make PRs for Nextstrain projects which depend on Auspice"
 on:
-  pull_request:
+  workflow_dispatch:
 jobs:
   make-pr-on-nextstrain-dot-org: # <job_id>
+    # I don't see this being used for tags, so ensure it's only run on branches
+    # to make subsequent logic and wording easier.
+    if: github.ref_type == 'branch'
+
     runs-on: ubuntu-latest
+
+    env:
+      DESTINATION_REPO_DIR: nextstrain.org
+
     steps:
+      # Outputs:
+      # - pr-number: The PR number from the branch name (exits if no PR exists).
+      - name: Detect PR from branch
+        id: detect-pr
+        run: |
+          PR_NUMBER=$(gh pr view $GITHUB_REF_NAME --repo nextstrain/auspice --json 'number' --jq '.number') || true
+          if [[ -z $PR_NUMBER ]]; then
+            echo "ERROR: This branch is not associated with a PR in Auspice." >&2
+            exit 1
+          fi
+          echo "::set-output name=pr-number::$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+
       - name: Checkout nextstrain.org repo
         uses: actions/checkout@v2
         with:
           repository: nextstrain/nextstrain.org
+          path: ${{ env.DESTINATION_REPO_DIR }}
+
       - name: Install Auspice from PRs HEAD commit
-        if: ${{ github.event_name == 'pull_request' }}
-        # Note: $GITHUB_SHA is _not_ the same commit as the HEAD commit on the PR branch
-        # see https://github.community/t/github-sha-not-the-same-as-the-triggering-commit/18286/2
         shell: bash
+        working-directory: ${{ env.DESTINATION_REPO_DIR }}
         run: |
-          AUSPICE_COMMIT=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha)
-          echo "auspice_commit=$AUSPICE_COMMIT" >> $GITHUB_ENV
           npm ci
-          npm install nextstrain/auspice#${AUSPICE_COMMIT}
+          npm install nextstrain/auspice#${GITHUB_SHA}
           git add package.json package-lock.json
+
       - name: Create Pull Request for testing on nextstrain.org repo
-        if: ${{ github.event_name == 'pull_request' }}
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
+          path: ${{ env.DESTINATION_REPO_DIR }}
           token: ${{ secrets.NEXTSTRAIN_BOT_PAT }}
-          branch: "nextstrain-bot/test-auspice-pr/${{ github.event.pull_request.number }}"
-          commit-message: "[testing only] Upgrade Auspice to ${{ env.auspice_commit }}"
+          branch: "nextstrain-bot/test-auspice-pr/${{ steps.detect-pr.outputs.pr-number }}"
+          commit-message: "[testing only] Upgrade Auspice to ${{ github.sha }}"
           author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
           committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
-          title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ github.event.pull_request.number }}'
+          title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ steps.detect-pr.outputs.pr-number }}'
           body: |
-            This PR has been created to test nextstrain.org running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ github.event.pull_request.number }}.
+            This PR has been created to test nextstrain.org running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ steps.detect-pr.outputs.pr-number }}.
 
             This message and corresponding commits were automatically created by a GitHub Action from [nextstrain/auspice](https://github.com/nextstrain/auspice).
           draft: true
           delete-branch: true
+
       - name: Check outputs
         run: |
           echo "Nextstrain.org PR: ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.NEXTSTRAIN_BOT_PAT }}
-          branch: "auspice-pr-${{ github.event.pull_request.number }}"
+          branch: "nextstrain-bot/test-auspice-pr/${{ github.event.pull_request.number }}"
           commit-message: "[testing only] upgrade auspice to ${{ env.auspice_commit }}"
           author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
           committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -1,9 +1,6 @@
 name: "Make PRs for Nextstrain projects which depend on Auspice"
 on:
-  # pull_request:
-  push:
-    branches: 
-      - "not-a-valid-branch"
+  pull_request:
 jobs:
   make-pr-on-nextstrain-dot-org: # <job_id>
     runs-on: ubuntu-latest

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -15,6 +15,14 @@ jobs:
     steps:
       # Outputs:
       # - pr-number: The PR number from the branch name (exits if no PR exists).
+      # - auspice-sha: The GitHub-managed merge ref. Used for npm install.
+      #
+      # Note that $GITHUB_SHA shouldn't be used here because it refers to the
+      # branch HEAD which is not merged with the PR target branch. If the
+      # workflow trigger event was `pull_request` then it would refer to the
+      # merge ref¹, but we use `workflow_dispatch` to reduce the number of PRs.
+      #
+      # ¹ https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - name: Detect PR from branch
         id: detect-pr
         run: |
@@ -23,7 +31,9 @@ jobs:
             echo "ERROR: This branch is not associated with a PR in Auspice." >&2
             exit 1
           fi
+          MERGE_SHA=$(gh pr view $GITHUB_REF_NAME --repo nextstrain/auspice --json 'potentialMergeCommit' --jq '.potentialMergeCommit.oid')
           echo "::set-output name=pr-number::$PR_NUMBER"
+          echo "::set-output name=auspice-sha::$MERGE_SHA"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,7 +52,7 @@ jobs:
         working-directory: ${{ env.DESTINATION_REPO_DIR }}
         run: |
           npm ci
-          npm install nextstrain/auspice#${GITHUB_SHA}
+          npm install nextstrain/auspice#${{ steps.detect-pr.outputs.auspice-sha }}
           git add package.json package-lock.json
 
       - name: Create Pull Request for testing on nextstrain.org repo
@@ -58,6 +68,9 @@ jobs:
           title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ steps.detect-pr.outputs.pr-number }}'
           body: |
             This PR has been created to test nextstrain.org running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ steps.detect-pr.outputs.pr-number }}.
+
+            Note that Auspice has been installed with changes from both the PR's source and target branches.
+            This will surface any issues that can arise from merging the PR in Auspice. To address these issues locally, update the source branch (e.g. with a git rebase).
 
             This message and corresponding commits were automatically created by a GitHub Action from [nextstrain/auspice](https://github.com/nextstrain/auspice).
           draft: true

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -30,14 +30,14 @@ jobs:
         with:
           token: ${{ secrets.NEXTSTRAIN_BOT_PAT }}
           branch: "nextstrain-bot/test-auspice-pr/${{ github.event.pull_request.number }}"
-          commit-message: "[testing only] upgrade auspice to ${{ env.auspice_commit }}"
+          commit-message: "[testing only] Upgrade Auspice to ${{ env.auspice_commit }}"
           author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
           committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
-          title: '[bot] [DO NOT MERGE] Test auspice PR ${{ github.event.pull_request.number }}'
+          title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ github.event.pull_request.number }}'
           body: |
-            This PR has been created to test Auspice from [PR ${{ github.event.pull_request.number }}](https://github.com/nextstrain/auspice/pull/${{ github.event.pull_request.number }})
+            This PR has been created to test nextstrain.org running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ github.event.pull_request.number }}.
 
-            This message and corresponding commits were automatically created by a GitHub Action from [nextstrain/auspice](https://github.com/nextstrain/auspice)
+            This message and corresponding commits were automatically created by a GitHub Action from [nextstrain/auspice](https://github.com/nextstrain/auspice).
           draft: true
           delete-branch: true
       - name: Check outputs


### PR DESCRIPTION
### Description of proposed changes

Follow-up to db858051b69db63ce725a673f8dd8e7edd3b922a.

Heroku is building review apps for nextstrain.org now.

### Related issue(s)

- Closes #1564 

### Testing

- [x] Manual trigger using `gh workflow run "Make PRs for Nextstrain projects which depend on Auspice" --repo nextstrain/auspice --ref victorlin/restore-nextstrain.org-prs` succeeds ([link](https://github.com/nextstrain/auspice/actions/runs/3199546724/jobs/5225418043))
- [x] The [resulting PR](https://github.com/nextstrain/nextstrain.org/pull/603) looks good, and a new PR doesn't get created upon updates
- [ ] ~Figure out why runs are taking so long (>15m)~ [not worth it](https://github.com/nextstrain/auspice/pull/1565#issuecomment-1270768343)