### PR TITLE
Ignore Nextstrain citation link for linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,8 @@ linkcheck_ignore = [
      # we have links to localhost for explanatory purposes; obviously
      # they will never work in the linkchecker
      r'^http://localhost:\d+',
+     # This URL will fail and return 403 (broken).
+     r'^https://academic\.oup\.com/bioinformatics/article/34/23/4121/5001388',
 ]
 linkcheck_anchors_ignore_for_url = [
      # Github uses anchor-looking links for highlighting lines but


### PR DESCRIPTION
This link has started returning 403 consistently.
<https://github.com/nextstrain/auspice/actions/runs/12242746997/job/34150982036#step:10:24>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
