### PR TITLE
make_pr_for_downstream_repo: Use Node.js 16

### DIFF
--- a/.github/workflows/make_pr_for_downstream_repo.yaml
+++ b/.github/workflows/make_pr_for_downstream_repo.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Checkout downstream repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Reasons to bump:

1. Both downstream repos use Node.js 16 now.
2. NPM 6 (bundled with Node.js 14) is slow to install Auspice from a GitHub commit reference. Later versions of NPM should fix this¹.

¹ https://github.com/npm/cli/issues/4896

### Related issues

Addresses concern raised in https://github.com/nextstrain/auspice/pull/1661#issuecomment-1500667474.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1] ([run](https://github.com/nextstrain/auspice/actions/runs/4641673754))
- [x] Check results of the run linked above.
    - The step to install Auspice from a GitHub commit reference now runs in ~10m opposed to ~15m. Still not the best, but better than before.

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
