### PR TITLE
JSON-definable zoom label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * **Streamtrees** are a new visualisation option for displaying phylogenetic trees. They require datasets with labels on internal nodes which we essentially use to partition the nodes of the tree and render each partition as a streamgraph. Such visualisations are useful for conveying relationships between parts of the tree as well as improving performance for very large trees. See the [added documentation](https://docs.nextstrain.org/projects/auspice/en/stable/advanced-functionality/streamtrees.html) for more details. ([#1902](https://github.com/nextstrain/auspice/issues/1902))
 
+* Label URL queries (available when zoomed into a node which has an branch label) are now added in more cases and, when loading the page, we now remove the query if it is not valid. ([#1952](https://github.com/nextstrain/auspice/pull/1952))
+* Datasets can define `display_defaults.label` to specify the starting zoom level of a tree, similarly to the `?label=...` URL query. ([#1952](https://github.com/nextstrain/auspice/pull/1952))
+* The tree's "Reset Layout" button has been renamed "Zoom to Root". ([#1952](https://github.com/nextstrain/auspice/pull/1952))
 * Removed the experimental markers from "Focus on selected" and "Explode Tree By" options. These seem to be working well. ([#1954](https://github.com/nextstrain/auspice/issues/1954))
 * Added Chinese language support. ([#1959](https://github.com/nextstrain/auspice/pull/1959))
 * Added flexibility to the way the "Built with …" sentence can be translated. ([#1964](https://github.com/nextstrain/auspice/pull/1964))

--- a/docs/advanced-functionality/view-settings.rst
+++ b/docs/advanced-functionality/view-settings.rst
@@ -51,6 +51,8 @@ These are exported as the (optional) property of the dataset JSON ``meta.display
 +---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
 | ``language``              | Language to display Auspice in                                        | "ja"                                               |
 +---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
+| ``label``                 | Labelled branch that tree starts zoomed to                            | "Sublineage:J" or "clade:2a.3a"                    |
++---------------------------+-----------------------------------------------------------------------+----------------------------------------------------+
 
 Note that ``meta.display_defaults.panels`` (optional) differs from ``meta.panels`` (required), where the latter lists the possible panels that auspice may display for the dataset. See the `JSON schema <https://github.com/nextstrain/augur/blob/master/augur/data/schema-export-v2.json>`__ for more details.
 

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -719,10 +719,8 @@ const modifyTreeStateVisAndBranchThickness = (oldState, zoomSelected, controlsSt
   if (zoomSelected) {
     const [labelName, labelValue] = zoomSelected.split(":");
     const cladeSelectedIdx = getIdxMatchingLabel(oldState.nodes, labelName, labelValue, dispatch);
-    oldState.selectedClade = zoomSelected;
     newIdxRoot = applyInViewNodesToTree(cladeSelectedIdx, oldState);
   } else {
-    oldState.selectedClade = undefined;
     newIdxRoot = applyInViewNodesToTree(0, oldState);
   }
 

--- a/src/actions/tree.ts
+++ b/src/actions/tree.ts
@@ -77,7 +77,6 @@ export const applyInViewNodesToTree = (
  */
 export const updateVisibleTipsAndBranchThicknesses = ({
   root = [undefined, undefined],
-  urlQueryLabel = undefined,
 }: {
   /**
    * Change the in-view part of the tree.
@@ -85,11 +84,6 @@ export const updateVisibleTipsAndBranchThicknesses = ({
    * [0, 0]: reset. [undefined, undefined]: do nothing
    */
   root?: Root
-
-  /**
-   * URL query label (i.e. `?label=${urlQueryLabel}`)
-   */
-  urlQueryLabel?: string
 } = {}
 ): ThunkFunction => {
   return (dispatch, getState) => {
@@ -113,7 +107,6 @@ export const updateVisibleTipsAndBranchThicknesses = ({
       branchThicknessVersion: data.branchThicknessVersion,
       idxOfInViewRootNode: rootIdxTree1,
       idxOfFilteredRoot: data.idxOfFilteredRoot,
-      urlQueryLabel,
     };
 
     if (controls.showTreeToo) {

--- a/src/actions/tree.ts
+++ b/src/actions/tree.ts
@@ -77,7 +77,7 @@ export const applyInViewNodesToTree = (
  */
 export const updateVisibleTipsAndBranchThicknesses = ({
   root = [undefined, undefined],
-  cladeSelected = undefined,
+  urlQueryLabel = undefined,
 }: {
   /**
    * Change the in-view part of the tree.
@@ -86,16 +86,15 @@ export const updateVisibleTipsAndBranchThicknesses = ({
    */
   root?: Root
 
-  cladeSelected?: string
+  /**
+   * URL query label (i.e. `?label=${urlQueryLabel}`)
+   */
+  urlQueryLabel?: string
 } = {}
 ): ThunkFunction => {
   return (dispatch, getState) => {
     const { tree, treeToo, controls, frequencies } = getState();
-    if (root[0] === undefined && !cladeSelected && tree.selectedClade) {
-      /* if not resetting tree to root, maintain previous selectedClade if one exists */
-      cladeSelected = tree.selectedClade;
-    }
-
+  
     if (!tree.nodes) {return;}
     // console.log("ROOT SETTING TO", root)
     /* mark nodes as "in view" as applicable */
@@ -114,8 +113,7 @@ export const updateVisibleTipsAndBranchThicknesses = ({
       branchThicknessVersion: data.branchThicknessVersion,
       idxOfInViewRootNode: rootIdxTree1,
       idxOfFilteredRoot: data.idxOfFilteredRoot,
-      cladeName: cladeSelected,
-      selectedClade: cladeSelected,
+      urlQueryLabel,
     };
 
     if (controls.showTreeToo) {

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -152,7 +152,7 @@ class Entropy extends React.Component {
             }
           }}
         >
-          <span style={styles.switchTitle}> {'RESET LAYOUT'} </span>
+          <span style={styles.switchTitle}> {this.props.t('Reset Layout')} </span>
         </button>
       </div>
     );

--- a/src/components/info/filtersSummary.js
+++ b/src/components/info/filtersSummary.js
@@ -35,7 +35,6 @@ const closeBracketSmall = <span style={{fontSize: "1.8rem", fontWeight: 300, pad
     totalStateCounts: state.tree.totalStateCounts,
     totalStateCountsSecondTree: state.treeToo?.totalStateCounts,
     visibility: state.tree.visibility,
-    selectedClade: state.tree.selectedClade,
     dateMin: state.controls.dateMin,
     dateMax: state.controls.dateMax,
     absoluteDateMin: state.controls.absoluteDateMin,

--- a/src/components/tree/reactD3Interface/callbacks.ts
+++ b/src/components/tree/reactD3Interface/callbacks.ts
@@ -4,7 +4,6 @@ import { NODE_VISIBLE, strainSymbol } from "../../../util/globals";
 import { getDomId, getParentBeyondPolytomy, getIdxOfInViewRootNode } from "../phyloTree/helpers";
 import { branchStrokeForHover, branchStrokeForLeave, LabelDatum, nonHoveredRippleOpacity } from "../phyloTree/renderers";
 import { PhyloNode } from "../phyloTree/types";
-import { ReduxNode, TreeState} from "../../../reducers/tree/types";
 import { SELECT_NODE, DESELECT_NODE } from "../../../actions/types";
 import { SelectedNode } from "../../../reducers/controls";
 import { TreeComponent } from "../tree";
@@ -82,10 +81,8 @@ export const onBranchClick = function onBranchClick(this: TreeComponent, d: Phyl
     const parentStreamName = this.props.tree.streams[d.n.streamName].parentStreamName;
     if (parentStreamName) { // if this is false we are zooming back into the "normal" tree, so use the non-stream-tree code path
       const parentStreamIndex = this.props.tree.streams[parentStreamName].startNode
-      const parentStreamNode = d.that.nodes[parentStreamIndex].n;``
       return this.props.dispatch(updateVisibleTipsAndBranchThicknesses({
         root: [parentStreamIndex, undefined],
-        urlQueryLabel: computeUrlQueryLabel(parentStreamNode, this.props.tree.availableBranchLabels)
       }));
     }
   }
@@ -97,35 +94,8 @@ export const onBranchClick = function onBranchClick(this: TreeComponent, d: Phyl
     d.n.arrayIdx; 
   const root: Root = LHSTree ? [arrayIdxToZoomTo, undefined] : [undefined, arrayIdxToZoomTo];
   /* clade selected (as used in the URL query) is only designed to work for the main tree, not the RHS tree */
-  const newZoomNode = zoomBackwards ? d.that.nodes[arrayIdxToZoomTo].n : d.n;
-  const urlQueryLabel = LHSTree ? computeUrlQueryLabel(newZoomNode, this.props.tree.availableBranchLabels) : undefined;
-  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root, urlQueryLabel}));
+  this.props.dispatch(updateVisibleTipsAndBranchThicknesses({root}));
 };
-
-/**
- * Scan the branch labels associated with the node *n* and if an appropriate one
- * exists then we want to set this as the branch label query. Branches with
- * multiple labels will be used in the order specified by *availableBranchLabels*
- * (i.e. the order of the drop-down on the menu)
- */
-function computeUrlQueryLabel(
-  n: ReduxNode,
-  availableBranchLabels: TreeState["availableBranchLabels"]
-): string | undefined {
-  let urlQueryLabel: string | undefined;
-  if (n.branch_attrs && n.branch_attrs.labels !== undefined) {
-    const legalBranchLabels: string[] = Object.keys(n.branch_attrs.labels)
-      // don't use AA mutations as zoom labels currently (the URL is ugly and there will be too many non-unique labels)
-      .filter((label) => label !== "aa")
-      // sort the possible branch labels by the order of those available on the tree
-      .sort((a, b) => availableBranchLabels.indexOf(a) - availableBranchLabels.indexOf(b));
-    if (legalBranchLabels.length) {
-      const key = legalBranchLabels[0]; // use the first one (if multiple)
-      urlQueryLabel = `${key}:${n.branch_attrs.labels[key]}`;
-    }
-  }
-  return urlQueryLabel;
-}
 
 
 /* onBranchLeave called when mouse-off, i.e. anti-hover */

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -305,7 +305,7 @@ export class TreeComponent extends React.Component<TreeComponentProps, TreeCompo
               style={{...tabSingle, ...styles.resetTreeButton}}
               onClick={this.redrawTree}
             >
-              {t("Reset Layout")}
+              {t("Zoom to Root")}
             </button>
           </div>
         )}

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "التنوع",
+  "Reset Layout": "إعادة تعيين التصميم",
   "entropy": "الانتروبيا",
   "events": "الأحداث",
   "Codon {{codon}} in protein {{protein}}": "شيفرة جينية {{codon}} في البروتين {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "شجرة تطور السلالات",
-  "Reset Layout": "إعادة تعيين التصميم",
   "Click on tip to display more info": "انقر على النصيحة لعرض المزيد من المعلومات",
   "Click to zoom into clade": "انقر لتكبير الفرع الحيوي",
   "Click to zoom out to parent clade": "انقر لتكبير سلف الفرع الحيوي ",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversität",
+  "Reset Layout": "Ansicht zurücksetzen",
   "entropy": "Entropie",
   "events": "Ereignisse",
   "Codon {{codon}} in protein {{protein}}": "Kodon {{codon}} in Protein {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Phylogenese",
-  "Reset Layout": "Ansicht zurücksetzen",
   "Click on tip to display more info": "Klicken, um mehr Informationen anzuzeigen",
   "Click to zoom into clade": "Klicken, um in die Klade einzuzoomen",
   "Branch leading to": "Ast führt zu",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -53,6 +53,7 @@
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Phylogeny",
   "Reset Layout": "Reset Layout",
+  "Zoom to Root": "Zoom to Root",
   "Zoom to Selected": "Zoom to Selected",
   "Click on tip to display more info": "Click on tip to display more info",
   "Click to zoom into clade": "Click to zoom into clade",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversity",
+  "Reset Layout": "Reset Layout",
   "entropy": "entropy",
   "events": "events",
   "Codon {{codon}} in protein {{protein}}": "Codon {{codon}} in protein {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Phylogeny",
-  "Reset Layout": "Reset Layout",
   "Zoom to Root": "Zoom to Root",
   "Zoom to Selected": "Zoom to Selected",
   "Click on tip to display more info": "Click on tip to display more info",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -53,6 +53,7 @@
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Phylogeny",
   "Reset Layout": "Reset Layout",
+  "Zoom to Selected": "Zoom to Selected",
   "Click on tip to display more info": "Click on tip to display more info",
   "Click to zoom into clade": "Click to zoom into clade",
   "Click to zoom out to parent clade": "Click to zoom out to parent clade",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversidad",
+  "Reset Layout": "Regresar al diseño original",
   "entropy": "entropía",
   "events": "eventos",
   "Codon {{codon}} in protein {{protein}}": "Codón {{codon}} en proteína {{protein}}",
@@ -50,7 +51,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Filogenia",
-  "Reset Layout": "Regresar al diseño original",
   "Click on tip to display more info": "Haz clic en la punta del árbol para más información",
   "Click to zoom into clade": "Haga clic para enfocarse en el clado",
   "Branch leading to": "Rama que conduce a",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversité",
+  "Reset Layout": "Réinitialiser la disposition",
   "entropy": "entropie",
   "events": "événements",
   "Codon {{codon}} in protein {{protein}}": "Codon {{codon}} en protéine {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Phylogénie",
-  "Reset Layout": "Réinitialiser la disposition",
   "Click on tip to display more info": "Cliquez sur la pointe de l'arbre pour plus d'informations",
   "Click to zoom into clade": "Cliquez pour agrandir le clade",
   "Click to zoom out to parent clade": "Cliquez pour effectuer un zoom arrière sur le clade parent",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -26,6 +26,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversità",
+  "Reset Layout": "Ripristina layout",
   "entropy": "entropia",
   "events": "eventi",
   "Codon {{codon}} in protein {{protein}}": "Codone {{codon}} nella proteina {{protein}}",
@@ -53,7 +54,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Filogenesi",
-  "Reset Layout": "Ripristina layout",
   "Click on tip to display more info": "Clicca sulla punta dell'albero per ulteriori informazioni",
   "Click to zoom into clade": "Clicca per ingrandire il clade",
   "Click to zoom out to parent clade": "Clicca per rimpicciolire al clade genitore",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "多様性",
+  "Reset Layout": "レイアウトをリセット",
   "entropy": "エントロピー",
   "events": "イベント",
   "Codon {{codon}} in protein {{protein}}": "タンパク質 {{protein}} に含まれるコドン {{codon}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "発生系統",
-  "Reset Layout": "レイアウトをリセット",
   "Click on tip to display more info": "詳細を表示するには吹き出しをクリック",
   "Click to zoom into clade": "クリックして分岐群へズーム",
   "Click to zoom out to parent clade": "親の分岐群にズームアウトするにはクリック",

--- a/src/locales/lt/translation.json
+++ b/src/locales/lt/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Įvairovė",
+  "Reset Layout": "Atstatyti Išdėstymą",
   "entropy": "entropija",
   "events": "įvykiai",
   "Codon {{codon}} in protein {{protein}}": "Kodonas {{codon}} iš {{protein}} baltymo",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Filogenetinis medis",
-  "Reset Layout": "Atstatyti Išdėstymą",
   "Click on tip to display more info": "Norėdami pamatyti daugiau informacijos paspauskite ant galiuko",
   "Click to zoom into clade": "Paspauskite pritraukti visą monofiletinę grupę",
   "Click to zoom out to parent clade": "Paspauskite pritraukti motininę monofiletinę grupę",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Różnorodność",
+  "Reset Layout": "Resetuj układ",
   "entropy": "entropia",
   "events": "zdarzenia",
   "Codon {{codon}} in protein {{protein}}": "Kodon {{codon}} w białku {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Analiza filogenetyczna",
-  "Reset Layout": "Resetuj układ",
   "Click on tip to display more info": "Kliknij wskazówkę, aby wyświetlić więcej informacji",
   "Click to zoom into clade": "Kliknij, aby powiększyć klad",
   "Click to zoom out to parent clade": "Kliknij, aby pomniejszyć do widoku kladu macierzystego",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Diversidade",
+  "Reset Layout": "Voltar ao design original",
   "entropy": "entropia",
   "events": "eventos",
   "Codon {{codon}} in protein {{protein}}": "Códão {{codon}} em proteína {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Filogenia",
-  "Reset Layout": "Voltar ao design original",
   "Click on tip to display more info": "Clique na dica para exibir mais informações",
   "Click to zoom into clade": "Clique para focar no clado",
   "Click to zoom out to parent clade": "Clique para diminuir o zoom do clado pai ",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Разновидность",
+  "Reset Layout": "Сбросить Чертеж",
   "entropy": "энтропия",
   "events": "события",
   "Codon {{codon}} in protein {{protein}}": "Кодон {{codon}} в белке {{protein}}",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Филогенез",
-  "Reset Layout": "Сбросить Чертеж",
   "Click on tip to display more info": "Нажмите на подсказку чтобы посмотреть детали",
   "Click to zoom into clade": "Нажмите чтобы приблизить филогенетическую ветвь",
   "Branch leading to": "Ветвь ведущая к",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -24,6 +24,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "Çeşitlilik",
+  "Reset Layout": "Görünümü Sıfırla",
   "entropy": "entropi",
   "events": "olaylar",
   "Codon {{codon}} in protein {{protein}}": "{{protein}} proteinindeki {{codon}} kodon",
@@ -51,7 +52,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "Filogeni",
-  "Reset Layout": "Görünümü Sıfırla",
   "Click on tip to display more info": "Daha çok bilgi göstermek için uca tıklayın",
   "Click to zoom into clade": "Dala yaklaşmak için tıklayın",
   "Click to zoom out to parent clade": "Ata dalına uzaklaşmak için tıklayın",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -25,6 +25,7 @@
 
   "__Entropy Panel__": "########################################",
   "Diversity": "多样性",
+  "Reset Layout": "重置布局",
   "entropy": "熵值",
   "events": "事件",
   "Codon {{codon}} in protein {{protein}}": "蛋白质{{protein}}的第{{codon}}个密码子",
@@ -52,7 +53,6 @@
 
   "__Tree (Phylogeny) panel__": "########################################",
   "Phylogeny": "系统发育树",
-  "Reset Layout": "重置布局",
   "Click on tip to display more info": "点击分支末端显示详细信息",
   "Click to zoom into clade": "点击放大进化枝",
   "Click to zoom out to parent clade": "点击缩回父进化枝",

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -186,7 +186,7 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS: {
-      query.label = action.cladeName ? action.cladeName : undefined;
+      query.label = action.urlQueryLabel;
       break;
     }
     case types.MAP_ANIMATION_PLAY_PAUSE_BUTTON:

--- a/src/middleware/changeURL.js
+++ b/src/middleware/changeURL.js
@@ -1,6 +1,7 @@
 import queryString from "query-string";
 import * as types from "../actions/types";
 import { numericToCalendar } from "../util/dateHelpers";
+import { urlQueryLabel } from "../util/treeVisibilityHelpers";
 import { shouldDisplayTemporalConfidence } from "../reducers/controls";
 import { genotypeSymbol, nucleotide_gene, strainSymbol } from "../util/globals";
 import { encodeGenotypeFilters, decodeColorByGenotype, isColorByGenotype } from "../util/getGenotype";
@@ -186,7 +187,8 @@ export const changeURLMiddleware = (store) => (next) => (action) => {
       break;
     }
     case types.UPDATE_VISIBILITY_AND_BRANCH_THICKNESS: {
-      query.label = action.urlQueryLabel;
+      // NOTE: `idxOfInViewRootNode` refers to the left tree only (if 2 trees displayed)
+      query.label = urlQueryLabel(state.tree.nodes[action.idxOfInViewRootNode], state.tree.availableBranchLabels)
       break;
     }
     case types.MAP_ANIMATION_PLAY_PAUSE_BUTTON:

--- a/src/reducers/tree/index.ts
+++ b/src/reducers/tree/index.ts
@@ -24,7 +24,6 @@ export const getDefaultTreeState = (): TreeState | TreeTooState => {
     totalStateCounts: {},
     observedMutations: {},
     availableBranchLabels: [],
-    selectedClade: undefined,
     streams: {},
   };
 };
@@ -53,8 +52,6 @@ const Tree = (
         branchThicknessVersion: action.branchThicknessVersion,
         idxOfInViewRootNode: action.idxOfInViewRootNode,
         idxOfFilteredRoot: action.idxOfFilteredRoot,
-        cladeName: action.cladeName,
-        selectedClade: action.cladeName,
       };
       return {
         ...state,

--- a/src/reducers/tree/types.ts
+++ b/src/reducers/tree/types.ts
@@ -131,7 +131,6 @@ export interface TreeState {
   availableBranchLabels: string[]
   branchThickness: number[] | null
   branchThicknessVersion: number
-  cladeName?: string
   idxOfFilteredRoot?: number
   idxOfInViewRootNode: number
   loaded: boolean
@@ -141,7 +140,6 @@ export interface TreeState {
   nodeColorsVersion: number
   nodes: ReduxNode[] | null
   observedMutations: Mutations
-  selectedClade?: string
   tipRadii: number[] | null
   tipRadiiVersion: number
   hoveredLegendSwatch: string|number|false

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -60,6 +60,33 @@ export const getIdxMatchingLabel = (nodes, labelName, labelValue, dispatch) => {
   return found;
 };
 
+
+
+/**
+ * Scan the branch labels associated with the node *n* and if an appropriate one
+ * exists then we want to set this as the branch label query. Branches with
+ * multiple labels will be used in the order specified by *availableBranchLabels*
+ * (i.e. the order of the drop-down on the menu)
+ */
+export function urlQueryLabel(
+  n,
+  availableBranchLabels
+) {
+  if (n.branch_attrs && n.branch_attrs.labels !== undefined) {
+    const legalBranchLabels = Object.keys(n.branch_attrs.labels)
+      // don't use AA mutations as zoom labels currently (the URL is ugly and there will be too many non-unique labels)
+      .filter((label) => label !== "aa")
+      // sort the possible branch labels by the order of those available on the tree
+      .sort((a, b) => availableBranchLabels.indexOf(a) - availableBranchLabels.indexOf(b));
+    if (legalBranchLabels.length) {
+      const key = legalBranchLabels[0]; // use the first one (if multiple)
+      return `${key}:${n.branch_attrs.labels[key]}`;
+    }
+  }
+  return undefined
+}
+
+
 /** calcBranchThickness **
 * returns an array of node (branch) thicknesses based on the tipCount at each node
 * If the node isn't visible, the thickness is 1.

--- a/src/util/treeVisibilityHelpers.js
+++ b/src/util/treeVisibilityHelpers.js
@@ -23,11 +23,12 @@ export const strainNameToIdx = (nodes, name) => {
 
 /**
  * Find the node with the given label name & value
- * NOTE: if there are multiple nodes with the same label then the first encountered is returned
+ * NOTE: if there are multiple nodes with the same label then `null` is returned
+ * 
  * @param {Array} nodes tree nodes (flat)
  * @param {string} labelName label name
  * @param {string} labelValue label value
- * @returns {int} the index of the matching node (0 if no match found)
+ * @returns {int|null} the index of the matching node (0 if no match found)
  */
 export const getIdxMatchingLabel = (nodes, labelName, labelValue, dispatch) => {
   let i;
@@ -46,7 +47,7 @@ export const getIdxMatchingLabel = (nodes, labelName, labelValue, dispatch) => {
           message: "Specified Zoom Label Found Multiple Times!",
           details: "Multiple nodes in the tree are labelled '"+labelName+" "+labelValue+"' - no zoom performed"
         }));
-        return 0;
+        return null;
       }
     }
   }
@@ -56,6 +57,7 @@ export const getIdxMatchingLabel = (nodes, labelName, labelValue, dispatch) => {
       message: "Specified Zoom Label Value Not Found!",
       details: "The label '"+labelName+"' value '"+labelValue+"' was not found in the tree - no zoom performed"
     }));
+    return null;
   }
   return found;
 };


### PR DESCRIPTION
First three commits tidy up previous code and add some more error handling  & improved behaviour in edge cases. 

Fourth commit allows us to specify a `display_default.label` in the JSON which behaves the same as the URL query `label` we have had for a long time. There are two improvements which in the interest of time I'd like to leave as future to-dos, but I can fix them here if people think they'll be encountered sooner rather than later:

1. One side effect with defining a display default label is that you can't always specify a URL which will load the tree at the tree root. If there's a branch label on the root node then you can almost get there by "zooming" to the root node which will then set a 'label' URL query.

2. Also note that when interacting with the tree, zooming to the same label as the display default will set a URL query 'label', which differs from our typical handling of defaults where we would not set any URL query here.