### PR TITLE
[bugfix] Restore shift-click branch behaviour

### DIFF
--- a/src/components/tree/phyloTree/types.ts
+++ b/src/components/tree/phyloTree/types.ts
@@ -35,7 +35,7 @@ export interface Regression {
 
 // ---------- Callbacks ---------- //
 
-type NodeCallback = (d: PhyloNode) => void
+type NodeCallback = (d: PhyloNode) => void // See <https://github.com/nextstrain/auspice/issues/1900> 
 
 export interface Callbacks {
   onBranchClick: NodeCallback

--- a/src/components/tree/reactD3Interface/callbacks.ts
+++ b/src/components/tree/reactD3Interface/callbacks.ts
@@ -61,7 +61,9 @@ export const onBranchClick = function onBranchClick(this: TreeComponent, d: Phyl
   if (this.props.narrativeMode) return;
 
   /* if a branch was clicked while holding the shift key, we instead display a node-clicked modal */
-  if (window.event instanceof KeyboardEvent && window.event.shiftKey) {
+  /* NOTE: window.event is deprecated, however the version of d3-selection we're using doesn't supply
+  the event as an argument */
+  if (window.event instanceof PointerEvent && window.event.shiftKey) {
     // no need to dispatch a filter action
     this.props.dispatch({type: SELECT_NODE, name: d.n.name, idx: d.n.arrayIdx, isBranch: true, treeId: d.that.id})
     return;


### PR DESCRIPTION
Clicking a branch while holding the shift-key should show an info modal.

Bisecting indicates that this regression occurred via

```console
25294e899be20256844e26cdfb5d6b550616b6eb is the first bad commit
commit 25294e899be20256844e26cdfb5d6b550616b6eb
Author: Victor Lin <13424970+victorlin@users.noreply.github.com>
Date:   Fri Oct 25 16:11:34 2024 -0700

    Properly check window.event.shiftKey

    Only KeyboardEvent has the shiftKey property.

 src/components/tree/reactD3Interface/callbacks.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

(See #1900 for a somewhat related bug discovered while fixing this.)
