### PR TITLE
Move dev installation to DEV_DOCS

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -19,9 +19,24 @@ This project strictly adheres to the [Contributor Covenant Code of Conduct](http
 
 Please see the [project boards](https://github.com/orgs/nextstrain/projects) for currently available issues.
 
-## Contributing code
+## Developer Installation
 
-Code contributions are welcomed! [Please see the main auspice docs](https://docs.nextstrain.org/projects/auspice/en/latest/introduction/install.html) for details on how to install and run auspice from source.
+This is useful for debugging, modifying the source code, or using an unpublished feature branch.
+
+You can install using your system `npm` or [within a Conda environment](https://docs.nextstrain.org/projects/auspice/en/stable/introduction/install.html#install-dependencies) to keep things isolated.
+
+```sh
+# grab the GitHub auspice repo
+git clone https://github.com/nextstrain/auspice.git
+cd auspice
+
+# install dependencies and make `auspice` available globally
+npm install --global .
+```
+
+Updating Auspice should only require pulling the new version from GitHub - it shouldn't require any `npm` commands. You will, however, have to re-build Auspice whenever the client-related code has changed, via `auspice build`.
+
+## Contributing code
 
 Please comment on an open issue if you are working on it.
 For changes unrelated to an open issue, please make an issue outlining what you would like to change/add.

--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -30,7 +30,10 @@ You can install using your system `npm` or [within a Conda environment](https://
 git clone https://github.com/nextstrain/auspice.git
 cd auspice
 
-# install dependencies and make `auspice` available globally
+# install dependencies and build auspice
+npm ci
+
+# make `auspice` available globally
 npm install --global .
 ```
 

--- a/docs/introduction/install.rst
+++ b/docs/introduction/install.rst
@@ -36,18 +36,7 @@ If you look at the :doc:`release notes <../releases/changelog>` you can see the 
 Install Auspice as a developer
 ==============================
 
-This is useful for debugging, modifying the source code, or using an unpublished feature branch.
-
-.. code:: bash
-
-   # grab the GitHub auspice repo
-   git clone https://github.com/nextstrain/auspice.git
-   cd auspice
-
-   # install dependencies and make `auspice` available globally
-   npm install --global .
-
-Updating Auspice should only require pulling the new version from GitHub - it shouldn't require any ``npm`` commands. You will, however, have to re-build Auspice whenever the client-related code has changed, via ``auspice build``.
+See `DEV_DOCS.md <https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#developer-installation>__`.
 
 Testing if it worked
 ====================


### PR DESCRIPTION
### Description of proposed changes

This keeps the Sphinx docs user-focused and makes DEV_DOCS.md more complete.

### Related issue(s)

Resolves #1656

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass, though this change shouldn't affect that.
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ N/A, no functional change

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
