### PR TITLE
Only support downloading Auspice JSONs if dataset name can be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fix bug where app crashed if measurements JSON did not define thresholds ([#1802](https://github.com/nextstrain/auspice/pull/1802))
 * Fix bug where measurements display did not honor the default `measurements_display` ([#1802](https://github.com/nextstrain/auspice/pull/1802))
+* Only display download-JSON button if the dataset name can be parsed from pathname ([#1804](https://github.com/nextstrain/auspice/pull/1804))
 
 ## version 2.56.0 - 2024/07/01
 

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -6,6 +6,7 @@ import { materialButton } from "../../globalStyles";
 import * as helpers from "./helperFunctions";
 import { getFullAuthorInfoFromNode } from "../../util/treeMiscHelpers";
 import { getNumSelectedTips } from "../../util/treeVisibilityHelpers";
+import { getDatasetNamesFromUrl } from "../../actions/loadData";
 
 const RectangularTreeIcon = withTheme(icons.RectangularTree);
 const PanelsGridIcon = withTheme(icons.PanelsGrid);
@@ -35,6 +36,10 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
       }
     }
   }
+  /* Verify that we can parse dataset name from URL to support Auspice JSON download */
+  const datasetNames = getDatasetNamesFromUrl(window.location.pathname);
+  const supportAuspiceJsonDownload = !gisaidProvenance && datasetNames.some(Boolean);
+
   const entropyBar = entropy?.selectedCds===nucleotide_gene ? "nucleotide" : "codon";
 
   return (
@@ -48,12 +53,12 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         <p/>
         {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
-      {!gisaidProvenance && (
+      {supportAuspiceJsonDownload && (
         <Button
           name="Auspice (Nextstrain) JSON"
           description={`The main Auspice dataset JSON(s) for the current view`}
           icon={<DatasetIcon width={iconWidth} selected />}
-          onClick={() => helpers.auspiceJSON(dispatch)}
+          onClick={() => helpers.auspiceJSON(dispatch, datasetNames)}
         />
       )}
       <Button

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -8,7 +8,7 @@ import { NODE_VISIBLE, nucleotide_gene } from "../../util/globals";
 import { datasetSummary } from "../info/datasetSummary";
 import { isColorByGenotype } from "../../util/getGenotype";
 import { EmptyNewickTreeCreated } from "../../util/exceptions";
-import { getDatasetNamesFromUrl, Dataset } from "../../actions/loadData";
+import { Dataset } from "../../actions/loadData";
 
 export const isPaperURLValid = (d) => {
   return (
@@ -623,15 +623,15 @@ export const entropyTSV = (dispatch, filePrefix, entropy) => {
 /**
  * Write out Auspice JSON(s) for the current view. We do this by re-fetching the original
  * JSON because we don't keep a copy of the unprocessed data around.
- * 
+ *
  * Sidecar files are not fetched, but we can also download them if desired.
- * 
+ *
  * Note that we are not viewing a narrative, as the download button functionality is disabled
  * for narratives.
  */
-export const auspiceJSON = (dispatch) => {
+export const auspiceJSON = (dispatch, datasetNames) => {
   const filenames = [];
-  for (const datasetName of getDatasetNamesFromUrl(window.location.pathname)) {
+  for (const datasetName of datasetNames) {
     if (!datasetName) continue; // e.g. no 2nd tree
     const filename = datasetName.replace('/', '_') + '.json';
     filenames.push(filename);

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -631,6 +631,10 @@ export const entropyTSV = (dispatch, filePrefix, entropy) => {
  */
 export const auspiceJSON = (dispatch, datasetNames) => {
   const filenames = [];
+  if (!datasetNames.some(Boolean)) {
+    console.error(`Unable to fetch empty dataset names: ${JSON.stringify(datasetNames)}`);
+    return dispatch(errorNotification({message: "Unable to download Auspice JSON (see console for more info)"}))
+  }
   for (const datasetName of datasetNames) {
     if (!datasetName) continue; // e.g. no 2nd tree
     const filename = datasetName.replace('/', '_') + '.json';

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -229,7 +229,7 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
   /* second switch: path change */
   switch (action.type) {
     case types.CLEAN_START:
-      if (action.pathnameShouldBe && !action.narrative) {
+      if (typeof action.pathnameShouldBe === "string" && !action.narrative) {
         pathname = action.pathnameShouldBe;
         break;
       }


### PR DESCRIPTION
## Description of proposed changes

Only supports downloading Auspice JSON if the dataset name can be parsed from the URL pathname. 
This mainly hides the download Auspice JSON option in auspice.us. 

## Related issue(s)

Resolves https://github.com/nextstrain/auspice/issues/1803

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
