### PR TITLE
docs/view-settings: Update URL param `gmin` to `gmax`

### DIFF
--- a/docs/advanced-functionality/view-settings.md
+++ b/docs/advanced-functionality/view-settings.md
@@ -72,7 +72,7 @@ All URL queries modify the view away from the default settings -- if you change 
 | `d`        | List of panels to display, `,` separated | `d=tree,map` |
 | `p`        | Panel layout (buggy!) | `p=full`, `p=grid` |
 | `gmin`     | Entropy panel zoom (minimum) bound | `gmin=1000` |
-| `gmin`     | Entropy panel zoom (maximum) bound | `gmax=2000` |
+| `gmax`     | Entropy panel zoom (maximum) bound | `gmax=2000` |
 | `animate`  | Animation settings | |
 | `n`        | Narrative page number | `n=1` goes to the first page |
 | `s`        | Selected strain | `s=1_0199_PF` |


### PR DESCRIPTION
Noticed typo when I was working on https://github.com/nextstrain/docs.nextstrain.org/pull/153

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- ~[ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
