### PR TITLE
Update entropy types

### DIFF
--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -2,8 +2,11 @@ import { genotypeColors } from "./globals";
 import { defaultEntropyState } from "../reducers/entropy";
 
 type JsonAnnotations = Record<string, JsonAnnotation>
+
 type Strand = '+' | '-' // other GFF-valid options are '.' and '?';
+
 type JsonSegmentRange = {start: number, end: number}; // Start is 1-based, End is 1-based closed (GFF)
+
 interface JsonAnnotation {
   /* Other properties are commonly set in the JSON structure, but the following are
   the only ones read by Auspice */
@@ -22,11 +25,13 @@ or defines the range of the genome (chromosome) itself.
 Start is always less than or equal to end. 
 Start is 1-based, End is 1-based closed. I.e. GFF. */
 type RangeGenome = [number, number];
+
 /* Same as RangeGenome but now relative to the nucleotides which make up the CDS
 (i.e. after slippage, splicing etc). The first CDS segment's RangeLocal will always
 start at 1, and the end value (of the last segment) corresponds to the number of nt in the CDS:
 range_segLast[1] - range_seg1[0] + 1 = 3 * number_of_amino_acids_in_translated_CDS */
 type RangeLocal = [number, number];
+
 type ChromosomeMetadata = {
   strandsObserved: Set<Strand>,
   posStrandStackHeight: number,
@@ -34,16 +39,19 @@ type ChromosomeMetadata = {
 }
 
 type GenomeAnnotation = Chromosome[];
+
 interface Chromosome {
   name: string;
   range: RangeGenome;
   genes: Gene[];
   metadata: ChromosomeMetadata
 }
+
 interface Gene {
   name: string;
   cds: CDS[];
 }
+
 interface CDS {
   length: number; /* length of the CDS in nucleotides. Will be a multiple of 3 */
   segments: CdsSegment[];
@@ -55,6 +63,7 @@ interface CDS {
   description?: string;
   stackPosition?: number;
 }
+
 interface CdsSegment {
   rangeLocal: RangeLocal;
   rangeGenome: RangeGenome;

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -48,8 +48,6 @@ interface ChromosomeMetadata {
   negStrandStackHeight: number
 }
 
-type GenomeAnnotation = Chromosome[]
-
 interface Chromosome {
   name: string
   range: RangeGenome
@@ -112,7 +110,7 @@ interface CdsSegment {
  * ¹ The exception being a single CDS which wraps around the origin, which we are able
  * to split into two segments here.
  */
-export const genomeMap = (annotations: JsonAnnotations): GenomeAnnotation => {
+export const genomeMap = (annotations: JsonAnnotations): Chromosome[] => {
 
   const nucAnnotation = Object.entries(annotations)
     .filter(([name,]) => name==='nuc')

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -5,13 +5,13 @@ type JsonAnnotations = Record<string, JsonAnnotation>
 
 type Strand = '+' | '-' // other GFF-valid options are '.' and '?';
 
-type JsonSegmentRange = {
+interface JsonSegmentRange {
   /** 1-based */
   start: number,
 
   /** 1-based closed (GFF) */
   end: number,
-};
+}
 
 interface JsonAnnotation {
   /* Other properties are commonly set in the JSON structure, but the following are
@@ -42,7 +42,7 @@ type RangeGenome = [number, number];
  */
 type RangeLocal = [number, number];
 
-type ChromosomeMetadata = {
+interface ChromosomeMetadata {
   strandsObserved: Set<Strand>,
   posStrandStackHeight: number,
   negStrandStackHeight: number,

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -130,8 +130,7 @@ export const genomeMap = (annotations: JsonAnnotations): Chromosome[] => {
     .map(([annotationKey, annotation]) => {
       const geneName = annotation.gene || annotationKey;
       if (!(geneName in annotationsPerGene)) annotationsPerGene[geneName] = {};
-      const gene = annotationsPerGene[geneName];
-      gene[annotationKey] = annotation;
+      annotationsPerGene[geneName][annotationKey] = annotation;
     })
 
   const nextColor = nextColorGenerator();

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -301,10 +301,10 @@ function cdsFromAnnotation(
     isWrapping: _isCdsWrapping(strand, segments),
     color: validColor(annotation.color) || defaultColor || '#000',
   }
-  if (typeof annotation.display_name === 'string') {
+  if (annotation.display_name !== undefined) {
     cds.displayName = annotation.display_name;
   }
-  if (typeof annotation.description === 'string') {
+  if (annotation.description !== undefined) {
     cds.description = annotation.description;
   }
   return cds

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -349,17 +349,16 @@ function _frame(
  */
 function calculateStackPosition(
   genes: Gene[],
-  strand: Strand | null = null,
+  strand: Strand,
 ): number {
   /* List of CDSs, sorted by their earliest occurrence in the genome (for any segment) */
-  let cdss = genes.reduce((acc: CDS[], gene) => [...acc, ...gene.cds], []);
-  if (strand) {
-    cdss = cdss.filter((cds) => cds.strand===strand);
-  }
-  cdss.sort((a, b) =>
-    Math.min(...a.segments.map((s) => s.rangeGenome[0])) < Math.min(...b.segments.map((s) => s.rangeGenome[0])) ?
-      -1 : 1
-  );
+  const cdss = genes
+    .reduce((acc: CDS[], gene) => [...acc, ...gene.cds], [])
+    .filter((cds) => cds.strand===strand)
+    .sort((a, b) =>
+      Math.min(...a.segments.map((s) => s.rangeGenome[0])) < Math.min(...b.segments.map((s) => s.rangeGenome[0])) ?
+        -1 : 1
+    );
   let stack: CDS[] = []; // current CDSs in stack
   for (const newCds of cdss) {
     /* remove any CDS from the stack which has ended (completely) before this one starts */

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -3,27 +3,27 @@ import { defaultEntropyState } from "../reducers/entropy";
 
 type JsonAnnotations = Record<string, JsonAnnotation>
 
-type Strand = '+' | '-' // other GFF-valid options are '.' and '?';
+type Strand = '+' | '-' // other GFF-valid options are '.' and '?'
 
 interface JsonSegmentRange {
   /** 1-based */
-  start: number,
+  start: number
 
   /** 1-based closed (GFF) */
-  end: number,
+  end: number
 }
 
 interface JsonAnnotation {
   /* Other properties are commonly set in the JSON structure, but the following are
   the only ones read by Auspice */
-  end?: number;
-  start?: number;
-  segments?: JsonSegmentRange[];
-  strand: Strand;
-  gene?: string;
-  color?: string;
-  display_name?: string;
-  description?: string;
+  end?: number
+  start?: number
+  segments?: JsonSegmentRange[]
+  strand: Strand
+  gene?: string
+  color?: string
+  display_name?: string
+  description?: string
 }
 
 /**
@@ -32,7 +32,7 @@ interface JsonAnnotation {
  * Start is always less than or equal to end. 
  * Start is 1-based, End is 1-based closed. I.e. GFF.
  */
-type RangeGenome = [number, number];
+type RangeGenome = [number, number]
 
 /**
  * Same as RangeGenome but now relative to the nucleotides which make up the CDS
@@ -40,39 +40,39 @@ type RangeGenome = [number, number];
  * start at 1, and the end value (of the last segment) corresponds to the number of nt in the CDS:
  * range_segLast[1] - range_seg1[0] + 1 = 3 * number_of_amino_acids_in_translated_CDS
  */
-type RangeLocal = [number, number];
+type RangeLocal = [number, number]
 
 interface ChromosomeMetadata {
-  strandsObserved: Set<Strand>,
-  posStrandStackHeight: number,
-  negStrandStackHeight: number,
+  strandsObserved: Set<Strand>
+  posStrandStackHeight: number
+  negStrandStackHeight: number
 }
 
-type GenomeAnnotation = Chromosome[];
+type GenomeAnnotation = Chromosome[]
 
 interface Chromosome {
-  name: string;
-  range: RangeGenome;
-  genes: Gene[];
+  name: string
+  range: RangeGenome
+  genes: Gene[]
   metadata: ChromosomeMetadata
 }
 
 interface Gene {
-  name: string;
-  cds: CDS[];
+  name: string
+  cds: CDS[]
 }
 
 interface CDS {
   /** length of the CDS in nucleotides. Will be a multiple of 3 */
-  length: number;
-  segments: CdsSegment[];
-  strand: Strand;
-  color: string;
-  name: string;
-  isWrapping: boolean;
-  displayName?: string;
-  description?: string;
-  stackPosition?: number;
+  length: number
+  segments: CdsSegment[]
+  strand: Strand
+  color: string
+  name: string
+  isWrapping: boolean
+  displayName?: string
+  description?: string
+  stackPosition?: number
 }
 
 type Phase = 0 | 1 | 2
@@ -80,17 +80,17 @@ type Phase = 0 | 1 | 2
 type Frame = 0 | 1 | 2
 
 interface CdsSegment {
-  rangeLocal: RangeLocal;
-  rangeGenome: RangeGenome;
+  rangeLocal: RangeLocal
+  rangeGenome: RangeGenome
 
   /** 1-based */
-  segmentNumber: number;
+  segmentNumber: number
 
   /** Indicates where the next codon begins relative to the 5' end of this segment */
-  phase: Phase;
+  phase: Phase
 
   /** The frame the codons are in, relative to the 5' end of the genome. It thus takes into account the phase */
-  frame: Frame;
+  frame: Frame
 }
 
 /**

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -2,8 +2,7 @@ import { genotypeColors } from "./globals";
 import { defaultEntropyState } from "../reducers/entropy";
 
 type JsonAnnotations = Record<string, JsonAnnotation>
-// enum Strand {'+', '-'} // other GFF-valid options are '.' and '?'
-type Strand = string;
+type Strand = '+' | '-' // other GFF-valid options are '.' and '?';
 type JsonSegmentRange = {start: number, end: number}; // Start is 1-based, End is 1-based closed (GFF)
 interface JsonAnnotation {
   /* Other properties are commonly set in the JSON structure, but the following are

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -167,7 +167,7 @@ export const entropyCreateState = (genomeAnnotations: JsonAnnotations) => {
 };
 
 
-function validColor(color:(string|undefined)) {
+function validColor(color: string | undefined) {
   if (!color) return false;
   return color; // TODO XXX
 }
@@ -183,7 +183,12 @@ function* nextColorGenerator() {
 /**
  * Returns a CDS object parsed from the provided JsonAnnotation block
  */
-function cdsFromAnnotation(cdsName: string, annotation: JsonAnnotation, rangeGenome: RangeGenome, defaultColor: (string|void)): CDS {
+function cdsFromAnnotation(
+  cdsName: string,
+  annotation: JsonAnnotation,
+  rangeGenome: RangeGenome,
+  defaultColor: string | void,
+): CDS {
   const invalidCds: CDS = {
     name: '__INVALID__',
     length: 0,
@@ -295,7 +300,13 @@ function cdsFromAnnotation(cdsName: string, annotation: JsonAnnotation, rangeGen
  * positiveStrand: boolean
  * Returns a number in the set {0, 1, 2}
  */
-function _frame(start:number, end:number, phase: number, genomeLength:number, positiveStrand:boolean) {
+function _frame(
+  start: number,
+  end: number,
+  phase:  number,
+  genomeLength: number,
+  positiveStrand: boolean,
+) {
   return positiveStrand ?
     (start+phase-1)%3 :
     Math.abs((end-phase-genomeLength)%3);
@@ -308,7 +319,10 @@ function _frame(start:number, end:number, phase: number, genomeLength:number, po
  * refers to this being a stacking problem.) The stack position starts at 1.
  * Returns the maximum position observed.
  */
-function calculateStackPosition(genes: Gene[], strand: (Strand|null) = null):number {
+function calculateStackPosition(
+  genes: Gene[],
+  strand: Strand | null = null,
+): number {
   /* List of CDSs, sorted by their earliest occurrence in the genome (for any segment) */
   let cdss = genes.reduce((acc: CDS[], gene) => [...acc, ...gene.cds], []);
   if (strand) {
@@ -358,7 +372,7 @@ function calculateStackPosition(genes: Gene[], strand: (Strand|null) = null):num
  * Given an array of sorted integers, if there are any spaces (starting with 1)
  * then return the value which can fill that space. Returns 0 if no spaces.
  */
-function _emptySlots(values: number[]):number {
+function _emptySlots(values: number[]): number {
   if ((values[0] || 0) > 1) return 1;
   for (let i=1; i<values.length; i++) {
     /* intermediate variables because of https://github.com/microsoft/TypeScript/issues/46253 */
@@ -373,7 +387,10 @@ function _emptySlots(values: number[]):number {
  * between-segment space of an existing segment, then return the stackPosition
  * of that existing CDS. Otherwise return 0;
  */
-function _fitCdssTogether(existing: CDS[], newCds: CDS):number {
+function _fitCdssTogether(
+  existing: CDS[],
+  newCds: CDS,
+): number {
   const a = Math.min(...newCds.segments.map((s) => s.rangeGenome[0]));
   const b = Math.max(...newCds.segments.map((s) => s.rangeGenome[1]));
   for (const cds of existing) {
@@ -408,7 +425,10 @@ function _fitCdssTogether(existing: CDS[], newCds: CDS):number {
 
 
 /* Does a CDS wrap the origin? */
-function _isCdsWrapping(strand: Strand, segments: CdsSegment[]): boolean {
+function _isCdsWrapping(
+  strand: Strand,
+  segments: CdsSegment[],
+): boolean {
   const positive = strand==='+';
   // segments ordered to guarantee rangeLocal will always be greater (than the previous segment)
   let prevSegment;

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -459,7 +459,7 @@ function _isCdsWrapping(
 ): boolean {
   const positive = strand==='+';
   // segments ordered to guarantee rangeLocal will always be greater (than the previous segment)
-  let prevSegment;
+  let prevSegment: CdsSegment;
   for (const segment of segments) {
     if (prevSegment) {
       if (positive && prevSegment.rangeGenome[0] > segment.rangeGenome[0]) {

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -19,7 +19,7 @@ interface JsonAnnotation {
   end?: number
   start?: number
   segments?: JsonSegmentRange[]
-  strand: Strand
+  strand?: Strand
   gene?: string
   color?: string
   display_name?: string
@@ -224,7 +224,7 @@ function cdsFromAnnotation(
      * which are represented by augur as '?' and null, respectively. (null comes from `None` in python.)
      * In both cases it's not a good idea to make an assumption of strandedness, or to assume it's even a CDS. */
     console.error(`[Genome annotation]  ${cdsName} has strand ` + 
-      (Object.prototype.hasOwnProperty.call(annotation, "strand") ? String(annotation.strand) : '(missing)') +
+      (annotation.strand !== undefined ? annotation.strand : '(missing)') +
       ". This CDS will be ignored.");
     return invalidCds;
   }


### PR DESCRIPTION
## Description of proposed changes

Updates TypeScript usage to be consistent with #1864, etc.

I thought of these changes after adding 6215591c49fc0c7b63065276bdc530b8bba5dd6a.

## Discussions

- [How to type unknown JSON inputs?](https://github.com/nextstrain/auspice/pull/1915#discussion_r1889284431)
- [Semicolons in interface definitions?](https://github.com/nextstrain/auspice/pull/1915#discussion_r1905857239)
- [Type cast value of `%3` operation `as Frame` or `as 0 | 1 | 2`?](https://github.com/nextstrain/auspice/pull/1915#discussion_r1905865269)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR~
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
