### PR TITLE
Conditionally disable reset layout button

### DIFF
--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -72,11 +72,6 @@ const getStyles = (width) => {
     loaded: state.entropy.loaded,
     onScreen: state.entropy.onScreen,
     colorBy: state.controls.colorBy,
-    /**
-     * Note that zoomMin & zoomMax only represent the state when changed by a URL
-     * i.e. on dataset load or narrative page change. As such, they fall out-of-sync
-     * as soon as any user-zooming is performed.
-     */
     zoomMin: state.controls.zoomMin,
     zoomMax: state.controls.zoomMax,
     defaultColorBy: state.controls.defaults.colorBy,
@@ -131,10 +126,7 @@ class Entropy extends React.Component {
     const viewingGenome = this.props.selectedCds===nucleotide_gene;
     /**
      * The intention for this button is to be inactive when viewing the genome &
-     * fully zoomed out, however zoom actions do not trigger redux state changes
-     * which would be necessary for this (see comment in @connect decorator
-     * above). Once we fix that it is simple to conditionally inactivate this
-     * button.
+     * fully zoomed out.
      */
     return (
       <div style={{...tabGroup, ...styles.resetLayout}}>

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -129,23 +129,21 @@ class Entropy extends React.Component {
      * fully zoomed out.
      */
     return (
-      <div style={{...tabGroup, ...styles.resetLayout}}>
-        <button
-          key={1}
-          style={tabGroupMember}
-          onClick={() => {
-            if (viewingGenome) {
-              this.state.chart.update({
-                zoomMin: this.state.chart.zoomBounds[0],
-                zoomMax: this.state.chart.zoomBounds[1],
-              })
-            }
-            this.props.dispatch(changeEntropyCdsSelection(nucleotide_gene));
-          }}
-        >
-          <span style={styles.switchTitle}> {'RESET LAYOUT'} </span>
-        </button>
-      </div>
+      <button
+        key={1}
+        style={{...tabSingle, ...styles.resetLayout}}
+        onClick={() => {
+          if (viewingGenome) {
+            this.state.chart.update({
+              zoomMin: this.state.chart.zoomBounds[0],
+              zoomMax: this.state.chart.zoomBounds[1],
+            })
+          }
+          this.props.dispatch(changeEntropyCdsSelection(nucleotide_gene));
+        }}
+      >
+        <span style={styles.switchTitle}> {'RESET LAYOUT'} </span>
+      </button>
     );
   }
   entropyCountSwitch(styles) {

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -8,7 +8,7 @@ import { FaInfoCircle } from "react-icons/fa";
 import { isEqual } from 'lodash';
 import Card from "../framework/card";
 import { changeColorBy } from "../../actions/colors";
-import { tabGroup, tabGroupMember, tabGroupMemberSelected } from "../../globalStyles";
+import { tabGroup, tabGroupMember, tabGroupMemberSelected, tabSingle, darkGrey, lightGrey } from "../../globalStyles";
 import EntropyChart from "./entropyD3";
 import InfoPanel from "./infoPanel";
 import { changeEntropyCdsSelection, showCountsNotEntropy } from "../../actions/entropy";
@@ -20,46 +20,6 @@ import { getCdsByName, calcEntropyInView } from "../../util/entropy";
 import { StyledTooltip } from "../controls/styles";
 import "../../css/entropy.css";
 
-
-const getStyles = (width) => {
-  return {
-    switchContainer: {
-      position: "absolute",
-      marginTop: -5,
-      paddingLeft: width - 100
-    },
-    switchContainerWide: {
-      position: "absolute",
-      marginTop: -25,
-      paddingLeft: width - 185
-    },
-    switchTitle: {
-      margin: 5,
-      position: "relative",
-      top: -1
-    },
-    resetLayout: {
-      position: "absolute",
-      right: 190,
-      top: 0,
-      zIndex: 100
-    },
-    entropyCountSwitch: {
-      position: "absolute",
-      right: 50,
-      top: 0,
-      zIndex: 100
-    },
-    helpIcon: {
-      position: "absolute",
-      right: 25,
-      top: 3,
-      fontSize: '16px', // controls icon size
-      cursor: 'help',
-      color: '#888'
-    }
-  };
-};
 
 @connect((state) => {
   return {
@@ -133,6 +93,9 @@ class Entropy extends React.Component {
         key={1}
         style={{...tabSingle, ...styles.resetLayout}}
         onClick={() => {
+          if (!this.isZoomed()) {
+            return;
+          }
           if (viewingGenome) {
             this.state.chart.update({
               zoomMin: this.state.chart.zoomBounds[0],
@@ -266,8 +229,65 @@ class Entropy extends React.Component {
     return `Amino acid diversity of CDS ${this.props.selectedCds.name}`
   }
 
+  getStyles() {
+    const zoomed = this.isZoomed();
+
+    return {
+      switchContainer: {
+        position: "absolute",
+        marginTop: -5,
+        paddingLeft: this.props.width - 100
+      },
+      switchContainerWide: {
+        position: "absolute",
+        marginTop: -25,
+        paddingLeft: this.props.width - 185
+      },
+      switchTitle: {
+        margin: 5,
+        position: "relative",
+        top: -1
+      },
+      resetLayout: {
+        position: "absolute",
+        right: 190,
+        top: 0,
+        zIndex: 100,
+        cursor: zoomed ? "pointer" : "auto",
+        color: zoomed ? darkGrey : lightGrey
+      },
+      entropyCountSwitch: {
+        position: "absolute",
+        right: 50,
+        top: 0,
+        zIndex: 100
+      },
+      helpIcon: {
+        position: "absolute",
+        right: 25,
+        top: 3,
+        fontSize: '16px', // controls icon size
+        cursor: 'help',
+        color: '#888'
+      }
+    };
+  };
+
+  isZoomed() {
+    return (
+      (this.props.selectedCds != nucleotide_gene) ||
+      (this.state.chart.zoomBounds && this.props.zoomMin != this.state.chart.zoomBounds[0]) ||
+      (this.state.chart.zoomBounds && this.props.zoomMax != this.state.chart.zoomBounds[1])
+    );
+  }
+
   render() {
-    const styles = getStyles(this.props.width);
+    const zoomed = (
+      (this.props.selectedCds != nucleotide_gene) ||
+      (this.state.chart.zoomBounds && this.props.zoomMin != this.state.chart.zoomBounds[0]) ||
+      (this.state.chart.zoomBounds && this.props.zoomMax != this.state.chart.zoomBounds[1])
+    );
+    const styles = this.getStyles();
     return (
       <Card infocard={this.props.showOnlyPanels} title={this.title()}>
         <InfoPanel d3event={this.state.hovered.d3event} width={this.props.width} height={this.props.height}>

--- a/src/reducers/controls.ts
+++ b/src/reducers/controls.ts
@@ -512,15 +512,8 @@ const Controls = (state: ControlsState = getDefaultControlsState(), action): Con
     case types.TOGGLE_MEASUREMENTS_THRESHOLD: // fallthrough
     case types.APPLY_MEASUREMENTS_FILTER:
       return {...state, ...action.controls};
-    /**
-     * Currently the CHANGE_ZOOM action (entropy panel zoom changed) does not
-     * update the zoomMin/zoomMax, and as such they only represent the initially
-     * requested zoom range. The following commented out code will keep the
-     * state in sync, but corresponding changes will be  required to the entropy
-     * code.
-     */
-    // case types.CHANGE_ZOOM: // this is the entropy panel zoom
-    //   return {...state, zoomMin: action.zoomc[0], zoomMax: action.zoomc[1]};
+    case types.CHANGE_ZOOM: // this is the entropy panel zoom
+      return {...state, zoomMin: action.zoomc[0], zoomMax: action.zoomc[1]};
     default:
       return state;
   }


### PR DESCRIPTION
## Description of proposed changes

Render this button useless when the view is not zoomed.

## Related issue(s)

Follow-up to https://github.com/nextstrain/auspice/pull/1684#issuecomment-1681955133

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].
- [ ] Merge base PR #1947 

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
