### PR TITLE
download: use the `node.shell.inView` property

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -135,7 +135,7 @@ function Button({name, description, icon, onClick}) {
 
 function getNumUniqueAuthors(nodes, nodeVisibilities) {
   const authors = new Set(nodes
-    .filter((n, i) => nodeVisibilities[i] === NODE_VISIBLE && n.inView)
+    .filter((n, i) => nodeVisibilities[i] === NODE_VISIBLE && n.shell.inView)
     .map((n) => getFullAuthorInfoFromNode(n))
     .filter((a) => a && a.value)
     .map((a) => a.value)

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -22,7 +22,7 @@ const treeToNewick = (tree, temporal, internalNodeNames=false, nodeAnnotation=()
   const getXVal = temporal ? (n) => getTraitFromNode(n, "num_date") : getDivFromNode;
 
   function recurse(node, parentX) {
-    if (!node.inView || tree.visibility[node.arrayIdx]!==NODE_VISIBLE) {
+    if (!node.shell.inView || tree.visibility[node.arrayIdx]!==NODE_VISIBLE) {
       return "";
     }
     if (node.hasChildren) {
@@ -176,7 +176,7 @@ export const authorTSV = (dispatch, filePrefix, tree) => {
   const UNKNOWN = "unknown";
   const info = {};
   tree.nodes
-    .filter((n, i) => tree.visibility[i] === NODE_VISIBLE && n.inView)
+    .filter((n, i) => tree.visibility[i] === NODE_VISIBLE && n.shell.inView)
     .filter((n) => !n.hasChildren).forEach((n) => {
       const author = getFullAuthorInfoFromNode(n);
       if (!author) return;
@@ -221,7 +221,7 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
   for (const [i, node] of nodes.entries()) {
     if (node.hasChildren) continue; /* we only consider tips */
 
-    if (nodeVisibilities[i] !== NODE_VISIBLE || !node.inView) {
+    if (nodeVisibilities[i] !== NODE_VISIBLE || !node.shell.inView) {
       continue;
     }
 
@@ -313,7 +313,7 @@ export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, nodeVisibilities
   for (const [i, node] of nodes.entries()) {
     if (node.hasChildren) continue; /* we only consider tips */
 
-    if (nodeVisibilities[i] !== NODE_VISIBLE || !node.inView) {
+    if (nodeVisibilities[i] !== NODE_VISIBLE || !node.shell.inView) {
       continue;
     }
 


### PR DESCRIPTION
### Description of proposed changes
The `node.inView` property is a temporary hold for the node's inView property to be able to zoom in on specific branches before the D3 PhyloTree has been constructed.

Once the D3 PhyloTree has been constructed, the inView property is available through `node.shell.inView`. This is the property that gets updated by `applyInViewNodesToTree` whenever the user interacts with any zooming functionality on the tree. The temporary `node.inView` property will never be updated and thus only represents the initial state of the node when the tree was first loaded.

Therefore, any downstream uses of the inView property should be using the `node.shell.inView` property.



<!-- What is the goal of this pull request? What does this pull request change? -->

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Fixes #1411 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
