### PR TITLE
Always show internal node name in branch modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 * Fix bug where drag-and-drop metadata columns were no longer included as tip labels ([#1845](https://github.com/nextstrain/auspice/pull/1845))
+* Fixed a bug where internal node names were sometimes omitted from the branch info modal (arrived at via shift-clicking on a branch).
+  They are now always displayed irrespective of the selected tip label.
+  ([#1849](https://github.com/nextstrain/auspice/pull/1849))
 
 ## version 2.57.0 - 2024/08/30
 

--- a/src/components/tree/infoPanels/click.js
+++ b/src/components/tree/infoPanels/click.js
@@ -259,7 +259,7 @@ const NodeClickedPanel = ({selectedNode, nodesLhsTree, nodesRhsTree, clearSelect
    * vs clicking on the tip (circle) itself */
   const isTerminal = !node.hasChildren;
   const isTip = !selectedNode.isBranch;
-  const shouldShowNodeName = tipLabelKey!==strainSymbol;
+  const shouldShowNodeName = tipLabelKey!==strainSymbol || !isTerminal;
 
   return (
     <div style={infoPanelStyles.modalContainer} onClick={() => clearSelectedNode(selectedNode)}>


### PR DESCRIPTION
This fixes a bug introduced in #1668 where the node name wouldn't be shown when the selected tip label is "Sample Name".

Closes #1847

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].
