### PR TITLE
Prevent concurrent workflow runs on the same PR

### DIFF
--- a/.github/workflows/preview_on_downstream_repo.yaml
+++ b/.github/workflows/preview_on_downstream_repo.yaml
@@ -13,9 +13,9 @@ on:
         required: true
         type: boolean
 
-# Cancel any in-progress runs of a caller workflow on the same branch.
+# Cancel any in-progress runs of a caller workflow on the same pull request.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Description of proposed changes

The previous concurrency key mostly did this, but did not consider that the PR's ref changes when a pull request is merged. In practice, this meant that closing/merging the PR shortly shortly after updating it would trigger two workflow runs. Only the latest run (cleanup) should continue.

## Related issue(s)

Follow-up to https://github.com/nextstrain/auspice/pull/1870#issuecomment-2427281169

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Test that this works by closing this PR shortly after opening it ([ref](https://github.com/nextstrain/auspice/pull/1873#issuecomment-2427286713))
- [x] ~If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR~
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
