### PR TITLE
dev: GitHub release creation

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -212,4 +212,4 @@ If a translation of a particular string is not yet available, then auspice will 
             ```
 
     3. Click through to create a Pull Request to the Bioconda GitHub repository.
-3. When the new version of Auspice is available on bioconda, manually run the [conda-base CI workflow](https://github.com/nextstrain/conda-base/actions/workflows/ci.yaml) on the `master` branch.
+3. When the new version of Auspice is available on Bioconda, manually run the [conda-base CI workflow](https://github.com/nextstrain/conda-base/actions/workflows/ci.yaml) on the `main` branch.

--- a/releaseNewVersion.sh
+++ b/releaseNewVersion.sh
@@ -113,4 +113,4 @@ echo -e "\nThe 'CI' GitHub Action will automatically publish this version to npm
 echo -e "\nNow attempting to make a GitHub release (https://github.com/nextstrain/auspice/releases). If this step fails please do this manually."
 
 # Step 10: create a release based off the tag with content from the changlog
-node scripts/extract-release-notes.js | gh release create v${newVersion} -t "Auspice ${newVersion}" --notes-file -
+node scripts/extract-release-notes.js | gh release create v${newVersion} --repo nextstrain/auspice -t "Auspice ${newVersion}" --notes-file -


### PR DESCRIPTION
See commit messages.

### Testing

When `./releaseNewVersion.sh` failed for me this morning, adding `--repo nextstrain/auspice` to the invocation and re-running that bit worked for me.

(CI checks are probably irrelevant for this PR.)