### PR TITLE
Add download JSON button

### DIFF
--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -10,6 +10,7 @@ import { getNumSelectedTips } from "../../util/treeVisibilityHelpers";
 const RectangularTreeIcon = withTheme(icons.RectangularTree);
 const PanelsGridIcon = withTheme(icons.PanelsGrid);
 const MetaIcon = withTheme(icons.Meta);
+const DatasetIcon = withTheme(icons.Dataset);
 const iconWidth = 25;
 
 /**
@@ -47,6 +48,14 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         <p/>
         {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
+      {!gisaidProvenance && (
+        <Button
+          name="Auspice (Nextstrain) JSON"
+          description={`The main Auspice dataset JSON(s) for the current view`}
+          icon={<DatasetIcon width={iconWidth} selected />}
+          onClick={() => helpers.auspiceJSON(dispatch)}
+        />
+      )}
       <Button
         name={`${temporal ? 'TimeTree' : 'Tree'} (Newick)`}
         description={`Phylogenetic tree in Newick format with branch lengths in units of ${temporal?'years':'divergence'}.`}

--- a/src/components/framework/svg-icons.js
+++ b/src/components/framework/svg-icons.js
@@ -150,3 +150,20 @@ export const PanelsFull = ({theme, selected, width}) => {
     </svg>
   );
 };
+
+
+export const Dataset = ({theme, selected, width}) => {
+  const stroke = selected ? theme.selectedColor : theme.unselectedColor;
+  return (
+    <svg width={width} height={width + 5}>
+      <g transform="translate(0,7)">
+        <svg width={width} height={width} viewBox="0 0 30 30 ">
+          <g id="Group" stroke="none" strokeWidth="3" fill="none" fillRule="evenodd">
+            <path stroke={stroke} d={`M 11 3 L 1 15 L 11 27`}/>
+            <path stroke={stroke} d={`M 19 3 L 29 15 L 19 27`}/>
+          </g>
+        </svg>
+      </g>
+    </svg>
+  );
+};


### PR DESCRIPTION
The main (i.e. not sidecar) dataset is downloaded (or datasets in the case of tangletrees). Downloading sidecar files is also possible if we want to expose them.

Given that we don't store the (un-modified) dataset JSON in Auspice to download it we can either (a) convert the modified data format back to the original JSON or (b) re-download it. (a) is by far the simpler implementation and with appropriate caching should have good performance.

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR