### PR TITLE
Increase time limit for immutability checks

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -21,6 +21,7 @@ const store = configureStore({
       immutableCheck: process.env.SKIP_REDUX_CHECKS
         ? false
         : {
+          warnAfter: 100, // ms. Default is 32.
           ignoredPaths: [
             'tree.nodes',
             'tree.vaccines',


### PR DESCRIPTION
The default resulted in very noisy console logging.

Docs: <https://redux-toolkit.js.org/api/serializabilityMiddleware>
