### PR TITLE
Remove prepare script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm run get-data
+      - run: npm run build
       - run: npm run smoke-test:ci
   lint:
     runs-on: ubuntu-latest
@@ -69,6 +70,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
+      - run: npm run build
       - run: npx bundlesize
   publish:
     if: ${{ github.ref == 'refs/heads/release' }}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you wish to view the [nextstrain-maintained narratives](https://nextstrain.or
 ### Run auspice
 
 ```bash
+auspice build --verbose
 auspice view --datasetDir data
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "start": "npm run view",
     "server": "npm run view",
     "build": "node auspice.js build --verbose",
-    "prepare": "npm run build",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "get-data": "env bash ./scripts/get-data.sh",


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

The prepare script is automatically run with every call to `npm ci` / `npm install`, among other scripts¹. As it is just an alias to the build script (which can take several minutes), it should be safe to remove this automation and speed up the dev experience.

Updated README accordingly.

¹ https://docs.npmjs.com/cli/v8/using-npm/scripts?v=true#life-cycle-operation-order

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

_N/A_

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
