### PR TITLE
Autofix: When date range includes very-in-the-future dates, tree display is broken

### DIFF
--- a/src/actions/tree.js
+++ b/src/actions/tree.js
@@ -151,8 +151,8 @@ export const changeDateFilter = ({newMin = false, newMax = false, quickdraw = fa
     const { tree, treeToo, controls, frequencies } = getState();
     if (!tree.nodes) {return;}
     const dates = {
-      dateMinNumeric: newMin ? calendarToNumeric(newMin) : controls.dateMinNumeric,
-      dateMaxNumeric: newMax ? calendarToNumeric(newMax) : controls.dateMaxNumeric
+      dateMinNumeric: newMin ? calendarToNumeric(newMin) : Math.min(controls.dateMinNumeric, tree.nodesByNumDate[0][0]),
+      dateMaxNumeric: newMax ? calendarToNumeric(newMax) : Math.max(controls.dateMaxNumeric, tree.nodesByNumDate[tree.nodesByNumDate.length-1][0])
     };
     const data = calculateVisiblityAndBranchThickness(tree, controls, dates);
     const dispatchObj = {

--- a/src/reducers/controls.ts
+++ b/src/reducers/controls.ts
@@ -78,8 +78,8 @@ export const getDefaultControlsState = () => {
     defaults.sidebarOpen = initialSidebarState.sidebarOpen;
   }
 
-  const dateMin = numericToCalendar(currentNumDate() - defaultDateRange);
-  const dateMax = currentCalDate();
+  const dateMin = numericToCalendar(1900);
+  const dateMax = numericToCalendar(currentNumDate() + 100); // 100 years into the future
   const dateMinNumeric = calendarToNumeric(dateMin);
   const dateMaxNumeric = calendarToNumeric(dateMax);
   return {


### PR DESCRIPTION
Modify the getDefaultControlsState function to set a wider default date range and update the changeDateFilter action to handle extreme future dates. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    