### PR TITLE
fix: tip_label settable through json default

### DIFF
--- a/cli/server/convertJsonSchemas.js
+++ b/cli/server/convertJsonSchemas.js
@@ -258,7 +258,7 @@ const setVaccineChoicesOnNodes = (v2, v1meta) => {
  */
 const setLabels = (v2) => {
   traverseTree(v2.tree, (node) => {
-    /* are their aa mutations? */
+    /* are there aa mutations? */
     if (node.branch_attrs && node.branch_attrs.mutations) {
       const mutations = node.branch_attrs.mutations;
       const aaMutsToLabel = Object.keys(mutations)

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -194,7 +194,6 @@ const restoreQueryableStateToDefaults = (state) => {
 
   state["panelLayout"] = calcBrowserDimensionsInitialState().width > twoColumnBreakpoint ? "grid" : "full";
   state.panelsToDisplay = state.panelsAvailable.slice();
-  state.tipLabelKey = strainSymbol;
   state.scatterVariables = {};
 
   state.showAllBranchLabels = false;
@@ -238,8 +237,8 @@ const modifyStateViaMetadata = (state, metadata, genomeMap) => {
   state.filters[strainSymbol] = [];
   state.filters[genotypeSymbol] = []; // this doesn't necessitate that mutations are defined
   if (metadata.displayDefaults) {
-    const keysToCheckFor = ["geoResolution", "colorBy", "distanceMeasure", "layout", "mapTriplicate", "selectedBranchLabel", 'sidebar', "showTransmissionLines", "normalizeFrequencies"];
-    const expectedTypes =  ["string",        "string",  "string",          "string", "boolean",       "string",              'string',  "boolean"              , "boolean"];
+    const keysToCheckFor = ["geoResolution", "colorBy", "distanceMeasure", "layout", "mapTriplicate", "selectedBranchLabel", 'sidebar', "showTransmissionLines", "normalizeFrequencies", "tipLabelKey"];
+    const expectedTypes =  ["string",        "string",  "string",          "string", "boolean",       "string",              'string',  "boolean"              , "boolean"             , "string"     ];
 
     for (let i = 0; i < keysToCheckFor.length; i += 1) {
       if (Object.hasOwnProperty.call(metadata.displayDefaults, keysToCheckFor[i])) {
@@ -305,7 +304,7 @@ const modifyStateViaMetadata = (state, metadata, genomeMap) => {
     state.panelsAvailable = state.panelsAvailable.filter((item) => item !== "entropy");
     state.panelsToDisplay = state.panelsToDisplay.filter((item) => item !== "entropy");
     if (Object.keys(metadata.colorings).includes('gt')) {
-      console.error("Genotype coloring ('gt') was specified as an option in the JSON, however the data does not support this: " + 
+      console.error("Genotype coloring ('gt') was specified as an option in the JSON, however the data does not support this: " +
       "check that 'metadata.genome_annotations' is correct and that mutations have been assigned to 'branch_attrs' on the tree.")
       delete metadata.colorings.gt;
     }
@@ -745,6 +744,7 @@ const createMetadataStateFromJSON = (json) => {
       geo_resolution: "geoResolution",
       distance_measure: "distanceMeasure",
       branch_label: "selectedBranchLabel",
+      tip_label: "tipLabelKey",
       map_triplicate: "mapTriplicate",
       layout: "layout",
       language: "language",


### PR DESCRIPTION
The schema advertises the ability to set tip_label default via `.meta.diplay_default.tip_label` see https://nextstrain.org/schemas/auspice/config/v2#/properties/display_defaults

Unintended duplicate of #1692 
