### PR TITLE
Branch labels don't capture click events

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -154,6 +154,7 @@ export const drawBranchLabels = function drawBranchLabels(key) {
     .style("font-family", this.params.branchLabelFont)
     .style("font-weight", fontWeight)
     .style("font-size", labelSize)
+    .style("pointer-events", "none")
     .text((d) => d.n.branch_attrs.labels[key]);
 };
 


### PR DESCRIPTION
There is currently no on-hover behavior for branch labels and they have a tendency to obscure branches behind them and make them un-clickable.

Closes #1580
