### PR TITLE
narratives: Convert Markdown → HTML before splitting into separate slides

### DIFF
--- a/cli/server/getNarrative.js
+++ b/cli/server/getNarrative.js
@@ -3,17 +3,6 @@ const path = require("path");
 const fs = require("fs");
 const utils = require("../utils");
 const marked = require('marked');
-const { parseMarkdownNarrativeFile } = require("../../src/util/parseNarrative");
-
-/**
- * A thin wrapper around the client-side `parseMarkdownNarrativeFile` function.
- * The main difference is that we pass in a different markdown parser
- * than the client uses.
- */
-const parseNarrative = (fileContents) => {
-  utils.verbose("Deprecation warning: Server-side parsing of narrative files is no longer needed!");
-  return parseMarkdownNarrativeFile(fileContents, marked);
-};
 
 const setUpGetNarrativeHandler = ({narrativesPath}) => {
   return async (req, res) => {
@@ -25,9 +14,7 @@ const setUpGetNarrativeHandler = ({narrativesPath}) => {
       .replace(/\//g, "_")            // change slashes to underscores
       .concat(".md");                 // add .md suffix
 
-    // the type-query string dictates whether to parse into JSON on the server or not
-    // we default to JSON which was behavior before this argument existed
-    const type = query.type ? query.type.toLowerCase() : "json";
+    const type = query.type ? query.type.toLowerCase() : null;
 
     const pathName = path.join(narrativesPath, filename);
     utils.log("trying to access & parse local narrative file: " + pathName);
@@ -37,9 +24,6 @@ const setUpGetNarrativeHandler = ({narrativesPath}) => {
         // we could stream the response (as we sometimes do for getDataset) but narrative files are small
         // so the expected time savings / server overhead is small.
         res.send(fileContents);
-      } else if (type === "json") {
-        const blocks = parseNarrative(fileContents);
-        res.send(JSON.stringify(blocks).replace(/</g, '\\u003c'));
       } else {
         throw new Error(`Unknown format requested: ${type}`);
       }
@@ -54,5 +38,4 @@ const setUpGetNarrativeHandler = ({narrativesPath}) => {
 
 module.exports = {
   setUpGetNarrativeHandler,
-  parseNarrative
 };

--- a/docs/server/api.md
+++ b/docs/server/api.md
@@ -73,7 +73,7 @@ Any other non-200 reponse behaves similarly but also displays a large "error" me
 * `type` (optional) - the format of the data returned (see below for more information).
 Current valid values are "json" and "md".
 If no type is specified the server will use "json" as a default (for backwards compatibility reasons).
-Requests to this API from the Auspice client are made with `type=md.
+Requests to this API from the Auspice client are made with `type=md`.
 
 **Response (on success):**
 
@@ -94,7 +94,7 @@ if (type === "json") {
 }
 ```
 
-> While the Auspice client (from v2.18 onwards) always requests the `type=md`, it will attempt to parse the response as JSON if markdown parsing fails, in an effort to remain backwards compatable with servers which may be using an earlier API.
+> While the Auspice client (from v2.18 onwards) always requests the `type=md`, it will attempt to parse the response as JSON if markdown parsing fails, in an effort to remain backwards compatible with servers which may be using an earlier API.
 
 ---
 

--- a/src/util/parseNarrative.js
+++ b/src/util/parseNarrative.js
@@ -1,14 +1,3 @@
-/**
- * This file, although residing in `src` is also used by the server.
- * This is to maintain a common source of code for narrative markdown
- * parsing both server-side and client-side, thus preserving backwards
- * capability with auspice from when it was only done on the server.
- * Because we do not transpile the server code (a conscious decision)
- * this means we should not use any import statements here, and
- * export functions via the `module.exports` syntax (applies
- * to "imported" code also).
- */
-
 /* eslint no-param-reassign: off */
 
 const { safeLoadFront } = require('yaml-front-matter');


### PR DESCRIPTION
Fixes handling of intra-document references like links and images that reference a definition found elsewhere in the file, e.g. before the first slide or on a different slide than the link/image reference.  Such features are soon to be used for embedding images (see related PR below).

Anyone previewing a document with such features outside of Auspice's narrative rendering would see the link/image references work, but they'd be broken when viewed thru Auspice.  Since narrative documents are intended to gracefully degrade with conventional Markdown rendering and still be a viewable document (e.g. on GitHub), it's nice to address this issue for that reason alone.

It's also nice to use the DOM as a structured way to split apart the document into slides, rather than relying on string manipulation and parsing.  An alternative approach would be to use a Markdown parser that emits an AST or stream of nodes as an intermediate we could split into slides while still preserving references/definitions, but that seemed like a bigger change (and I'd have to go survey the parsers available instead of using the browser's built-in DOM).

While the entire internals of parseNarrativeBody() change, the shape of the output "slide objects" is the same.  The one minor exception is that slides will always have a "mainDisplayMarkdown" property (though it will usually be the empty string) even if they don't have a corresponding code block in the source text.  All downstream usages I found condition not on property existence but on truthiness of the value, so this should result in no functional change.

Resolves: <https://github.com/nextstrain/auspice/issues/1599>
Related-to: <https://github.com/nextstrain/cli/pull/235>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manually tested with [this silly narrative](https://gist.githubusercontent.com/tsibley/0f128232ae9a27da3b0f6cadeda93eb6/raw/ba621eab7cd8383106bced054435731e599c11fb/test_trs.md)
- [x] Checks pass
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
