### PR TITLE
Support build avatars sourced from non-GitHub URLs #1441

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -755,6 +755,9 @@ const createMetadataStateFromJSON = (json) => {
   if (json.meta.build_url) {
     metadata.buildUrl = json.meta.build_url;
   }
+  if (json.meta.build_avatar) {
+    metadata.buildAvatar = json.meta.build_avatar;
+  }
   if (json.meta.data_provenance) {
     metadata.dataProvenance = json.meta.data_provenance;
   }

--- a/src/components/info/byline.js
+++ b/src/components/info/byline.js
@@ -39,9 +39,14 @@ const AvatarImg = styled.img`
  * which is a GitHub repo. The avatar image is fetched from GitHub (by the client).
  */
 function renderAvatar(t, metadata) {
-  const repo = metadata.buildUrl;
-  if (typeof repo === 'string') {
-    const match = repo.match(/(https?:\/\/)?(www\.)?github.com\/([^/]+)/);
+  const { buildAvatar, buildUrl } = metadata;
+  // If buildAvatar is present, return the avatar image
+  if (buildAvatar) {
+    return <AvatarImg alt="avatar" width="28" src={buildAvatar} />;
+  }
+
+  if (typeof buildUrl === 'string') {
+    const match = buildUrl.match(/(https?:\/\/)?(www\.)?github.com\/([^/]+)/);
     if (match) {
       return (
         <AvatarImg alt="avatar" width="28" src={`https://github.com/${match[3]}.png?size=200`}/>


### PR DESCRIPTION
## Description of proposed changes
Users will now be able to define a path to a custom avatar that is not hosted on GitHub through the config file. 

## Related issue(s)
Related Issue: #1441 

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
