### PR TITLE
view: Error on missing build files

### DIFF
--- a/cli/view.js
+++ b/cli/view.js
@@ -79,11 +79,14 @@ const getAuspiceBuild = () => {
   const cwd = path.resolve(process.cwd());
   const sourceDir = path.resolve(__dirname, "..");
   if (
-    cwd !== sourceDir &&
-    fs.existsSync(path.join(cwd, "index.html")) &&
-    fs.existsSync(path.join(cwd, "dist")) &&
-    fs.readdirSync(path.join(cwd, "dist")).filter((fn) => fn.match(/^auspice.bundle.[a-z0-9]+.js$/)).length === 1
+    !fs.existsSync(path.join(cwd, "dist")) ||
+    !fs.existsSync(path.join(cwd, "dist/index.html")) ||
+    !fs.readdirSync(path.join(cwd, "dist")).filter((fn) => fn.match(/^auspice.bundle.[a-z0-9]+.js$/)).length === 1
   ) {
+    console.log(chalk.redBright(`ERROR: Auspice build files not found under ${cwd}. Did you run \`auspice build\` in this directory?`));
+    process.exit(1);
+  }
+  if (cwd !== sourceDir) {
     return {
       message: "Serving the auspice build which exists in this directory.",
       baseDir: cwd,


### PR DESCRIPTION
### Description of proposed changes

When running from Auspice's root directory, this replaces an unhandled scandir error with a more meaningful message.

When running from an external project, this prevents falling back to running from build files in Auspice's root directory, which is often unintentional.

<!-- What is the goal of this pull request? What does this pull request change? -->

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Prevents issues such as https://github.com/nextstrain/auspice/pull/1520#discussion_r1036594154 from arising.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].
    - https://github.com/nextstrain/auspice.us/pull/46
    - Not necessary for nextstrain.org since it doesn't use `auspice view`
- [x] Homepage of auspice.us deployment on preview PR looks correct
- [x] `rm -rf dist/ && npm run start` from Auspice root shows the new error message (checked locally)
- [x] `rm -rf dist/ && npm run start` from auspice.us project root shows the new error message (checked locally)
- [x] `npm run build && npm run start` from Auspice root works fine (checked locally)
- [x] `npm run build && npm run start` from auspice.us project root works fine (checked locally)

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
