### PR TITLE
controls: Hide date/animation sections for `divOnly` trees

### DIFF
--- a/src/components/controls/controls.tsx
+++ b/src/components/controls/controls.tsx
@@ -35,14 +35,19 @@ function Controls() {
   const panelsToDisplay = useSelector((state: RootState) => state.controls.panelsToDisplay);
   const showTreeToo = useSelector((state: RootState) => state.controls.showTreeToo);
   const canTogglePanelLayout = useSelector((state: RootState) => state.controls.canTogglePanelLayout);
+  const branchLengthsToDisplay = useSelector((state: RootState) => state.controls.branchLengthsToDisplay);
 
   return (
     <ControlsContainer>
       <ChooseDataset />
 
-      <ControlHeader title={t("sidebar:Date Range")} tooltip={DateRangeInfo}/>
-      <DateRangeInputs />
-      <AnimationControls />
+      {branchLengthsToDisplay !== 'divOnly' &&
+        <>
+          <ControlHeader title={t("sidebar:Date Range")} tooltip={DateRangeInfo}/>
+          <DateRangeInputs />
+          <AnimationControls />
+        </>
+      }
 
       <ControlHeader title={t("sidebar:Color By")} tooltip={ColorByInfo}/>
       <ColorBy />
@@ -110,10 +115,12 @@ function Controls() {
         />
       }
 
-      <span style={{ marginTop: "10px" }}>
-        <ControlHeader title={t("sidebar:Animation Options")} tooltip={AnimationOptionsInfo}/>
-        <AnimationOptions />
-      </span>
+      {branchLengthsToDisplay !== "divOnly" &&
+        <span style={{ marginTop: "10px" }}>
+          <ControlHeader title={t("sidebar:Animation Options")} tooltip={AnimationOptionsInfo}/>
+          <AnimationOptions />
+        </span>
+      }
 
       {canTogglePanelLayout &&
         <>


### PR DESCRIPTION
## Description of proposed changes

Previously, the date/animation control components were hidden, but the headers were still shown in the side panel. This commit hides the entire section including the headers to reduce confusion.

Resolves https://github.com/nextstrain/auspice/issues/1833

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
