### PR TITLE
Fix download empty tree

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -41,6 +41,9 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         Downloaded data represents the currently displayed view.
         By zooming the tree, changing the branch-length metric, applying filters etc, the downloaded data will change accordingly.
         <p/>
+        NOTE: We do not support downloads of multiple subtrees, which are usually created with the date range filter or genotype filters.
+        Downloading multiple subtrees will result in an empty Newick tree!
+        <p/>
         {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
       <Button

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -36,7 +36,12 @@ const treeToNewick = (tree, temporal, internalNodeNames=false, nodeAnnotation=()
     return leaf;
   }
 
-  const rootNode = tree.nodes[tree.idxOfInViewRootNode];
+  /**
+   * Try the filtered root first as this may be different from the in view root node
+   * We still need to fallback on the idxOfInViewRootNode because the idxOfFilteredRoot
+   * is undefined when there are no filters applied.
+   */
+  const rootNode = tree.nodes[tree.idxOfFilteredRoot || tree.idxOfInViewRootNode];
   const rootXVal = getXVal(rootNode);
   return recurse(rootNode, rootXVal) + ";";
 };

--- a/src/util/exceptions.js
+++ b/src/util/exceptions.js
@@ -3,3 +3,15 @@ export class NoContentError extends Error {
     super(...params);
   }
 }
+
+/**
+ * Thrown when a download produces an empty Newick tree.
+ * Usually caused by users trying to download multiple subtrees that do not
+ * share a common ancestor that is "visible"
+ */
+export class EmptyNewickTreeCreated extends Error {
+  constructor(...params) {
+    super(...params);
+    this.name = this.constructor.name;
+  }
+}


### PR DESCRIPTION
### Description of proposed changes

Fixes the empty tree downloads when the tree is filtered. 
This does _not_ support the case of downloading multiple subtrees. I'm going to punt that for now and just added a note to the users that we do not support this feature. We can open another issue if this feature is ever requested.

I've made the `treeToNewick` function raise an error if it ever creates an empty tree since this seems like generally undesired behavior. I can drop this change if people think otherwise. 

### Related issue(s)
Resolves #1267

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
