### PR TITLE
eslint: Remove enforcement of operator-linebreak

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -40,7 +40,6 @@ rules:
   # Code style rules
   arrow-parens: ["error", "always"]
   no-unneeded-ternary: ["error", { "defaultAssignment": true }]
-  operator-linebreak: ["error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }]
   quote-props: ["error", "as-needed"]
 
 parserOptions:


### PR DESCRIPTION
## Description of proposed changes

Developers should be free to choose whatever linebreak style they wish.

<https://eslint.org/docs/latest/rules/operator-linebreak>

## Related issue(s)

Follow-up to https://github.com/nextstrain/nextstrain.org/pull/1076#discussion_r1842762650

## Checklist

N/A