### PR TITLE
Remove custom LBI color scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* Remove hardcoded color scale for LBI ([#1842](https://github.com/nextstrain/auspice/pull/1842))
 * Any `node_attr` in the tree can be used as a tip label, as well as the special-cases of strain-name and "none".
   Previously we only allowed valid colorings.
   ([#1668](https://github.com/nextstrain/auspice/pull/1668))

--- a/src/util/colorScale.js
+++ b/src/util/colorScale.js
@@ -223,12 +223,7 @@ function createOrdinalScale(colorBy, t1nodes, t2nodes) {
 
 function createContinuousScale(colorBy, providedScale, t1nodes, t2nodes) {
 
-  let minMax;
-  if (colorBy==="lbi") {
-    minMax = [0, 0.7]; /* TODO: this is for historical reasons, and we should switch to a provided scale */
-  } else {
-    minMax = getMinMaxFromTree(t1nodes, t2nodes, colorBy);
-  }
+  const minMax = getMinMaxFromTree(t1nodes, t2nodes, colorBy);
 
   /* user-defined anchor points across the scale */
   const anchorPoints = _validateAnchorPoints(providedScale, (val) => typeof val==="number");
@@ -244,19 +239,14 @@ function createContinuousScale(colorBy, providedScale, t1nodes, t2nodes) {
   }
   const scale = scaleLinear().domain(domain).range(range);
 
-  let legendValues;
-  if (colorBy==="lbi") {
-    /* TODO: this is for historical reasons, and we should switch to a provided scale */
-    legendValues = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7];
-  } else {
-    const spread = minMax[1] - minMax[0];
-    const dp = spread > 5 ? 2 : 3;
-    /* if legend values are identical (for the specified number of decimal places) then we
-    should filter them out */
-    legendValues = genericDomain
-      .map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)))
-      .filter((el, idx, values) => values.indexOf(el)===idx);
-  }
+  const spread = minMax[1] - minMax[0];
+  const dp = spread > 5 ? 2 : 3;
+  /* if legend values are identical (for the specified number of decimal places) then we
+  should filter them out */
+  const legendValues = genericDomain
+    .map((d) => parseFloat((minMax[0] + d*spread).toFixed(dp)))
+    .filter((el, idx, values) => values.indexOf(el)===idx);
+
   // Hack to avoid a bug: https://github.com/nextstrain/auspice/issues/540
   if (Object.is(legendValues[0], -0)) legendValues[0] = 0;
 


### PR DESCRIPTION
## Description of proposed changes

Closing an ancient TODO to remove the hardcoded color scale for LBI, since we can define custom scales now.

## Example

[See deployment of H3N2 HA tree colored by LBI](https://auspice-remove-lbi-colo-okn9h3.herokuapp.com/flu/seasonal/h3n2/ha/2y?c=lbi&d=tree&p=full).

## Related issue(s)

Closes #805

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
