### PR TITLE
webpack: Remove unused variable `directoriesToTransform`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,9 +13,6 @@ const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyzeBundle=false}) => {
   utils.verbose(`Generating webpack config. Extensions? ${!!extensionPath}. devMode: ${devMode}`);
 
-  /* which directories should be parsed by babel and other loaders? */
-  const directoriesToTransform = [path.join(__dirname, 'src')];
-
   // Pins all react stuff, and uses hot loader's dom (can be used safely in production)
   // Format is either "libName" or "libName:libPath"
   const coreDeps = [
@@ -58,8 +55,6 @@ const generateConfig = ({extensionPath, devMode=false, customOutputPath, analyze
     // console.log("BUILDING WITH EXTENSIONS");
     const dir = path.resolve(__dirname, path.dirname(extensionPath));
     aliasesToResolve["@extensions"] = dir;
-    directoriesToTransform.push(dir);
-    // console.log("directoriesToTransform", directoriesToTransform);
     extensionData = JSON.parse(fs.readFileSync(extensionPath, {encoding: 'utf8'}));
     // console.log("extensionData", extensionData);
   }


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This was introduced in c73f590d8ebdba1f00bf473c65bb510f6a14eb15 but usage was removed in a6a46c0eba40983b792792829fb526e14fe1a92b and c93e97b6c1c6211a3d6aaa1c9fd3818fa43b8c2b.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
