### PR TITLE
Bugfix in Entropy panel when window resizes

### DIFF
--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -190,7 +190,7 @@ EntropyChart.prototype._setZoomCoordinates = function _setZoomCoordinates(overri
 
 EntropyChart.prototype._setSelectedNodes = function _setSelectedNodes() {
   this.selectedNodes = [];
-  if (!this.selectedPositions.length) return;
+  if (!this.selectedPositions.length || !this.bars) return;
   if (this.aa) { /*     P  R  O  T  E  I  N  S    */
     for (const node of this.bars) {
       for (const position of this.selectedPositions) {


### PR DESCRIPTION
The bug arose because window-resizes trigger a complete re-render of the entropy panel's SVG and this didn't correctly handle an edge case where the entropy data was stale (a concept introduced in #1879).

For specific steps to reproduce see <https://github.com/nextstrain/auspice/issues/1895#issuecomment-2471014837>

Closes #1895
