### PR TITLE
Reset layout when nucleotide position is selected

### DIFF
--- a/src/actions/entropy.js
+++ b/src/actions/entropy.js
@@ -69,9 +69,6 @@ export const changeEntropyCdsSelection = (arg) => (dispatch, getState) => {
   if (!entropy.loaded) return;
 
   if (arg === nucleotide_gene) {
-    if (entropy.selectedCds === nucleotide_gene) {
-      return
-    }
     action.selectedCds = arg;
     action.selectedPositions = [];
   } else if (typeof arg === 'string') {

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -147,9 +147,8 @@ class Entropy extends React.Component {
                 zoomMin: this.state.chart.zoomBounds[0],
                 zoomMax: this.state.chart.zoomBounds[1],
               })
-            } else {
-              this.props.dispatch(changeEntropyCdsSelection(nucleotide_gene));
             }
+            this.props.dispatch(changeEntropyCdsSelection(nucleotide_gene));
           }}
         >
           <span style={styles.switchTitle}> {'RESET LAYOUT'} </span>


### PR DESCRIPTION
## Description of proposed changes

Previously, this did not work because the dispatch to reset layout was conditional on having a CDS selected.

## Related issue(s)

Closes #1774

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
