### PR TITLE
Create PRs on other repos with GitHub CLI

### DIFF
--- a/.github/workflows/make_pr_for_downstream_repo.yaml
+++ b/.github/workflows/make_pr_for_downstream_repo.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           path: ${{ env.DESTINATION_REPO_DIR }}
+          token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
 
       - name: Install Auspice from PRs HEAD commit
         shell: bash
@@ -63,16 +64,15 @@ jobs:
           npm install nextstrain/auspice#${{ steps.detect-pr.outputs.auspice-sha }}
           git add package.json package-lock.json
 
+          git config user.name "nextstrain-bot"
+          git config user.email "nextstrain-bot@users.noreply.github.com"
+          git commit --message="[testing only] Upgrade Auspice to ${{ github.sha }}"
+
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          path: ${{ env.DESTINATION_REPO_DIR }}
-          token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
-          branch: "nextstrain-bot/test-auspice-pr/${{ steps.detect-pr.outputs.pr-number }}"
-          commit-message: "[testing only] Upgrade Auspice to ${{ github.sha }}"
-          author: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
-          committer: 'nextstrain-bot <nextstrain-bot@users.noreply.github.com>'
+        working-directory: ${{ env.DESTINATION_REPO_DIR }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
           title: '[bot] [DO NOT MERGE] Test Auspice PR ${{ steps.detect-pr.outputs.pr-number }}'
           body: |
             This PR has been created to test this project running Auspice with changes from https://github.com/nextstrain/auspice/pull/${{ steps.detect-pr.outputs.pr-number }}.
@@ -81,10 +81,17 @@ jobs:
             This will surface any issues that can arise from merging the PR in Auspice. To address these issues locally, update the source branch (e.g. with a git rebase).
 
             This message and corresponding commits were automatically created by a GitHub Action from [nextstrain/auspice](https://github.com/nextstrain/auspice).
-          draft: true
-          delete-branch: true
-
-      - name: Check outputs
+          body_file: pr_body.txt
         run: |
-          echo "PR number: ${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "PR URL: ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"
+          branch="nextstrain-bot/test-auspice-pr/${{ steps.detect-pr.outputs.pr-number }}"
+          git switch -c "$branch"
+          git push --force origin HEAD
+          pr_url=$(gh pr list --head "$branch" --json url | jq -r '.[0].url')
+
+          if [ "$pr_url" = "null" ]; then
+            echo "$body" > "$body_file"
+            pr_url="$(gh pr create --title "$title" --body-file "$body_file" --draft)"
+            echo "Pull request created: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Pull request updated: $pr_url" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/make_pr_for_downstream_repo.yaml
+++ b/.github/workflows/make_pr_for_downstream_repo.yaml
@@ -40,8 +40,8 @@ jobs:
             exit 1
           fi
           MERGE_SHA=$(gh pr view $GITHUB_REF_NAME --repo nextstrain/auspice --json 'potentialMergeCommit' --jq '.potentialMergeCommit.oid')
-          echo "::set-output name=pr-number::$PR_NUMBER"
-          echo "::set-output name=auspice-sha::$MERGE_SHA"
+          echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "auspice-sha=$MERGE_SHA" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/make_pr_for_downstream_repo.yaml
+++ b/.github/workflows/make_pr_for_downstream_repo.yaml
@@ -86,5 +86,5 @@ jobs:
 
       - name: Check outputs
         run: |
-          echo "PR number: ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "PR URL: ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "PR number: ${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "PR URL: ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Motivation: move away from 3rd party Actions.

No functional change here except removal of the PR number from outputs (URL is more directly available and useful)

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Mentioned in https://github.com/nextstrain/auspice/pull/1565#pullrequestreview-1130727744
- Closes #1751 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass, but they don't actually test these changes
- [x] ~If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR~ no functional changes
- [x] Create preview PRs on downstream repositories ([run](https://github.com/nextstrain/auspice/actions/runs/8638883185/attempts/1))
- [x] Preview PRs look good
- [x] Job summary has PR links
- [x] Running again updates existing PRs ([run](https://github.com/nextstrain/auspice/actions/runs/8638883185/attempts/2))
- [ ] Post-merge: remove `peter-evans/create-pull-request` from allow list in [GitHub org settings](https://github.com/organizations/nextstrain/settings/actions) ([it is only used in this repo](https://github.com/search?q=org%3Anextstrain+peter-evans%2Fcreate-pull-request&type=code))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
