### PR TITLE
measurements: fix disappearing mean/SD on entropy click

### DIFF
--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -127,7 +127,7 @@ const filterMeasurements = (measurements, treeStrainVisibility, filters) => {
 const MeasurementsPlot = ({height, width, showLegend, setPanelTitle}) => {
   // Use `lodash.isEqual` to deep compare object states to prevent unnecessary re-renderings of the component
   const { treeStrainVisibility, treeStrainColors } = useSelector((state) => treeStrainPropertySelector(state), isEqual);
-  const legendValues = useSelector((state) => state.controls.colorScale.legendValues);
+  const legendValues = useSelector((state) => state.controls.colorScale.legendValues, isEqual);
   const colorings = useSelector((state) => state.metadata.colorings);
   const colorBy = useSelector((state) => state.controls.colorBy);
   const groupBy = useSelector((state) => state.controls.measurementsGroupBy);
@@ -220,7 +220,7 @@ const MeasurementsPlot = ({height, width, showLegend, setPanelTitle}) => {
   // Display raw/mean measurements when SVG is re-drawn, colors have changed, or display has changed
   useEffect(() => {
     changeMeasurementsDisplay(d3Ref.current, display);
-  }, [svgData, treeStrainColors, display]);
+  }, [svgData, treeStrainColors, legendValues, handleHover, display]);
 
   useEffect(() => {
     toggleDisplay(d3Ref.current, "overallMean", showOverallMean);


### PR DESCRIPTION
### Description of proposed changes

Previously, when clicking on an entropy rect, the colored mean/SD in the measurements panel would flash and disappear. I tracked this down to the following:
1. Clicking on an entropy rect would trigger two NEW_COLOR dispatches.
2. The second NEW_COLOR action does _not_ update the colors, but the react-redux `useSelector` hook does a strict reference comparison by default, so it thinks the `legendValues` (an array) was updated.
3. This would trigger the side-effect `drawMeansForColorBy` but _not_ the `changeMeasurementsDisplay` so the colored mean/SD would get hidden.

This commit updates the `legendValues` to use `lodash.isEqual` equality function to ensure that we don't run any unnecessary updates. It also updates the dependencies for the `changeMeasurementsDisplay` side-effect to make sure they match the dependencies for the `drawMeansForColorBy` side-effect.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
