### PR TITLE
CI: Fail on ESLint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server": "npm run view",
     "build": "node auspice.js build --verbose",
     "prepare": "npm run build",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --fix .",
     "type-check": "tsc",
     "type-check:watch": "npm run type-check -- --watch",


### PR DESCRIPTION
## Description of proposed changes

Configure ESLint to fail on any number of warnings. This better surfaces warnings on PR checks.

I considered putting this in the ESLint config file (.eslintrc.yaml), however it cannot be configured there and there are no plans to support that behavior¹.

¹ https://github.com/eslint/eslint/issues/16804#issuecomment-1453380014

## Related issue(s)

Closes #1839

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Lint jobs fail as expected since #1838 is unmerged
- [x] ~If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR~ N/A
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ N/A
- [ ] Merge #1838

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
