### PR TITLE
Convey uncertainty via tip colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* We now use the reported confidence / entropy values to change the saturation of tips (circles) on the tree, which matches the behaviour seen for branches. If there is no (or very little) uncertainty in these nodes then the tips will appear the same as seen in previous versions of Auspice. ([#1796](https://github.com/nextstrain/auspice/pull/1796))
 * We no longer show the "second tree" sidebar dropdown when there are no available options. The possible options are defined by [the charon/getAvailable API](https://docs.nextstrain.org/projects/auspice/en/stable/server/api.html) response and as such vary depending on the server in use. ([#1795](https://github.com/nextstrain/auspice/pull/1795))
 
 

--- a/src/components/tree/reactD3Interface/change.js
+++ b/src/components/tree/reactD3Interface/change.js
@@ -1,4 +1,4 @@
-import { calcBranchStrokeCols, getBrighterColor } from "../../../util/colorHelpers";
+import { calculateStrokeColors, getBrighterColor } from "../../../util/colorHelpers";
 
 export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps, newProps) => {
   const args = {};
@@ -16,9 +16,9 @@ export const changePhyloTreeViaPropsComparison = (mainTree, phylotree, oldProps,
       (oldTreeRedux.nodeColorsVersion !== newTreeRedux.nodeColorsVersion ||
       newProps.colorByConfidence !== oldProps.colorByConfidence)) {
     args.changeColorBy = true;
-    args.branchStroke = calcBranchStrokeCols(newTreeRedux, newProps.colorByConfidence, newProps.colorBy);
-    args.tipStroke = newTreeRedux.nodeColors;
-    args.fill = newTreeRedux.nodeColors.map(getBrighterColor);
+    args.branchStroke = calculateStrokeColors(newTreeRedux, true, newProps.colorByConfidence, newProps.colorBy);
+    args.tipStroke = calculateStrokeColors(newTreeRedux, false, newProps.colorByConfidence, newProps.colorBy);
+    args.fill = args.tipStroke.map(getBrighterColor);
   }
 
   /* visibility */

--- a/src/components/tree/reactD3Interface/initialRender.js
+++ b/src/components/tree/reactD3Interface/initialRender.js
@@ -1,6 +1,6 @@
 import { select } from "d3-selection";
 import 'd3-transition';
-import { calcBranchStrokeCols, getBrighterColor } from "../../../util/colorHelpers";
+import { calculateStrokeColors, getBrighterColor } from "../../../util/colorHelpers";
 import * as callbacks from "./callbacks";
 import { makeTipLabelFunc } from "../phyloTree/labels";
 
@@ -16,6 +16,7 @@ export const renderTree = (that, main, phylotree, props) => {
   if (Object.prototype.hasOwnProperty.call(props.scatterVariables, "showBranches") && props.scatterVariables.showBranches===false) {
     renderBranchLabels=false;
   }
+  const tipStrokeColors = calculateStrokeColors(treeState, false, props.colorByConfidence, props.colorBy);
   /* simply the call to phylotree.render */
   phylotree.render(
     select(ref),
@@ -43,9 +44,9 @@ export const renderTree = (that, main, phylotree, props) => {
     treeState.visibility,
     props.temporalConfidence.on, /* drawConfidence? */
     treeState.vaccines,
-    calcBranchStrokeCols(treeState, props.colorByConfidence, props.colorBy),
-    treeState.nodeColors,
-    treeState.nodeColors.map(getBrighterColor),
+    calculateStrokeColors(treeState, true, props.colorByConfidence, props.colorBy), 
+    tipStrokeColors,
+    tipStrokeColors.map(getBrighterColor), // tip fill colors
     treeState.tipRadii, /* might be null */
     [props.dateMinNumeric, props.dateMaxNumeric],
     props.scatterVariables

--- a/src/reducers/controls.ts
+++ b/src/reducers/controls.ts
@@ -66,7 +66,7 @@ export const getDefaultControlsState = () => {
     absoluteDateMax: dateMax,
     absoluteDateMaxNumeric: dateMaxNumeric,
     colorBy: defaults.colorBy,
-    colorByConfidence: { display: false, on: false },
+    colorByConfidence: false,
     colorScale: undefined,
     explodeAttr: undefined,
     selectedBranchLabel: "none",


### PR DESCRIPTION
The previous code conveyed uncertainty in node attrs for _branches_ by making them appear grey-er, but we never implemented this for _tips_; most likely because we never had a dataset with such data when this was built.

Here we use the same approach for tips as for branches, but with a slightly different parameterisation of the interpolation. The mapping of the entropy value into `[0,1]` (`tipOpacityFunction`) was chosen so that tips with no (or very little) uncertainty look unchanged from previous Auspice versions, and uncertainty makes them appear more similar to the branch colour (for an equivalent uncertainty).

There should be no visible changes for views without any uncertainty (genotype is a good one to use to test this), as well as traits where there is uncertainty in the dataset but not in the tips (e.g. ebola country / division reconstruction). Here's a side-by-side with the h5n1-cattle-flu dataset from https://github.com/nextstrain/avian-flu/pull/66, which identified this issue in Auspice (this PR LHS, current Auspice RHS):

![Frame 12(1)](https://github.com/nextstrain/auspice/assets/8350992/c9fb896a-67d2-4b38-82ad-65da8c10e0ad)



- [x] Checks pass _(CI passes, RTD is currently broken however that's unrelated to this PR)_
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

