### PR TITLE
Avoid rendering branches for the first node

### DIFF
--- a/src/components/tree/phyloTree/renderers.js
+++ b/src/components/tree/phyloTree/renderers.js
@@ -181,7 +181,7 @@ export const drawBranches = function drawBranches() {
   } else {
     this.groups.branchTee
       .selectAll('.branch')
-      .data(this.nodes.filter((d) => d.n.hasChildren))
+      .data(this.nodes.filter((d) => d.n.hasChildren && d.displayOrder !== undefined))
       .enter()
       .append("path")
       .attr("class", "branch T")
@@ -213,7 +213,7 @@ export const drawBranches = function drawBranches() {
   }
   this.groups.branchStem
     .selectAll('.branch')
-    .data(this.nodes)
+    .data(this.nodes.filter((d) => d.displayOrder !== undefined))
     .enter()
     .append("path")
     .attr("class", "branch S")


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This is a follow-up to 937c68cf223e292f1c1322c508cbbf1f9f889333, which added a dummy node as the first node.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Resolves #1647

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Console errors no longer show up locally on any dataset, including the one uploaded to the linked issue.
- [x] Checks pass
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
