### PR TITLE
Allow YYYY-MM-DD values in a temporal scales

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -249,23 +249,6 @@ const restoreQueryableStateToDefaults = (state) => {
 };
 
 const modifyStateViaMetadata = (state, metadata, genomeMap) => {
-  if (metadata.date_range) {
-    /* this may be useful if, e.g., one were to want to display an outbreak
-    from 2000-2005 (the default is the present day) */
-    if (metadata.date_range.date_min) {
-      state["dateMin"] = metadata.date_range.date_min;
-      state["dateMinNumeric"] = calendarToNumeric(state["dateMin"]);
-      state["absoluteDateMin"] = metadata.date_range.date_min;
-      state["absoluteDateMinNumeric"] = calendarToNumeric(state["absoluteDateMin"]);
-      state["mapAnimationStartDate"] = metadata.date_range.date_min;
-    }
-    if (metadata.date_range.date_max) {
-      state["dateMax"] = metadata.date_range.date_max;
-      state["dateMaxNumeric"] = calendarToNumeric(state["dateMax"]);
-      state["absoluteDateMax"] = metadata.date_range.date_max;
-      state["absoluteDateMaxNumeric"] = calendarToNumeric(state["absoluteDateMax"]);
-    }
-  }
   if (metadata.analysisSlider) {
     state["analysisSlider"] = {key: metadata.analysisSlider, valid: false};
   }

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -92,13 +92,31 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.tl) {
     state["tipLabelKey"] = query.tl===strainSymbolUrlString ? strainSymbol : query.tl;
   }
+
   if (query.dmin) {
-    state["dateMin"] = query.dmin;
-    state["dateMinNumeric"] = calendarToNumeric(query.dmin);
+    const dateNum = calendarToNumeric(query.dmin);
+    if (_validDate(dateNum, state.absoluteDateMinNumeric, state.absoluteDateMaxNumeric)) {
+      state["dateMin"] = query.dmin;
+      state["dateMinNumeric"] = dateNum;
+    } else {
+      console.error(`URL query "dmin=${query.dmin}" is invalid ${state.branchLengthsToDisplay==='divOnly'?'(the tree is not a timetree)':''}`);
+      delete query.dmin;
+    }
   }
   if (query.dmax) {
-    state["dateMax"] = query.dmax;
-    state["dateMaxNumeric"] = calendarToNumeric(query.dmax);
+    const dateNum = calendarToNumeric(query.dmax);
+    if (_validDate(dateNum, state.absoluteDateMinNumeric, state.absoluteDateMaxNumeric)) {
+      if ((query.dmin && dateNum <= state.dateMinNumeric)) {
+        console.error(`Requested "dmax=${query.dmax}" is earlier than "dmin=${query.dmin}", ignoring dmax.`);
+        delete query.dmax;
+      } else {
+        state["dateMax"] = query.dmax;
+        state["dateMaxNumeric"] = dateNum;
+      }
+    } else {
+      console.error(`URL query "dmax=${query.dmax}" is invalid ${state.branchLengthsToDisplay==='divOnly'?'(the tree is not a timetree)':''}`);
+      delete query.dmax;
+    }
   }
 
   /** Queries 's', 'gt', and 'f_<name>' correspond to active filters */
@@ -115,21 +133,39 @@ const modifyStateViaURLQuery = (state, query) => {
     state.filters[genotypeSymbol] = decodeGenotypeFilters(query.gt||"");
   }
 
+  state.animationPlayPauseButton = "Play";
   if (query.animate) {
     const params = query.animate.split(',');
-    // console.log("start animation!", params);
-    window.NEXTSTRAIN.animationStartPoint = calendarToNumeric(params[0]);
-    window.NEXTSTRAIN.animationEndPoint = calendarToNumeric(params[1]);
-    state.dateMin = params[0];
-    state.dateMax = params[1];
-    state.dateMinNumeric = calendarToNumeric(params[0]);
-    state.dateMaxNumeric = calendarToNumeric(params[1]);
-    state.mapAnimationShouldLoop = params[2] === "1";
-    state.mapAnimationCumulative = params[3] === "1";
-    state.mapAnimationDurationInMilliseconds = parseInt(params[4], 10);
-    state.animationPlayPauseButton = "Pause";
-  } else {
-    state.animationPlayPauseButton = "Play";
+    if (params.length!==5) {
+      console.error("Invalid 'animate' URL query (not enough fields)");
+      delete query.animate;
+    } else if (state.branchLengthsToDisplay==='divOnly') {
+      console.error("Invalid 'animate' URL query (tree is not a timetree)");
+      delete query.animate;
+    } else {
+      const [_dmin, _dminNum] = [params[0], calendarToNumeric(params[0])];
+      const [_dmax, _dmaxNum] = [params[1], calendarToNumeric(params[1])];
+      if (
+        !_validDate(_dminNum, state.absoluteDateMinNumeric, state.absoluteDateMaxNumeric) || 
+        !_validDate(_dmaxNum, state.absoluteDateMinNumeric, state.absoluteDateMaxNumeric) || 
+        _dminNum >= _dmaxNum
+      ) {
+        console.error("Invalid 'animate' URL query (invalid date range)")
+        delete query.animate
+      } else {
+        window.NEXTSTRAIN.animationStartPoint = _dminNum;
+        window.NEXTSTRAIN.animationEndPoint = _dmaxNum;
+        state.dateMin = _dmin;
+        state.dateMax = _dmax;
+        state.dateMinNumeric = _dminNum;
+        state.dateMaxNumeric = _dmaxNum;
+        state.mapAnimationShouldLoop = params[2] === "1";
+        state.mapAnimationCumulative = params[3] === "1";
+        const duration = parseInt(params[4], 10);
+        state.mapAnimationDurationInMilliseconds = isNaN(duration) ? 30_000 : duration;
+        state.animationPlayPauseButton = "Pause";
+      }
+    }
   }
   if (query.branchLabel) {
     state.selectedBranchLabel = query.branchLabel;
@@ -171,6 +207,10 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.scatterX) state.scatterVariables.x = query.scatterX;
   if (query.scatterY) state.scatterVariables.y = query.scatterY;
   return state;
+
+  function _validDate(dateNum, absoluteDateMinNumeric, absoluteDateMaxNumeric) {
+    return !(dateNum===undefined || dateNum > absoluteDateMaxNumeric || dateNum < absoluteDateMinNumeric);
+  }
 };
 
 const restoreQueryableStateToDefaults = (state) => {

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -4,6 +4,7 @@ import scalePow from "d3-scale/src/pow";
 import { isColorByGenotype, decodeColorByGenotype } from "./getGenotype";
 import { getTraitFromNode } from "./treeMiscHelpers";
 import { isValueValid } from "./globals";
+import { calendarToNumeric } from "./dateHelpers";
 
 /**
  * Average over the visible colours for a given location
@@ -147,3 +148,19 @@ export const getColorByTitle = (colorings, colorBy) => {
   return colorings[colorBy] === undefined ?
     "" : colorings[colorBy].title;
 };
+
+/**
+ * We allow values (on nodes) to be encoded as numeric dates (2021.123) or
+ * YYYY-MM-DD strings. This helper function handles this flexibility and
+ * translates any provided value to either a number or undefined.
+ */
+export function numDate(value) {
+  switch (typeof value) {
+    case "number":
+      return value;
+    case "string":
+      return calendarToNumeric(value, true); // allow XX ambiguity
+    default:
+      return undefined;
+  }
+}

--- a/src/util/tipRadiusHelpers.ts
+++ b/src/util/tipRadiusHelpers.ts
@@ -1,5 +1,5 @@
 import { tipRadius, tipRadiusOnLegendMatch } from "./globals";
-import { getTipColorAttribute } from "./colorHelpers";
+import { getTipColorAttribute, numDate } from "./colorHelpers";
 import { getTraitFromNode } from "./treeMiscHelpers";
 
 /**
@@ -13,7 +13,10 @@ import { getTraitFromNode } from "./treeMiscHelpers";
 * @returns bool
 */
 export const determineLegendMatch = (selectedLegendItem: (string|number), node:any, colorScale:any) => {
-  const nodeAttr = getTipColorAttribute(node, colorScale);
+  let nodeAttr = getTipColorAttribute(node, colorScale);
+  if (colorScale.scaleType === 'temporal') {
+    nodeAttr = numDate(nodeAttr);
+  }
   if (colorScale.continuous) {
     if (selectedLegendItem === colorScale.legendValues[0] && nodeAttr===colorScale.legendBounds[selectedLegendItem][0]) {
       return true;

--- a/test/dates.test.js
+++ b/test/dates.test.js
@@ -93,3 +93,50 @@ test("dates are prettified as expected", () => {
   expect(prettifyDate("MONTH", "2020-01-01")).toStrictEqual("2020-Jan");
   expect(prettifyDate("CENTURY", "-3000-01-01")).toStrictEqual("-3000"); // BCE
 });
+
+
+const ambiguousCalendarDates = {
+  "2024-XX-XX": 2024.5,
+  "2024-01-XX": 2024.044,
+  "2024-11-XX": 2024.88, 
+  "2024-12-XX": 2024.96,
+}
+
+test("calendarToNumeric doesn't allow ambiguous dates unless requested", () => {
+  for (const [calendarDate, _] of Object.entries(ambiguousCalendarDates)) {
+    expect(calendarToNumeric(calendarDate)).toBe(undefined)
+  }
+});
+
+test("calendarToNumeric allows ambiguous dates when requested", () => {
+  for (const [calendarDate, numericDate] of Object.entries(ambiguousCalendarDates)) {
+    expect(calendarToNumeric(calendarDate, true)).toBeCloseTo(numericDate);
+  }
+});
+
+const invalidUnambiguousCalendarDates = [
+  "string",
+  "-string",
+  "2024-XX-01",
+  "2024-X-XX",
+  "2024-XX-XXX",
+  2024.123,
+]
+
+test("calendarToNumeric returns undefined for erroneous dates without ambiguity", () => {
+  for (const calendarDate of invalidUnambiguousCalendarDates) {
+    expect(calendarToNumeric(calendarDate)).toBe(undefined);
+  }
+});
+
+const invalidAmbiguousCalendarDates = [
+  "2024-XX-01",
+  "2024-X-XX",
+  "2024-XX-XXX",
+]
+
+test("calendarToNumeric returns undefined for erroneous dates with ambiguity", () => {
+  for (const calendarDate of invalidAmbiguousCalendarDates) {
+    expect(calendarToNumeric(calendarDate, true)).toBe(undefined);
+  }
+});


### PR DESCRIPTION
Includes a number of improvements to date parsing and validation as well (see commits).

Temporal scales previously could only use numeric dates (2024.123 etc) but can now also use YYYY-MM-DD values including ambiguous values (YYYY-XX-XX, YYYY-MM-XX). For ambiguous values the midpoint of the ambiguous range is used to pick the colour / match the legend swatches to tips.

Example datasets (rabies):

* [YYYY-MM-DD sampling date, most of which are ambiguous, but only for tips (i.e. no timetree)](https://nextstrain-s-nextstrain-waprls.herokuapp.com/staging/rabies/YYYY-MM-DD-coloring?c=date)
* [same dataset with a custom scale provided](https://nextstrain-s-nextstrain-waprls.herokuapp.com/staging/rabies/YYYY-MM-DD-custom-coloring?c=date)

<img width="1611" alt="image" src="https://github.com/user-attachments/assets/82c22d9b-bec6-456f-9bcb-31771a6831e7">

Closes #1427
