### PR TITLE
Properly use useAppDispatch hook

### DIFF
--- a/src/components/narrativeEditor/useDatasetFetch.js
+++ b/src/components/narrativeEditor/useDatasetFetch.js
@@ -14,7 +14,7 @@ import { FetchError } from "../../util/exceptions";
  */
 
 export function useDatasetFetch(datasets) {
-  const dispatchRedux = useAppDispatch;
+  const dispatchRedux = useAppDispatch();
   const [datasetResponses, dispatchDatasetResponses] = useReducer(
     (state, action) => {
       if (action.reset) return {};


### PR DESCRIPTION
### Description of proposed changes

Function call parentheses were accidentally removed in 3e77a0a0f572db0e4621d9dfc3614a7353311be2.

The code is only invoked during runtime when accessing the narrative editor, which was not tested before merging that change.

### Related issue(s)

Fixes #1725

### Testing

- [x] Checks pass
- [x] [Preview narrative editor](https://auspice-victorlin-fix-n-c3t4ly.herokuapp.com/edit/narratives) works
