### PR TITLE
Extend usefulness of tip labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+* Any `node_attr` in the tree can be used as a tip label, as well as the special-cases of strain-name and "none".
+  Previously we only allowed valid colorings.
+  ([#1668](https://github.com/nextstrain/auspice/pull/1668))
+
+
 ## version 2.56.1 - 2024/08/22
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Any `node_attr` in the tree can be used as a tip label, as well as the special-cases of strain-name and "none".
   Previously we only allowed valid colorings.
   ([#1668](https://github.com/nextstrain/auspice/pull/1668))
-
+* The specified tip label is surfaced more prominently within the the on-hover info boxes & on-click modals.
+  ([#1668](https://github.com/nextstrain/auspice/pull/1668))
 
 ## version 2.56.1 - 2024/08/22
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -555,9 +555,9 @@ const checkAndCorrectErrorsInState = (state, metadata, genomeMap, query, tree, v
 
   /* check tip label is valid. We use the function which generates the options for the dropdown here.
    * state.defaults.tipLabelKey is set by the JSON's display_defaults (default: strainSymbol)
-   * state.tipLabelKey is first set the JSON and then overridden via the URL query (default: state.defaults.tipLabelKey)
+   * state.tipLabelKey is initially the same value and then overridden via the URL query (default: state.defaults.tipLabelKey)
    */
-  const validTipLabels = collectAvailableTipLabelOptions(metadata.colorings).map((o) => o.value);
+  const validTipLabels = collectAvailableTipLabelOptions(tree.nodeAttrKeys, metadata.colorings).map((o) => o.value);
   if (!validTipLabels.includes(state.defaults.tipLabelKey)) {
     console.error("Invalid JSON-defined tip label:", state.defaults.tipLabelKey);
     state.defaults.tipLabelKey = strainSymbol;

--- a/src/components/tree/infoPanels/helpers.js
+++ b/src/components/tree/infoPanels/helpers.js
@@ -1,0 +1,23 @@
+import { getTraitFromNode } from "../../../util/treeMiscHelpers";
+import { numericToCalendar } from "../../../util/dateHelpers";
+
+
+/**
+ * Attempt to display the best name we can for a node, depending on how we are looking at a node.
+ * The returned string will be rendered on a line of its own, so an empty string will look ok
+ * Future enhancement: we could examine the coloring metadata (if available) and format the value accordingly
+ */
+export function nodeDisplayName(t, node, tipLabelKey, branch) {
+  let tipLabel = getTraitFromNode(node, tipLabelKey)
+  if (tipLabelKey==='num_date' && tipLabel) tipLabel = numericToCalendar(tipLabel)
+  const terminal = !node.hasChildren;
+
+  if (branch) {
+    if (terminal) {
+      return tipLabel ? t("Branch leading to {{tipLabel}}", {tipLabel}) : t("Terminal branch") // hover + click
+    }
+    return t("Internal branch")  // branch click only
+  }
+  /* TIP */
+  return tipLabel;
+}

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -5,9 +5,10 @@ import { getTipColorAttribute } from "../../../util/colorHelpers";
 import { isColorByGenotype, decodeColorByGenotype } from "../../../util/getGenotype";
 import { getTraitFromNode, getDivFromNode, getVaccineFromNode,
   getFullAuthorInfoFromNode, getTipChanges, getBranchMutations } from "../../../util/treeMiscHelpers";
-import { isValueValid } from "../../../util/globals";
+import { isValueValid, strainSymbol } from "../../../util/globals";
 import { formatDivergence, getIdxOfInViewRootNode } from "../phyloTree/helpers";
 import { parseIntervalsOfNsOrGaps } from "./MutationTable";
+import { nodeDisplayName } from "./helpers";
 
 export const InfoLine = ({name, value, padBelow=false}) => {
   const renderValues = () => {
@@ -31,12 +32,6 @@ export const InfoLine = ({name, value, padBelow=false}) => {
     </div>
   );
 };
-
-const StrainName = ({name}) => (
-  <div style={infoPanelStyles.tooltipHeading}>
-    {name}
-  </div>
-);
 
 /**
  * A React component to display information about the branch's time & divergence (where applicable)
@@ -267,13 +262,12 @@ const BranchMutations = ({node, geneSortFn, observedMutations, t}) => {
  * @param  {Object} props
  * @param  {Object} props.node  branch node which is currently highlighted
  */
-const BranchDescendents = ({node, t}) => {
+const BranchDescendants = ({node, t, tipLabelKey}) => {
   const [name, value] = node.fullTipCount === 1 ?
-    [t("Branch leading to"), node.name] :
+    [nodeDisplayName(t, node, tipLabelKey, true), ""] :
     [t("Number of descendants")+":", node.fullTipCount];
   return <InfoLine name={name} value={value} padBelow/>;
 };
-
 
 /**
  * A React component to show vaccine information, if present
@@ -399,17 +393,20 @@ const HoverInfoPanel = ({
   colorings,
   geneSortFn,
   observedMutations,
+  tipLabelKey,
   t
 }) => {
   if (!selectedNode) return null
   const node = selectedNode.node.n; // want the redux node, not the phylo node
   const idxOfInViewRootNode = getIdxOfInViewRootNode(node);
-
   return (
     <Container node={node} panelDims={panelDims}>
       {selectedNode.isBranch===false ? (
         <>
-          <StrainName name={node.name}/>
+          <div style={infoPanelStyles.tooltipHeading}>
+            {nodeDisplayName(t, node, tipLabelKey, false)}
+          </div>
+          {tipLabelKey!==strainSymbol && <InfoLine name="Node name:" value={node.name}/>}
           <VaccineInfo node={node} t={t}/>
           <TipMutations node={node} t={t}/>
           <BranchLength node={node} t={t}/>
@@ -419,7 +416,7 @@ const HoverInfoPanel = ({
         </>
       ) : (
         <>
-          <BranchDescendents node={node} t={t}/>
+          <BranchDescendants node={node} t={t} tipLabelKey={tipLabelKey}/>
           <BranchMutations node={node} geneSortFn={geneSortFn} observedMutations={observedMutations} t={t}/>
           <BranchLength node={node} t={t}/>
           <ColorBy node={node} colorBy={colorBy} colorByConfidence={colorByConfidence} colorScale={colorScale} colorings={colorings}/>

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -206,6 +206,7 @@ class Tree extends React.Component {
           geneSortFn={this.state.geneSortFn}
           observedMutations={this.props.tree.observedMutations}
           panelDims={{width: this.props.width, height: this.props.height, spaceBetweenTrees}}
+          tipLabelKey={this.props.tipLabelKey}
           t={t}
         />
         <NodeClickedPanel
@@ -216,6 +217,7 @@ class Tree extends React.Component {
           observedMutations={this.props.tree.observedMutations}
           colorings={this.props.colorings}
           geneSortFn={this.state.geneSortFn}
+          tipLabelKey={this.props.tipLabelKey}
           t={t}
         />
         {this.props.showTangle && this.state.tree && this.state.treeToo ? (


### PR DESCRIPTION
The motivating use case is the proliferation of datasets using an accession for `node.name` but who wish to see node names of another piece of metadata. See commit messages for more details.

Using our current monkeypox/mpxv dataset with the following differences:
* `node.name` is the accession (which is the uniq ID used throughout the pipeline). This removes the need for the pipelines to use JSON-modification scripts such as `set_final_strain_name.py`.
* "strain" is added to `node_attrs` reflecting the original strain name. (Any name can be used here.)
* `"tip_label": "strain"` added as a `display_defaults`
* "strain" added to filters and colorings


On hover boxes show both the chosen tip-label and the underlying node name (accession). (On-click modals are similar)
![image](https://github.com/nextstrain/auspice/assets/8350992/4baad320-1485-4f3d-bf6f-b6b938ebe9ca)

Filtering to duplicate strain names works intuitively
![image](https://github.com/nextstrain/auspice/assets/8350992/8a18e5c6-cba9-44fa-aec7-e91674ca5830)



