### PR TITLE
Streamline display with onlyPanels

### DIFF
--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -79,7 +79,8 @@ const getStyles = (width) => {
     zoomMax: state.controls.zoomMax,
     defaultColorBy: state.controls.defaults.colorBy,
     panelLayout: state.controls.panelLayout,
-    narrativeMode: state.narrative.display
+    narrativeMode: state.narrative.display,
+    showOnlyPanels: state.controls.showOnlyPanels
   };
 })
 class Entropy extends React.Component {
@@ -258,7 +259,7 @@ class Entropy extends React.Component {
   render() {
     const styles = getStyles(this.props.width);
     return (
-      <Card title={this.title()}>
+      <Card infocard={this.props.showOnlyPanels} title={this.title()}>
         <InfoPanel d3event={this.state.hovered.d3event} width={this.props.width} height={this.props.height}>
           {this.state.hovered ? this.state.hovered.tooltip(this.props.t) : null}
         </InfoPanel>

--- a/src/components/frequencies/index.js
+++ b/src/components/frequencies/index.js
@@ -20,7 +20,8 @@ import "../../css/entropy.css";
     colorBy: state.controls.colorBy,
     colorScale: state.controls.colorScale,
     colorOptions: state.metadata.colorings,
-    normalizeFrequencies: state.controls.normalizeFrequencies
+    normalizeFrequencies: state.controls.normalizeFrequencies,
+    showOnlyPanels: state.controls.showOnlyPanels    
   };
 })
 
@@ -102,7 +103,7 @@ class Frequencies extends React.Component {
     const { t } = this.props;
     const {tipCount, fullTipCount} = this.props.nodes[0];
     return (
-      <Card title={`${t("Frequencies")} (${t("colored by")} ${parseColorBy(this.props.colorBy, this.props.colorOptions)} ${t(normString(this.props.normalizeFrequencies, tipCount, fullTipCount))})`}>
+      <Card infocard={this.props.showOnlyPanels} title={`${t("Frequencies")} (${t("colored by")} ${parseColorBy(this.props.colorBy, this.props.colorOptions)} ${t(normString(this.props.normalizeFrequencies, tipCount, fullTipCount))})`}>
         <div
           id="freqinfo"
           style={{

--- a/src/components/map/map.js
+++ b/src/components/map/map.js
@@ -56,7 +56,8 @@ import "../../css/mapbox.css";
       state.controls.geoResolution !== state.controls.colorScale.colorBy // geo circles match colorby == no pie chart
     ),
     legendValues: state.controls.colorScale.legendValues,
-    showTransmissionLines: state.controls.showTransmissionLines
+    showTransmissionLines: state.controls.showTransmissionLines,
+    showOnlyPanels: state.controls.showOnlyPanels
   };
 })
 
@@ -614,7 +615,7 @@ class Map extends React.Component {
     const transmissionsExist = this.state.transmissionData && this.state.transmissionData.length;
     // clear layers - store all markers in map state https://github.com/Leaflet/Leaflet/issues/3238#issuecomment-77061011
     return (
-      <Card center title={transmissionsExist ? t("Transmissions") : t("Geography")}>
+      <Card center infocard={this.props.showOnlyPanels} title={transmissionsExist ? t("Transmissions") : t("Geography")}>
         {this.props.legend && <ErrorBoundary>
           <Legend right width={this.props.width} />
         </ErrorBoundary>}

--- a/src/components/measurements/index.js
+++ b/src/components/measurements/index.js
@@ -313,6 +313,7 @@ const MeasurementsPlot = ({height, width, showLegend, setPanelTitle}) => {
 const Measurements = ({height, width, showLegend}) => {
   const measurementsLoaded = useSelector((state) => state.measurements.loaded);
   const measurementsError = useSelector((state) => state.measurements.error);
+  const showOnlyPanels = useSelector((state) => state.controls.showOnlyPanels);
 
   const [title, setTitle] = useState("Measurements");
 
@@ -332,7 +333,7 @@ const Measurements = ({height, width, showLegend}) => {
   };
 
   return (
-    <Card title={title} titleStyles={getCardTitleStyle()}>
+    <Card infocard={showOnlyPanels} title={title} titleStyles={getCardTitleStyle()}>
       {measurementsLoaded &&
         (measurementsError ?
           <Flex style={{ height, width}} direction="column" justifyContent="center">

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -26,7 +26,8 @@ const Tree = connect((state) => ({
   showAllBranchLabels: state.controls.showAllBranchLabels,
   tipLabelKey: state.controls.tipLabelKey,
   narrativeMode: state.narrative.display,
-  animationPlayPauseButton: state.controls.animationPlayPauseButton
+  animationPlayPauseButton: state.controls.animationPlayPauseButton,
+  showOnlyPanels: state.controls.showOnlyPanels
 }))(UnconnectedTree);
 
 export default Tree;

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -193,7 +193,7 @@ class Tree extends React.Component {
     const styles = this.getStyles();
     const widthPerTree = this.props.showTreeToo ? (this.props.width - spaceBetweenTrees) / 2 : this.props.width;
     return (
-      <Card center title={t("Phylogeny")}>
+      <Card center infocard={this.props.showOnlyPanels} title={t("Phylogeny")}>
         <ErrorBoundary>
           <Legend width={this.props.width}/>
         </ErrorBoundary>


### PR DESCRIPTION
Following up on #1787.

When `controls.showOnlyPanels` is active via the URL param `&onlyPanels` switch each primary panel to be an "infoPanel". This removes the title and the line above the title in the display card giving the panel a more streamlined appearance. This results in a more pleasant embedding into slide decks.

Here's example display in the context of a Reveal.js slidedeck.

### Single panel
#### Current
<img width="1331" alt="Screenshot 2024-06-11 at 8 55 26 PM" src="https://github.com/nextstrain/auspice/assets/1176109/0534bc28-30db-419c-aa36-894768419881">

#### With PR
<img width="1331" alt="Screenshot 2024-06-11 at 8 53 32 PM" src="https://github.com/nextstrain/auspice/assets/1176109/40b6974c-20f1-4e5e-b3fb-c6f5d4342c2f">

### Grid 
#### Current
<img width="1331" alt="Screenshot 2024-06-11 at 8 55 06 PM" src="https://github.com/nextstrain/auspice/assets/1176109/02660dde-3c53-45d9-be9f-9b31f723e2c2">

#### With PR
<img width="1331" alt="Screenshot 2024-06-11 at 8 54 33 PM" src="https://github.com/nextstrain/auspice/assets/1176109/62f9644b-8bee-42f5-be13-11b951cbd255">

Note that I couldn't figure out how to do the equivalent for measurements panel due to it not using the same `@connect((state)` pattern that's used by tree, map, entropy and frequencies.
