### PR TITLE
Make icons change layout too [#1911]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Bugfix: Clicking on the icons for FULL and GRID layout now changes the layout, just like clicking on the text ([#1911](https://github.com/nextstrain/auspice/issues/1911))
+
 ## version 2.61.2 - 2024/11/19
 
 

--- a/src/components/controls/panel-layout.js
+++ b/src/components/controls/panel-layout.js
@@ -10,7 +10,8 @@ import { SidebarButton } from "./styles";
 const ButtonText = styled.span`
   margin: 5px;
   position: relative;
-  top: -1px;
+  left: 4px;
+  top: -6px;
 `;
 
 const PanelsFullIcon = withTheme(icons.PanelsFull);
@@ -27,7 +28,6 @@ class PanelLayouts extends React.Component {
 
     return (
       <div style={{marginTop: 0, marginBottom: 10}}>
-        <PanelsFullIcon width={22} selected={this.props.panelLayout === "full"}/>
         <SidebarButton
           selected={this.props.panelLayout === "full"}
           onClick={() => {
@@ -35,10 +35,10 @@ class PanelLayouts extends React.Component {
             this.props.dispatch({ type: CHANGE_PANEL_LAYOUT, data: "full" });
           }}
         >
+          <PanelsFullIcon width={22} selected={this.props.panelLayout === "full"}/>
           <ButtonText>{t("sidebar:full")}</ButtonText>
         </SidebarButton>
 
-        <PanelsGridIcon width={22} selected={this.props.panelLayout === "grid"}/>
         <SidebarButton
           selected={this.props.panelLayout === "grid"}
           onClick={() => {
@@ -46,9 +46,9 @@ class PanelLayouts extends React.Component {
             this.props.dispatch({ type: CHANGE_PANEL_LAYOUT, data: "grid" });
           }}
         >
+          <PanelsGridIcon width={22} selected={this.props.panelLayout === "grid"}/>
           <ButtonText>{t("sidebar:grid")}</ButtonText>
         </SidebarButton>
-
       </div>
     );
   }


### PR DESCRIPTION
## Description of proposed changes

This PR adds wrapping `<span>`s to the grid/full buttons in the layout sub-panel, so clicking the icons changes the layout, just like clicking the words. 

## Related issue(s)

Closes #1911

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
