### PR TITLE
feat: remove missing geo_resolutions warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* remove missing warning then dataset JSON has no `.meta.geo_resolutions` field ([#1791](https://github.com/nextstrain/auspice/pull/1791))
+
+
 ## version 2.54.3 - 2024/06/12
 
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -308,7 +308,7 @@ const modifyStateViaMetadata = (state, metadata, genomeMap) => {
     state.panelsAvailable = state.panelsAvailable.filter((item) => item !== "entropy");
     state.panelsToDisplay = state.panelsToDisplay.filter((item) => item !== "entropy");
     if (Object.keys(metadata.colorings).includes('gt')) {
-      console.error("Genotype coloring ('gt') was specified as an option in the JSON, however the data does not support this: " + 
+      console.error("Genotype coloring ('gt') was specified as an option in the JSON, however the data does not support this: " +
       "check that 'metadata.genome_annotations' is correct and that mutations have been assigned to 'branch_attrs' on the tree.")
       delete metadata.colorings.gt;
     }
@@ -544,8 +544,6 @@ const checkAndCorrectErrorsInState = (state, metadata, genomeMap, query, tree, v
       console.error("Error detected. Setting geoResolution to ", state.geoResolution);
       delete query.r; // no-op if query.r doesn't exist
     }
-  } else {
-    console.warn("JSONs did not include `geoResolutions`");
   }
 
   /* show label */
@@ -588,7 +586,7 @@ const checkAndCorrectErrorsInState = (state, metadata, genomeMap, query, tree, v
   const _queryKey = (traitName) => (traitName === strainSymbol) ? 's' :
     (traitName === genotypeSymbol) ? 'gt' :
       `f_${traitName}`;
-      
+
   for (const traitName of Reflect.ownKeys(state.filters)) {
     /* delete empty filters, e.g. "?f_country" or "?f_country=" */
     if (!state.filters[traitName].length) {
@@ -812,7 +810,7 @@ function updateMetadataStateViaSecondTree(metadata, json, genomeMap) {
   // ¹ This could be relaxed in the future - currently we enforce that the order
   //   of genes matches. We could also make this more fine grained and allow the
   //   2nd tree to have a subset of CDSs (wrt the main tree), with genotypes
-  //   only working for the shared CDSs.     
+  //   only working for the shared CDSs.
   if (genomeMap && json.meta.genome_annotations) {
     try {
       metadata.identicalGenomeMapAcrossBothTrees = isEqualWith(


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

When `.meta.geo_resolutions` are not present, Auspice prints a console warning:
```
JSONs did not include `geoResolutions`
```

My understanding is that it is not a required field: https://github.com/nextstrain/augur/blob/0eab3357376f0fe7347fe60dd75dbc2fb01bed33/augur/data/schema-export-v2.json#L18 and auspice can function without it.

It seems to have been added a long time ago:
https://github.com/nextstrain/auspice/blame/a537d390e6a54214ea084240a292da786479693e/src/actions/recomputeReduxState.js#L548

I propose to remove the warning. My goal here is to clean up the dev console of Nextclade. Just being a purist here (I like my console to be clean :)), but if this warning is useful in other contexts, I don't insist.


## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
