### PR TITLE
Remove workflow_dispatch trigger from preview PR workflows

### DIFF
--- a/.github/workflows/preview_on_auspice_us.yaml
+++ b/.github/workflows/preview_on_auspice_us.yaml
@@ -7,8 +7,6 @@ on:
       - reopened
       - labeled
 
-  workflow_dispatch:
-
 jobs:
   run:
     # Run if PR has the label and is updated or is newly labeled with the label

--- a/.github/workflows/preview_on_nextstrain_org.yaml
+++ b/.github/workflows/preview_on_nextstrain_org.yaml
@@ -7,8 +7,6 @@ on:
       - reopened
       - labeled
 
-  workflow_dispatch:
-
 jobs:
   run:
     # Run if PR has the label and is updated or is newly labeled with the label


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This was erroneously copied from make_prs_for_other_repos.yaml during the switch away from it in "Create preview PRs using labels" (90b7dee46), which replaces the previous usage of workflow_dispatch with the more automated pull_request trigger.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Follow-up to https://github.com/nextstrain/auspice/pull/1767#discussion_r1566286938

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

Not testing or adding a changelog entry - trivial dev change.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
