### PR TITLE
Enable preview PRs for auspice.us

### DIFF
--- a/.github/workflows/make_pr_for_downstream_repo.yaml
+++ b/.github/workflows/make_pr_for_downstream_repo.yaml
@@ -1,8 +1,12 @@
-name: "Make PRs for Nextstrain projects which depend on Auspice"
+name: "Make PR for a repository which depends on Auspice"
 on:
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
 jobs:
-  make-pr-on-nextstrain-dot-org:
+  make-pr-on-downstream-repo:
     # I don't see this being used for tags, so ensure it's only run on branches
     # to make subsequent logic and wording easier.
     if: github.ref_type == 'branch'
@@ -10,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DESTINATION_REPO_DIR: nextstrain.org
+      DESTINATION_REPO_DIR: repo
 
     steps:
       # Outputs:
@@ -41,10 +45,10 @@ jobs:
         with:
           node-version: '14'
 
-      - name: Checkout nextstrain.org repo
+      - name: Checkout downstream repo
         uses: actions/checkout@v2
         with:
-          repository: nextstrain/nextstrain.org
+          repository: ${{ inputs.repository }}
           path: ${{ env.DESTINATION_REPO_DIR }}
 
       - name: Install Auspice from PRs HEAD commit
@@ -55,7 +59,7 @@ jobs:
           npm install nextstrain/auspice#${{ steps.detect-pr.outputs.auspice-sha }}
           git add package.json package-lock.json
 
-      - name: Create Pull Request for testing on nextstrain.org repo
+      - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
@@ -67,7 +71,7 @@ jobs:
           committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
           title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ steps.detect-pr.outputs.pr-number }}'
           body: |
-            This PR has been created to test nextstrain.org running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ steps.detect-pr.outputs.pr-number }}.
+            This PR has been created to test this project running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ steps.detect-pr.outputs.pr-number }}.
 
             Note that Auspice has been installed with changes from both the PR's source and target branches.
             This will surface any issues that can arise from merging the PR in Auspice. To address these issues locally, update the source branch (e.g. with a git rebase).
@@ -78,5 +82,5 @@ jobs:
 
       - name: Check outputs
         run: |
-          echo "Nextstrain.org PR: ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR number: ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "PR URL: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -1,13 +1,24 @@
 name: "Make PRs for Nextstrain projects which depend on Auspice"
 on:
   workflow_dispatch:
+    inputs:
+      nextstrain-org:
+        description: 'Make PR on nextstrain.org'
+        required: true
+        type: boolean
+      auspice-us:
+        description: 'Make PR on auspice.us'
+        required: true
+        type: boolean
 jobs:
-  make-pr-on-nextstrain-dot-org:
+  nextstrain-org:
+    if: inputs.nextstrain-org
     uses: ./.github/workflows/make_pr_for_downstream_repo.yaml
     secrets: inherit
     with:
       repository: nextstrain/nextstrain.org
-  make-pr-on-auspice-us:
+  auspice-us:
+    if: inputs.auspice-us
     uses: ./.github/workflows/make_pr_for_downstream_repo.yaml
     secrets: inherit
     with:

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -7,3 +7,8 @@ jobs:
     secrets: inherit
     with:
       repository: nextstrain/nextstrain.org
+  make-pr-on-auspice-us:
+    uses: ./.github/workflows/make_pr_for_downstream_repo.yaml
+    secrets: inherit
+    with:
+      repository: nextstrain/auspice.us

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -2,7 +2,7 @@ name: "Make PRs for Nextstrain projects which depend on Auspice"
 on:
   workflow_dispatch:
 jobs:
-  make-pr-on-nextstrain-dot-org: # <job_id>
+  make-pr-on-nextstrain-dot-org:
     # I don't see this being used for tags, so ensure it's only run on branches
     # to make subsequent logic and wording easier.
     if: github.ref_type == 'branch'

--- a/.github/workflows/make_prs_for_other_repos.yaml
+++ b/.github/workflows/make_prs_for_other_repos.yaml
@@ -1,0 +1,9 @@
+name: "Make PRs for Nextstrain projects which depend on Auspice"
+on:
+  workflow_dispatch:
+jobs:
+  make-pr-on-nextstrain-dot-org:
+    uses: ./.github/workflows/make_pr_for_downstream_repo.yaml
+    secrets: inherit
+    with:
+      repository: nextstrain/nextstrain.org


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Currently, preview PRs are only created on the nextstrain.org repo. Also create them for auspice.us and add inputs to select which PRs to make. This looks like:

![workflow-dispatch-ui](https://user-images.githubusercontent.com/13424970/194963100-0903c802-3f66-465f-a4fd-0d31e02072bf.png)


### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

_N/A_

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Manually triggered run is successful
- [x] Generated PRs look good

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
