### PR TITLE
Fix bug in narratives with filter changes

### DIFF
--- a/src/reducers/controls.ts
+++ b/src/reducers/controls.ts
@@ -110,8 +110,8 @@ export const getDefaultControlsState = () => {
     canRenderBranchLabels: true,
     analysisSlider: false,
     geoResolution: defaults.geoResolution,
-    filters: defaults.filters,
-    filtersInFooter: defaults.filtersInFooter,
+    filters: JSON.parse(JSON.stringify(defaults.filters)),
+    filtersInFooter: JSON.parse(JSON.stringify(defaults.filtersInFooter)),
     modal: null,
     quickdraw: false, // if true, components may skip expensive computes.
     mapAnimationDurationInMilliseconds: 30000, // in milliseconds


### PR DESCRIPTION
Noticed while debugging #1879. Minimal narrative to reproduce:

```md
---
title: Test narrative for bugs when changing filters during narratives
authors:
  - James Hadfield
dataset: "http://localhost:4000/flu/seasonal/h3n2/ha/2y?d=tree&f_clade_membership=2a.1"
date: October 2024
abstract:
    Opening page defines a filter query to clade 2a.1
---


# [Flu dataset (filtered)](http://localhost:4000/flu/seasonal/h3n2/ha/2y?d=tree&f_clade_membership=2a.1)

Initial slide (identical to title slide) is filtered to clade 2a.1


# [Flu dataset (no filters)](http://localhost:4000/flu/seasonal/h3n2/ha/2y?d=tree)

Tree should no longer be filtered. If you load this slide directly it's ok, but if you load the previous slide and move to this one the filter query is not applied.

Reason: When we constructed the initial controls state we essentially did

controls.defaults = {
    filters: {}
},
controls.filters = controls.defaults.filters

and thus changing the current filter would also change the default. For narratives we need to be able to reset the default state, and we ended up keeping the current state.
```