### PR TITLE
Add 'none' option to hide tip labels

### DIFF
--- a/src/components/controls/choose-tip-label.js
+++ b/src/components/controls/choose-tip-label.js
@@ -49,9 +49,15 @@ export default WithTranslation;
  */
 export function collectAvailableTipLabelOptions(colorings) {
   return [
+    /**
+     * We should consider using a Symbol for the 'none' value so that it
+     * can't clash with potential coloring values, but then it's not as
+     * straightforward to specify this option via the URL query
+     */
+    {value: 'none', label: "none"},
     {value: strainSymbol, label: "Sample Name"},
     ...Object.entries(colorings)
-      .filter((keyValue) => keyValue[0] !== 'gt')
+      .filter((keyValue) => keyValue[0] !== 'gt' && keyValue[0] !== 'none')
       .map(([key, value]) => {
         return {value: key, label: value.title};
       })

--- a/src/components/tree/phyloTree/change.js
+++ b/src/components/tree/phyloTree/change.js
@@ -392,7 +392,7 @@ export const change = function change({
 
   const extras = { removeConfidences, showConfidences, newBranchLabellingKey };
   extras.timeSliceHasPotentiallyChanged = changeVisibility || newDistance;
-  extras.hideTipLabels = animationInProgress;
+  extras.hideTipLabels = animationInProgress || newTipLabelKey === 'none';
   if (useModifySVGInStages) {
     this.modifySVGInStages(elemsToUpdate, svgPropsToUpdate, transitionTime, 1000, extras);
   } else {


### PR DESCRIPTION
### Description of proposed changes

Adds a new 'none' option to turn off the tip labels. We should consider using a Symbol for the 'none' value so that it can't clash with potential coloring values, but then it's not as straightforward to specify this option via the URL query.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
