### PR TITLE
Remove entropy font style injection

### DIFF
--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -502,8 +502,6 @@ const writeSVGPossiblyIncludingMap = (dispatch, filePrefix, panelsInDOM, panelLa
   if (panelsInDOM.indexOf("entropy") !== -1) {
     try {
       panels.entropy = processXMLString((new XMLSerializer()).serializeToString(document.getElementById("d3entropyParent")));
-      panels.entropy.inner = panels.entropy.inner.replace(/<text/g, `<text class="txt"`);
-      panels.entropy.inner = `<style>.txt { font-family: "Lato", "Helvetica Neue", "Helvetica", "sans-serif"; }</style>${panels.entropy.inner}`;
     } catch (e) {
       panels.entropy = undefined;
       errors.push("entropy");


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This reverts commit 08952cfb0383e0c1c6b4f14f1f5b8813b2f9ee19.

The XML string replacement causes issues when the text element already has a class defined (multiple class attributes are not allowed).

Remove the replacement entirely since similar styles are inherited from global.css:
 https://github.com/nextstrain/auspice/blob/8111de141aa3eba1e7b86638b7ae1b5b10ff6327/src/css/global.css#L3

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Fixes #1695

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] SVG export of zika dataset with entropy panel opens without errors
- [x] Checks pass
~- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ Small change, not necessary

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
