### PR TITLE
James/second tree dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* We no longer show the "second tree" sidebar dropdown when there are no available options. The possible options are defined by [the charon/getAvailable API](https://docs.nextstrain.org/projects/auspice/en/stable/server/api.html) response and as such vary depending on the server in use. ([#1795](https://github.com/nextstrain/auspice/pull/1795))
+
+
 ## version 2.55.1 - 2024/06/25
 
 

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -33,6 +33,9 @@ class ChooseSecondTree extends React.Component {
         .filter((opt) => !!opt) // .secondTreeOptions is not required
     )]
 
+    // Don't display the sidebar UI if we're just going to display an empty dropdown!
+    if (!options.length) return null;
+
     if (this.props.showTreeToo) options.unshift("REMOVE");
 
     const selectOptions = options.map((opt) => ({value: opt, label: opt}));

--- a/src/components/controls/choose-second-tree.js
+++ b/src/components/controls/choose-second-tree.js
@@ -26,14 +26,12 @@ class ChooseSecondTree extends React.Component {
       .replace(/\/$/, '')
       .split(':')[0];
 
-    let options = [];
-    this.props.available.datasets
-    .filter((dataset) => {
-      if (dataset.request === displayedDataset) {
-        options = [...dataset.secondTreeOptions];
-      }
-      return null;
-    });
+    const options = [...new Set(
+      this.props.available.datasets
+        .filter((dataset) => dataset.request === displayedDataset)
+        .flatMap((dataset) => dataset.secondTreeOptions)
+        .filter((opt) => !!opt) // .secondTreeOptions is not required
+    )]
 
     if (this.props.showTreeToo) options.unshift("REMOVE");
 


### PR DESCRIPTION
Don't display the sidebar UI if we're just going to display an empty
dropdown!

See <https://bedfordlab.slack.com/archives/C0K3GS3J8/p1719424903252149>
for context

- [x] Checks pass (Our CI passes, RTD is currently broken)
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

