### PR TITLE
Tip label can be defined in display_defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+
+* Allow the tip label key to be defined in the JSON via `display_defaults.tip_label`, in addition to being settable via a URL query.
+See [the docs](https://docs.nextstrain.org/projects/auspice/en/stable/advanced-functionality/view-settings.html) or [PR #1668](https://github.com/nextstrain/auspice/pull/1668) for more.
+
 ## version 2.48.0 - 2023/08/31
-
-
 
 * Root sequence data may be inlined in the main dataset JSON
 ([Auspice PR #1688](https://github.com/nextstrain/auspice/pull/1688) and [Augur PR #1295](https://github.com/nextstrain/augur/pull/1295)).
@@ -32,8 +34,6 @@ detailed in [augur PR #1281](https://github.com/nextstrain/augur/pull/1281).
 * Dependencies updated. See [PR #1669](https://github.com/nextstrain/auspice/pull/1669) for more.
 
 ## version 2.46.0 - 2023/05/15
-
-
 * Fixed a bug where narratives with multiple datasets that had measurements panels would error when switching datasets. ([#1603](https://github.com/nextstrain/auspice/issues/1603))
 
 _There have been a number of internal changes with this release, most of which should not result in any different behavior while using Auspice._

--- a/docs/advanced-functionality/view-settings.rst
+++ b/docs/advanced-functionality/view-settings.rst
@@ -17,6 +17,7 @@ Auspice has some hardcoded defaults, largely for historical reasons. Each of the
 -  Default geographic resolution is "country", if available.
 -  Default colouring is "country", if available.
 -  Default branch labelling is "clade", if available.
+-  Default tip labelling is the sample / strain name (`node.name`)
 
 Dataset (JSON) configurable defaults
 ------------------------------------
@@ -35,6 +36,8 @@ These are exported as the (optional) property of the dataset JSON ``meta.display
 | ``map_triplicate``        | Should the map repeat, so that you can pan further in each direction? | Boolean                                            |
 +---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
 | ``layout``                | Tree layout                                                           | "rect", "radial", "unrooted", "clock" or "scatter" |
++---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
+| ``tip_label``             | What attribute (in 'node_attrs') to use as tip (node) labels          | "country"                                          |
 +---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
 | ``branch_label``          | Which set of branch labels are to be displayed                        | "aa", "lineage"                                    |
 +---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
@@ -102,6 +105,8 @@ URL queries are the part of the URL coming after the ``?`` character, and typica
 | ``n``                | Narrative page number                                     | ``n=1`` goes to the first page                    |
 +----------------------+-----------------------------------------------------------+---------------------------------------------------+
 | ``s``                | Selected strain                                           | ``s=1_0199_PF``                                   |
++----------------------+-----------------------------------------------------------+---------------------------------------------------+
+| ``tl``               | Tip label to display                                      | ``tl=country``                                    |
 +----------------------+-----------------------------------------------------------+---------------------------------------------------+
 | ``branchLabel``      | Branch labels to display                                  | ``branchLabel=aa``                                |
 +----------------------+-----------------------------------------------------------+---------------------------------------------------+

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -5,6 +5,8 @@ import { shouldDisplayTemporalConfidence } from "../reducers/controls";
 import { genotypeSymbol, nucleotide_gene, strainSymbol } from "../util/globals";
 import { encodeGenotypeFilters, decodeColorByGenotype, isColorByGenotype } from "../util/getGenotype";
 
+export const strainSymbolUrlString = "__strain__";
+
 /**
  * This middleware acts to keep the app state and the URL query state in sync by
  * intercepting actions and updating the URL accordingly. Thus, in theory, this
@@ -167,7 +169,9 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.CHANGE_TIP_LABEL_KEY: {
-      query.tl = action.key===strainSymbol ? undefined : action.key;
+      query.tl = action.key===state.controls.defaults.tipLabelKey ? undefined :
+        action.key===strainSymbol ? strainSymbolUrlString :
+        action.key;
       break;
     }
     case types.CHANGE_DATES_VISIBILITY_THICKNESS: {

--- a/src/reducers/controls.js
+++ b/src/reducers/controls.js
@@ -24,6 +24,7 @@ export const getDefaultControlsState = () => {
     filtersInFooter: [],
     colorBy: defaultColorBy,
     selectedBranchLabel: "none",
+    tipLabelKey: strainSymbol,
     showTransmissionLines: true
   };
   // a default sidebarOpen status is only set via JSON, URL query
@@ -78,7 +79,7 @@ export const getDefaultControlsState = () => {
     panelsAvailable: [],
     panelsToDisplay: [],
     panelLayout: calcBrowserDimensionsInitialState().width > twoColumnBreakpoint ? "grid" : "full",
-    tipLabelKey: strainSymbol,
+    tipLabelKey: defaults.tipLabelKey,
     showTreeToo: undefined,
     showTangle: false,
     zoomMin: undefined,


### PR DESCRIPTION
The ability to encode the tip-label in the URL (?tl=...) was implemented at the same time as the ability to change tip-label keys was done - see https://github.com/nextstrain/auspice/commit/0e55b3022db5ac8c5ffa52deddec61b7182f8103

The ability to encode this in the JSON's display_defaults wasn't done, presumably due to time constraints.

This commit was originally part of the larger https://github.com/nextstrain/auspice/pull/1668, however that's had no comments on it and so I don't know if/when it'll be merged. 

Augur PR https://github.com/nextstrain/augur/pull/1298 will update the schema to allow this field
