### PR TITLE
Align first major grid circle in radial view

### DIFF
--- a/src/components/tree/phyloTree/grid.js
+++ b/src/components/tree/phyloTree/grid.js
@@ -273,7 +273,8 @@ export const addGrid = function addGrid() {
           " " +
           yScale.range()[0].toString();
       } else if (layoutShadow==="radial") {
-        const xPos = xScale(gridPoint.position-xmin);
+        const relativePosition = gridPoint.position - xmin;
+        const xPos = xScale(Math.max(relativePosition, 0));
         svgPath = 'M '+xPos.toString() +
           "  " +
           yScale(0).toString() +
@@ -307,7 +308,8 @@ export const addGrid = function addGrid() {
   /* same as xTextPos HOF, but for y-values */
   const yTextPos = (yScale, layoutShadow) => (gridPoint) => {
     if (gridPoint.axis === "x") {
-      return layoutShadow === "radial" ? yScale(gridPoint.position-xmin)-5 : yScale.range()[1] + 18;
+      const relativePosition = gridPoint.position - xmin;
+      return layoutShadow === "radial" ? yScale(Math.max(relativePosition, 0))-5 : yScale.range()[1] + 18;
     }
     return yScale(gridPoint.position);
   };


### PR DESCRIPTION
Compare radial tree view of Zika dataset [before](https://nextstrain.org/zika?l=radial) and [after](https://auspice-victorlin-fix-r-st5x6f.herokuapp.com/zika?l=radial).

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

When plotting the first major grid, its position value can be below the domain of the x-axis. I'm not sure why. To reduce the effects of this, impose a lower limit on grid positions.

Previously, these situations would render a first major grid circle offset from the center. With this change, it draws a point at the actual center.

The text labels are similarly adjusted.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Prompted by [a discussion post](https://discussion.nextstrain.org/t/1429/5).

## Checklist
<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] PR preview looks good - no more weird circle, and the text is aligned.
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ I don't think this is necessary.

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
