### PR TITLE
Retrospectively add changelog for version 2.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## version 2.45.1 - 2023/03/14
 
+* Small improvements to Auspice documentation. ([#1588](https://github.com/nextstrain/auspice/pull/1588))
 
 ## version 2.45.0 - 2023/03/08
 


### PR DESCRIPTION
This should have been added with the release of v2.45.1. Adding it now.

Also updated the description of the [GitHub Release](https://github.com/nextstrain/auspice/releases/tag/v2.45.1).