### PR TITLE
Link Auspice version to the changelog

### DIFF
--- a/src/components/framework/fine-print.js
+++ b/src/components/framework/fine-print.js
@@ -101,7 +101,9 @@ class FinePrint extends React.Component {
             {dot}
             {this.downloadDataButton()}
             {dot}
-            {"Auspice v" + version}
+            <a href="https://docs.nextstrain.org/projects/auspice/page/releases/changelog.html" target="_blank" rel="noreferrer noopener">
+              {"Auspice v" + version}
+            </a>
           </Flex>
           <div style={{height: "5px"}}/>
           {getCustomFinePrint()}


### PR DESCRIPTION
### Description of proposed changes

Adds context to the version number hidden at the bottom of the page. There's a likely possibility that anyone who goes looking for it wants to learn more about what changes are included in the version.

A pop-up like [what's done in Nextclade](https://github.com/nextstrain/nextclade/blob/954cd6acce6349ab1e99e58bba0a99e2de15db0c/packages_rs/nextclade-web/src/components/Layout/WhatsNewButton.tsx#L250) would be more visible, but this is the simplest change.

### Related issue(s)

N/A

### Testing

- [x] Checks pass
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ N/A, small change

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
