### PR TITLE
Fix filter badge display for single trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Small bugfix to the filter badge improvements introduced in v2.55.0 where we incorrectly showed the 2-tree display when viewing a single tree. ([#1794](https://github.com/nextstrain/auspice/pull/1794))
+
 ## version 2.55.0 - 2024/06/17
 
 

--- a/src/components/info/filtersSummary.js
+++ b/src/components/info/filtersSummary.js
@@ -93,7 +93,7 @@ class FiltersSummary extends React.Component {
           If we have two trees shown we show both values.
           */
           const tree1count = this.props.totalStateCounts[filterName]?.get(item.value) ?? 0;
-          if (this.props.totalStateCountsSecondTree) {
+          if (this.props.totalStateCountsSecondTree && Reflect.ownKeys(this.props.totalStateCountsSecondTree).length) {
             const tree2count = this.props.totalStateCountsSecondTree[filterName]?.get(item.value) ?? 0;
             label+=` (L: ${tree1count}, R: ${tree2count})`;
           } else {


### PR DESCRIPTION
Due to a truthy default value in redux state we incorrectly displayed the 2-tree display when viewing a single tree.

It's a one-line bugfix, so I plan to merge and review as soon as CI passes