### PR TITLE
[v3] [cli] Allow one or more positional path args

### DIFF
--- a/cli/develop.js
+++ b/cli/develop.js
@@ -5,11 +5,12 @@ const webpack = require("webpack");
 const webpackDevMiddleware = require("webpack-dev-middleware");
 const webpackHotMiddleware = require("webpack-hot-middleware");
 const utils = require("./utils");
-const { loadAndAddHandlers, serveRelativeFilepaths } = require("./view");
+const view = require("./view");
 const version = require('../src/version').version;
 const chalk = require('chalk');
 const generateWebpackConfig = require("../webpack.config.js").default;
 const SUPPRESS = require('argparse').Const.SUPPRESS;
+const { processPathArguments } = require("./server/processPaths");
 
 const addParser = (parser) => {
   const description = `Launch auspice in development mode.
@@ -21,8 +22,7 @@ const addParser = (parser) => {
   subparser.addArgument('--verbose', {action: "storeTrue", help: "Print more verbose progress messages in the terminal."});
   subparser.addArgument('--extend', {action: "store", metavar: "JSON", help: "Client customisations to be applied. See documentation for more details. Note that hot reloading does not currently work for these customisations."});
   subparser.addArgument('--handlers', {action: "store", metavar: "JS", help: "Overwrite the provided server handlers for client requests. See documentation for more details."});
-  subparser.addArgument('--datasetDir', {metavar: "PATH", help: "Directory where datasets (JSONs) are sourced. This is ignored if you define custom handlers."});
-  subparser.addArgument('--narrativeDir', {metavar: "PATH", help: "Directory where narratives (Markdown files) are sourced. This is ignored if you define custom handlers."});
+  view.addDatasetNarrativePathArgs(subparser)
   subparser.addArgument('--includeTiming', {action: "storeTrue", help: "Do not strip timing functions. With these included the browser console will print timing measurements for a number of functions."});
 
   /* there are some options which we deliberately do not document via `--help`. See build.js for explanations. */
@@ -31,6 +31,8 @@ const addParser = (parser) => {
 
 
 const run = (args) => {
+  const dataPaths = processPathArguments(args)
+
   /* Basic server set up */
   const app = express();
   app.set('port', process.env.PORT || 4000);
@@ -69,10 +71,18 @@ const run = (args) => {
 
   let handlerMsg = "";
   if (args.gh_pages) {
-    handlerMsg = serveRelativeFilepaths({app, dir: path.resolve(args.gh_pages)});
+    handlerMsg = view.serveRelativeFilepaths({app, dir: path.resolve(args.gh_pages)});
+  } else if (args.handlers) {
+    handlerMsg = view.customRouteHandlers(app, path.resolve(args.handlers));
   } else {
-    handlerMsg = loadAndAddHandlers({app, handlersArg: args.handlers, datasetDir: args.datasetDir, narrativeDir: args.narrativeDir});
+    handlerMsg = view.defaultRouteHandlers({app, dataPaths});
   }
+  /* Handle unhandled API (charon) routes */
+  app.get("/charon*", (req, res) => {
+    const errorMessage = "Query unhandled -- " + req.originalUrl;
+    utils.warn(errorMessage);
+    return res.status(500).type("text/plain").send(errorMessage);
+  });
 
   app.get("*", (req, res) => res.redirect("/"));
 

--- a/cli/server/getAvailable.js
+++ b/cli/server/getAvailable.js
@@ -1,94 +1,104 @@
 const utils = require("../utils");
 const fs = require('fs');
+const path = require("path");
 const { promisify } = require('util');
 const { findAvailableSecondTreeOptions } = require('./getDatasetHelpers');
 
 const readdir = promisify(fs.readdir);
 
-const getAvailableDatasets = async (localDataPath) => {
+const getAvailableDatasets = (dir, files) => {
   const datasets = [];
   /* NOTE: if there are v1 & v2 files with the same name the v2 JSON is
    * preferentially fetched. E.g. if `zika.json`, `zika_meta.json` and
    * `zika_tree.json` exist then only `zika.json` is viewable in auspice.
    */
-  try {
-    const files = await readdir(localDataPath);
-    /* v2 files -- match JSONs not ending with `_tree.json`, `_meta.json`,
-    `_tip-frequencies.json`, `_seq.json` */
-    const v2Files = files.filter((file) => (
-      file.endsWith(".json") &&
-      !file.includes("manifest") &&
-      !file.endsWith("_tree.json") &&
-      !file.endsWith("_meta.json") &&
-      !file.endsWith("_tip-frequencies.json") &&
-      !file.endsWith("_root-sequence.json") &&
-      !file.endsWith("_seq.json") &&
-      !file.endsWith("_measurements.json")
-    ))
+
+  /* v2 files -- match JSONs not ending with `_tree.json`, `_meta.json`,
+  `_tip-frequencies.json`, `_seq.json` */
+  const v2Files = files.filter((file) => (
+    file.endsWith(".json") &&
+    !file.includes("manifest") &&
+    !file.endsWith("_tree.json") &&
+    !file.endsWith("_meta.json") &&
+    !file.endsWith("_tip-frequencies.json") &&
+    !file.endsWith("_root-sequence.json") &&
+    !file.endsWith("_seq.json") &&
+    !file.endsWith("_measurements.json")
+  ))
+  .map((file) => file
+    .replace(".json", "")
+    .split("_")
+    .join("/")
+  );
+
+  v2Files.forEach((filepath) => {
+    datasets.push({
+      request: filepath,
+      v2: true,
+      secondTreeOptions: findAvailableSecondTreeOptions(filepath, v2Files),
+      fileType: 'dataset',
+      dir,
+    });
+  });
+
+  /* v1 files -- match files ending with `_tree.json` */
+  const v1Files = files
+    .filter((file) => file.endsWith("_tree.json"))
     .map((file) => file
-      .replace(".json", "")
+      .replace("_tree.json", "")
       .split("_")
       .join("/")
     );
 
-    v2Files.forEach((filepath) => {
-      datasets.push({
-        request: filepath,
-        v2: true,
-        secondTreeOptions: findAvailableSecondTreeOptions(filepath, v2Files)
-      });
+  v1Files.forEach((filepath) => {
+    datasets.push({
+      request: filepath,
+      v2: false,
+      secondTreeOptions: findAvailableSecondTreeOptions(filepath, v1Files),
+      fileType: 'dataset',
+      dir,
     });
-
-    /* v1 files -- match files ending with `_tree.json` */
-    const v1Files = files
-      .filter((file) => file.endsWith("_tree.json"))
-      .map((file) => file
-        .replace("_tree.json", "")
-        .split("_")
-        .join("/")
-      );
-
-    v1Files.forEach((filepath) => {
-      datasets.push({
-        request: filepath,
-        v2: false,
-        secondTreeOptions: findAvailableSecondTreeOptions(filepath, v1Files)
-      });
-    });
-  } catch (err) {
-    utils.warn(`Couldn't collect available dataset files (path searched: ${localDataPath})`);
-    utils.verbose(err);
-  }
+  });
   return datasets;
 };
 
-const getAvailableNarratives = async (localNarrativesPath) => {
-  let narratives = [];
-  try {
-    narratives = await readdir(localNarrativesPath);
-    narratives = narratives
-      .filter((file) => file.endsWith(".md") && file!=="README.md")
-      .map((file) => file.replace(".md", ""))
-      .map((file) => file.split("_").join("/"))
-      .map((filepath) => `narratives/${filepath}`)
-      .map((filepath) => ({request: filepath}));
-  } catch (err) {
-    utils.warn(`Couldn't collect available narratives (path searched: ${localNarrativesPath})`);
-    utils.verbose(err);
-  }
-  return narratives;
+const getAvailableNarratives = (dir, files) => {
+  return files
+    .filter((file) => file.endsWith(".md") && file!=="README.md")
+    .map((file) => ({
+      fullPath: path.join(dir, file),
+      request: 'narratives/' + file.replace(".md", "").split("_").join("/"),
+      fileType: 'narrative',
+    }));
 };
 
-const setUpGetAvailableHandler = ({datasetsPath, narrativesPath}) => {
+const setUpGetAvailableHandler = (dataPaths) => {
   /* return Auspice's default handler for "/charon/getAvailable" requests.
    * Remember that auspice itself only serves local files.
    * Servers often use their own handler instead of this.
    */
   return async (req, res) => {
     utils.log("GET AVAILABLE returning locally available datasets & narratives");
-    const datasets = await getAvailableDatasets(datasetsPath);
-    const narratives = await getAvailableNarratives(narrativesPath);
-    res.json({datasets, narratives});
+    let resources = []
+    for (const [p, dataTypes] of Object.entries(dataPaths)) {
+      try {
+        // FUTURE TODO - recurse into subfolders (readdir can do this natively)
+        const files = await readdir(p);
+        if (dataTypes.has('datasets')) {
+          resources.push(...getAvailableDatasets(p, files))
+        }
+        if (dataTypes.has('narratives')) {
+          resources.push(...getAvailableNarratives(p, files))
+        }
+      } catch (err) {
+        utils.warn(`Couldn't collect files (path searched: ${p})`);
+        utils.verbose(err);
+      }
+    }
+    resources = unique(resources)
+
+    /* convert to the expected API response structure */
+    res.json(availableResponseStructure(resources));
   };
 
 };
@@ -97,5 +107,28 @@ const setUpGetAvailableHandler = ({datasetsPath, narrativesPath}) => {
 module.exports = {
   setUpGetAvailableHandler,
   getAvailableDatasets,
-  getAvailableNarratives
+  getAvailableNarratives,
 };
+
+function availableResponseStructure(resources) {
+  const datasets = resources.filter((r) => r.fileType==='dataset')
+    .map((r) => ({request: r.request, buildUrl: r.buildUrl, secondTreeOptions: r.secondTreeOptions}));
+  const narratives = resources.filter((r) => r.fileType==='narrative')
+    .map((r) => ({request: r.request}));
+  return {datasets, narratives};
+}
+
+/**
+ * First match wins
+ */
+function unique(resources) {
+  const seen = {dataset: new Set(), narrative: new Set()};
+  return resources.filter((r) => {
+    if (seen[r.fileType].has(r.request)) {
+      // utils.verbose(`Dropping duplicate ${r.request} from available`); // Too verbose!
+      return false;
+    }
+    seen[r.fileType].add(r.request);
+    return true;
+  })
+}

--- a/cli/server/getDataset.js
+++ b/cli/server/getDataset.js
@@ -1,23 +1,104 @@
+const { promisify } = require('util');
+const path = require("path");
+const fs = require('fs');
 const getAvailable = require("./getAvailable");
 const helpers = require("./getDatasetHelpers");
+const utils = require("../utils");
 
-const setUpGetDatasetHandler = ({datasetsPath}) => {
+const readdir = promisify(fs.readdir);
+
+/**
+ * Returns a route handler which responds to requests by serving the relevant JSON file
+ * from disk.
+ */
+const setUpGetDatasetHandler = (dataPaths) => {
   return async (req, res) => {
+
+    let requestInfo;
     try {
-      const availableDatasets = await getAvailable.getAvailableDatasets(datasetsPath);
-      const info = helpers.interpretRequest(req, datasetsPath);
-      const redirected = helpers.redirectIfDatapathMatchFound(res, info, availableDatasets);
-      if (redirected) return;
-      helpers.makeFetchAddresses(info, datasetsPath, availableDatasets);
-      await helpers.sendJson(res, info);
+      requestInfo = helpers.interpretRequest(req);
     } catch (err) {
-      console.trace(err);
-      // Throw 404 when not available
-      const errorCode = err.message.endsWith("not in available datasets") ? 404 : 500;
-      return helpers.handleError(res, `couldn't fetch JSONs`, err.message, errorCode);
+      return helpers.handleError(res, err.message, err.message, 400);
     }
+
+    const matchResult = await matchDatasetFile(dataPaths, requestInfo);
+
+    if (!Array.isArray(matchResult)) {
+      return await helpers.sendJson(res, { ...requestInfo, address: matchResult });
+    }
+
+    /* No perfect match - attempt to find a close one iff type=dataset */
+    if (requestInfo.dataType==='dataset') {
+      const closeMatchRequest = helpers.closestMatch(requestInfo.parts, matchResult);
+      if (closeMatchRequest) {
+        utils.verbose(`Redirecting request to ${closeMatchRequest}`);
+        return res.redirect(`./getDataset?prefix=/${closeMatchRequest}`);
+      }
+    }
+
+    /* fallthrough to 404 error */
+    const msg = `no matching file for ${requestInfo.dataType || 'unknown data type'}`;
+    return helpers.handleError(res, msg, msg, 404);
   };
 };
+
+
+/** Charon sidecar type query -> filename suffix */
+const SIDECARS = {
+  'root-sequence': '_root-sequence.json',
+  'tip-frequencies': '_tip-frequencies.json',
+  measurements: '_measurements.json',
+}
+
+/** Walk through folders (dataPaths) looking for a file on disk which
+ * exactly matches (in terms of dataset name & type). We return the
+ * first exact match ("first match wins"), which mirrors `getAvailable`
+ *
+ * Return either:
+ *  - string: the path to a v2 main dataset / sidecar JSON
+ *  - object: the paths for (v1) meta/tree dataset JSONs
+ *  - array:  no matching file found. The array represents all available datasets
+ */
+async function matchDatasetFile(dataPaths, requestInfo) {
+  /**
+   * Iterate through the dataPaths and return the first match we find
+   * (this "first match wins" approach mirrors that of `getAvailable`)
+   */
+  const allAvailableDatasets = []
+  for (const [dir, dataTypes] of Object.entries(dataPaths)) {
+    if (!dataTypes.has('datasets')) continue;
+    let files = [];
+    try {
+      files = await readdir(dir);
+    } catch (err) {
+      utils.warn(`Error reading datasets from ${dir}: ${err.message}`)
+    }
+
+    if (requestInfo.dataType==='dataset') {
+      // list all available datasets -- includes v1 (meta+tree) & v2 ("main") dataset
+      const availableDatasets = getAvailable.getAvailableDatasets(dir, files);
+      allAvailableDatasets.push(...availableDatasets);
+      for (const resource of availableDatasets) {
+        if (resource.request === requestInfo.parts.join("/")) {
+          const address = resource.v2 ?
+            path.join(resource.dir, `${requestInfo.parts.join("_")}.json`) :
+            ({
+              meta: path.join(resource.dir, `${requestInfo.parts.join("_")}_meta.json`),
+              tree: path.join(resource.dir, `${requestInfo.parts.join("_")}_tree.json`)
+            });
+          return address;
+        }
+      }
+    } else if (Object.hasOwn(SIDECARS, requestInfo.dataType)) {
+      const expectedFileName = requestInfo.parts.join("_") + SIDECARS[requestInfo.dataType];
+      const matches = files.filter((f) => f === expectedFileName);
+      if (matches.length) {
+        return path.join(dir, matches[0]);
+      }
+    }
+  }
+  return allAvailableDatasets;
+}
 
 
 module.exports = {

--- a/cli/server/getDatasetHelpers.js
+++ b/cli/server/getDatasetHelpers.js
@@ -11,7 +11,6 @@
 
 const utils = require("../utils");
 const queryString = require("query-string");
-const path = require("path");
 const convertFromV1 = require("./convertJsonSchemas").convertFromV1;
 const fs = require("fs");
 
@@ -27,12 +26,15 @@ const splitPrefixIntoParts = (url) => url
 
 
 /**
- * Basic interpretation of an auspice request
- * @returns {Object} keys: `dataType`, `parts`
+ * Parses the dataset URL query into an object with two keys 'parts' and 'dataType'
+ *
+ * @returns {Object}   ret
+ * @returns {string[]} ret.parts is the dataset name spit on '/' character
+ * @returns {string}   ret.dataType is the dataset type ('dataset', 'root-sequence' etc)
  */
 const interpretRequest = (req) => {
-  utils.log(`GET DATASET query received: ${req.url.split('?')[1]}`);
   const query = queryString.parse(req.url.split('?')[1]);
+  utils.log(`[GET DATASET] ${Object.entries(query).map(([k,v]) => `${k}: '${v}'`).join(', ')}`);
   if (!query.prefix) throw new Error("'prefix' not defined in request");
   const datanameParts = splitPrefixIntoParts(query.prefix);
   const info = {parts: datanameParts};
@@ -46,64 +48,34 @@ const interpretRequest = (req) => {
   } else if (sidecars.includes(query.type)) {
     info.dataType = query.type;
   } else {
-    throw new Error(`Unknown file type '${query.type}' requested.`);
+    throw new Error(`Unknown dataset type '${query.type}' requested.`);
   }
   return info;
 };
 
 /**
- * Given a request, if the dataset does not exist then either
- * (a) redirect to an appropriate dataset if possible & return `true`
- * (b) throw.
- * If the dataset existed then return `false` as no redirect necessary.
+ * Given a request for which there is no perfect match, return a close match
+ * if one exists else return false
  */
-const redirectIfDatapathMatchFound = (res, info, availableDatasets) => {
+const closestMatch = (requestedDatasetParts, availableDatasets) => {
   let matchingDatasets = availableDatasets;
   let i;
-  const matchDatasetRequest = (d) => d.request.split("/")[i] === info.parts[i];
+  const matchDatasetRequest = (d) => d.request.split("/")[i] === requestedDatasetParts[i];
   // Filter gradually by path fragment, starting from the root
-  for (i = 0; i < info.parts.length; i++) {
+  for (i = 0; i < requestedDatasetParts.length; i++) {
     const newMatchingDatasets = matchingDatasets.filter(matchDatasetRequest);
     if (!newMatchingDatasets.length) break;
     matchingDatasets = newMatchingDatasets;
   }
-  // If root fragment does cannot be matched, throw
-  if (!i) throw new Error(`${info.parts.join("/")} not in available datasets`);
+  // If root fragment cannot be matched return false (no closest match found)
+  if (!i) return false;
   // If best match is not equal to path requested, redirect
-  if (matchingDatasets[0].request !== info.parts.join("/")) {
-    res.redirect(`./getDataset?prefix=/${matchingDatasets[0].request}`);
-    return true;
+  if (matchingDatasets[0].request !== requestedDatasetParts.join("/")) {
+    return matchingDatasets[0].request;
   }
   return false;
 };
 
-/**
- * sets info.address.
- * if we need v1 datasets then `info.address` will be an object with `meta`
- * and `tree` keys. Otherwise `info.address` will be a string of the fetch
- * path.
- * @sideEffect sets `info.address` {Object | string}
- * @throws
- */
-const makeFetchAddresses = (info, datasetsPath, availableDatasets) => {
-  if (info.dataType !== "dataset") {
-    info.address = path.join(
-      datasetsPath,
-      `${info.parts.join("_")}_${info.dataType}.json`
-    );
-  } else {
-    const requestStr = info.parts.join("/"); // TO DO
-    const availableInfo = availableDatasets.filter((d) => d.request === requestStr)[0];
-    if (availableInfo.v2) {
-      info.address = path.join(datasetsPath, `${info.parts.join("_")}.json`);
-    } else {
-      info.address = {
-        meta: path.join(datasetsPath, `${info.parts.join("_")}_meta.json`),
-        tree: path.join(datasetsPath, `${info.parts.join("_")}_tree.json`)
-      };
-    }
-  }
-};
 
 const sendJson = async (res, info) => {
   if (typeof info.address === "string") {
@@ -173,8 +145,7 @@ const findAvailableSecondTreeOptions = (currentDatasetUrl, availableDatasetUrls)
 
 module.exports = {
   interpretRequest,
-  redirectIfDatapathMatchFound,
-  makeFetchAddresses,
+  closestMatch,
   handleError,
   sendJson,
   findAvailableSecondTreeOptions

--- a/cli/server/getNarrative.js
+++ b/cli/server/getNarrative.js
@@ -1,38 +1,50 @@
 const queryString = require("query-string");
-const path = require("path");
+const { promisify } = require('util');
 const fs = require("fs");
 const utils = require("../utils");
+const getAvailable = require("./getAvailable");
 
-const setUpGetNarrativeHandler = ({narrativesPath}) => {
+const readdir = promisify(fs.readdir);
+
+
+const setUpGetNarrativeHandler = (dataPaths) => {
   return async (req, res) => {
+    utils.log(`GET NARRATIVE request received: ${req.url}`);
     const query = queryString.parse(req.url.split('?')[1]);
-    const prefix = query.prefix || "";
-    const filename = prefix
-      .replace(/.+narratives\//, "")  // remove the URL up to (& including) "narratives/"
-      .replace(/\/$/, "")             // remove ending slash
-      .replace(/\//g, "_")            // change slashes to underscores
-      .concat(".md");                 // add .md suffix
-
     const type = query.type ? query.type.toLowerCase() : null;
-
-    const pathName = path.join(narrativesPath, filename);
-    utils.log("trying to access & parse local narrative file: " + pathName);
-    try {
-      const fileContents = fs.readFileSync(pathName, 'utf8');
-      if (type === "md" || type === "markdown") {
-        // we could stream the response (as we sometimes do for getDataset) but narrative files are small
-        // so the expected time savings / server overhead is small.
-        res.send(fileContents);
-      } else {
-        throw new Error(`Unknown format requested: ${type}`);
-      }
-      utils.verbose("SUCCESS");
-    } catch (err) {
-      const errorMessage = `Narratives couldn't be served -- ${err.message}`;
-      utils.warn(errorMessage);
-      res.status(500).type("text/plain").send(errorMessage);
+    if (!(type === "md" || type === "markdown")) {
+      return res.status(400).type("text/plain").send(`Unknown format requested: ${type}`);
     }
-  };
+    if (!query.prefix || !(String(query.prefix).startsWith('narratives/') || String(query.prefix).startsWith('/narratives/'))) {
+      return res.status(400).type("text/plain").send(`Query must include a prefix starting with [/]narratives/`);
+    }
+
+    const requestStr = query.prefix // we know this starts with [/]narratives/
+      .replace(/^\//, "")  // remove leading slash
+      .replace(/\/$/, "")  // remove ending slash
+
+    for (const [p, dataTypes] of Object.entries(dataPaths)) {
+      if (!dataTypes.has('narratives')) continue;
+      try {
+        const files = await readdir(p);
+        const match = getAvailable.getAvailableNarratives(p, files)
+          .filter((d) => d.request===requestStr)[0]
+        if (match) {
+          // we could stream the response (as we sometimes do for getDataset) but narrative files are small
+          // so the expected time savings / server overhead is small.
+          return res.send(fs.readFileSync(match.fullPath, 'utf8'));
+        }
+        // else go scan the next dataPaths (directory)
+      } catch (err) {
+        const errorMessage = `Narratives couldn't be served -- ${err.message}`;
+        utils.warn(errorMessage);
+        return res.status(500).type("text/plain").send(errorMessage);
+      }
+    }
+    const errorMessage = `No matching narrative found`;
+    utils.warn(errorMessage);
+    res.status(404).type("text/plain").send(errorMessage);
+  }
 };
 
 module.exports = {

--- a/cli/server/processPaths.js
+++ b/cli/server/processPaths.js
@@ -1,0 +1,77 @@
+const utils = require("../utils");
+
+/**
+ * Returns an object linking (absolute) paths to a set whose members indicate whether
+ * the path should be searched for dataset JSONs, narrative markdown files, or both.
+ *
+ * Historically the CLI took a single dataset path and a single narrative path, and
+ * that behaviour is still allowed here in addition to the newer approach of supplying
+ * any number of paths which can contain datasets and/or narratives. The two approaches
+ * are mutually exclusive and enforcement of this happens here.
+ *
+ * If no paths are provided via arguments then we attempt to choose sensible defaults
+ * (via `defaultDataPaths()`), however in my (james) experience it's never worked
+ * well an I recommend providing paths via args.
+ */
+function processPathArguments(args) {
+
+  if (args.handlers) {
+    if (args.datasetDir || args.narrativeDir || args.path.length>0) {
+      utils.error("Can't provide data paths if you use custom handlers")
+    }
+    return {}
+  }
+
+  if (args.gh_pages) {
+    if (args.handlers || args.datasetDir || args.narrativeDir || args.path.length > 0) {
+      utils.error("Can't provide data paths or handlers if you use --gh-pages")
+    }
+    return {}
+  }
+
+  if ((args.datasetDir || args.narrativeDir) && args.path.length>0) {
+    utils.error("Incompatible arguments defining paths for datasets and/or narratives: " +
+      "You must either specify the paths as named arguments (--datasetDir and/or --narrativeDir) " +
+      "_or_ specify one or more <path> positional arguments.");
+  }
+
+  if (args.datasetDir) {
+    utils.warn(`[DEPRECATED] Instead of 'auspice ... --datasetDir ${args.datasetDir}' please use 'auspice ... ${args.datasetDir}' `)
+  }
+  if (args.narrativeDir) {
+    utils.warn(`[DEPRECATED] Instead of 'auspice ... --narrativeDir ${args.narrativeDir}' please use 'auspice ... ${args.narrativeDir}' `)
+  }
+
+  const dataPaths = Object.fromEntries(
+    (args.path.length ?
+      args.path.map(utils.cleanUpPathname) :
+      args.datasetDir ?
+        [utils.cleanUpPathname(args.datasetDir)] :
+        utils.defaultDataPaths()
+    ).map((p) => [p, new Set(['datasets'])])
+  );
+
+  for (const narrativePath of
+    (args.path.length ?
+      args.path.map(utils.cleanUpPathname) :
+      args.narrativeDir ?
+        [utils.cleanUpPathname(args.narrativeDir)] :
+        utils.defaultDataPaths({narrative: true}))) {
+    if (narrativePath in dataPaths) {
+      dataPaths[narrativePath].add('narratives');
+    } else {
+      dataPaths[narrativePath] = new Set(['narratives']);
+    }
+  }
+
+  if (undefined in dataPaths) {
+    utils.error("One or more provided paths does not exist")
+  }
+
+  return dataPaths;
+}
+
+
+module.exports = {
+  processPathArguments,
+};

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -31,6 +31,7 @@ const cleanUpPathname = (pathIn) => {
   }
   pathOut = path.resolve(pathOut);
   if (!fs.existsSync(pathOut)) {
+    warn(`path ${pathOut} doesn't exist`)
     return undefined;
   }
   return pathOut;
@@ -45,18 +46,12 @@ const getCurrentDirectoriesFor = (type) => {
   return cleanUpPathname(cwd);
 };
 
-const resolveLocalDirectory = (providedPath, isNarratives) => {
-  let localPath;
-  if (providedPath) {
-    localPath = cleanUpPathname(providedPath);
-  } else if (isNpmGlobalInstall()) {
-    localPath = getCurrentDirectoriesFor(isNarratives ? "narratives" : "data");
-  } else {
-    // fallback to the auspice source directory
-    localPath = path.join(path.resolve(__dirname), "..", isNarratives ? "narratives" : "data");
-  }
-  return localPath;
-};
+
+const defaultDataPaths = ({narrative=false} = {}) => {
+  return isNpmGlobalInstall() ?
+    [getCurrentDirectoriesFor(narrative ? "narratives" : "data")] :
+    [path.join(path.resolve(__dirname), "..", narrative ? "narratives" : "data")];
+}
 
 const readFilePromise = (fileName) => {
   return new Promise((resolve, reject) => {
@@ -97,7 +92,8 @@ module.exports = {
   log,
   warn,
   error,
-  resolveLocalDirectory,
   readFilePromise,
-  exportIndexDotHtml
+  exportIndexDotHtml,
+  cleanUpPathname,
+  defaultDataPaths
 };

--- a/cli/view.js
+++ b/cli/view.js
@@ -11,7 +11,7 @@ const utils = require("./utils");
 const version = require('../src/version').version;
 const chalk = require('chalk');
 const SUPPRESS = require('argparse').Const.SUPPRESS;
-
+const { processPathArguments } = require("./server/processPaths");
 
 const addParser = (parser) => {
   const description = `Launch a local server to view locally available datasets & narratives.
@@ -22,12 +22,23 @@ const addParser = (parser) => {
   const subparser = parser.addParser('view', {addHelp: true, description});
   subparser.addArgument('--verbose', {action: "storeTrue", help: "Print more verbose logging messages."});
   subparser.addArgument('--handlers', {action: "store", metavar: "JS", help: "Overwrite the provided server handlers for client requests. See documentation for more details."});
-  subparser.addArgument('--datasetDir', {metavar: "PATH", help: "Directory where datasets (JSONs) are sourced. This is ignored if you define custom handlers."});
-  subparser.addArgument('--narrativeDir', {metavar: "PATH", help: "Directory where narratives (Markdown files) are sourced. This is ignored if you define custom handlers."});
+  addDatasetNarrativePathArgs(subparser)
   subparser.addArgument('--customBuildOnly', {action: "storeTrue", help: "Error if a custom build is not found."});
   /* there are some options which we deliberately do not document via `--help`. */
   subparser.addArgument('--gh-pages', {action: "store", help: SUPPRESS}); /* related to the "static-site-generation" or "github-pages" */
 };
+
+function addDatasetNarrativePathArgs(parser) {
+  parser.addArgument('--datasetDir', {
+    metavar: "PATH",
+    help: "[DEPRECATED] Directory where datasets (JSONs) are sourced. This cannot be used with <path> positional arg(s) or custom handlers."
+  });
+  parser.addArgument('--narrativeDir', {
+    metavar: "PATH",
+    help: "[DEPRECATED] Directory where narratives (Markdown files) are sourced. This cannot be used with <path> positional arg(s) or custom handlers."
+  });
+  parser.addArgument('path', {action: "store", nargs: '*', help: "Directories where datasets and/or narratives are stored"});
+}
 
 const serveRelativeFilepaths = ({app, dir}) => {
   app.get("*.json", (req, res) => {
@@ -38,42 +49,29 @@ const serveRelativeFilepaths = ({app, dir}) => {
   return `JSON requests will be served relative to ${dir}.`;
 };
 
-const loadAndAddHandlers = ({app, handlersArg, datasetDir, narrativeDir}) => {
-  /* load server handlers, either from provided path or the defaults */
-  const handlers = {};
-  let datasetsPath, narrativesPath;
-  if (handlersArg) {
-    const handlersPath = path.resolve(handlersArg);
-    utils.verbose(`Loading handlers from ${handlersPath}`);
-    const inject = require(handlersPath);
-    handlers.getAvailable = inject.getAvailable;
-    handlers.getDataset = inject.getDataset;
-    handlers.getNarrative = inject.getNarrative;
-  } else {
-    datasetsPath = utils.resolveLocalDirectory(datasetDir, false);
-    narrativesPath = utils.resolveLocalDirectory(narrativeDir, true);
-    handlers.getAvailable = require("./server/getAvailable")
-      .setUpGetAvailableHandler({datasetsPath, narrativesPath});
-    handlers.getDataset = require("./server/getDataset")
-      .setUpGetDatasetHandler({datasetsPath});
-    handlers.getNarrative = require("./server/getNarrative")
-      .setUpGetNarrativeHandler({narrativesPath});
-  }
+function customRouteHandlers(app, handlersPath) {
+  utils.verbose(`Loading handlers from ${handlersPath}`);
+  const customCode = require(handlersPath);
+  app.get("/charon/getAvailable", customCode.getAvailable);
+  app.get("/charon/getDataset", customCode.getDataset);
+  app.get("/charon/getNarrative", customCode.getNarrative);
+  return `Custom server handlers provided.`;
+}
 
-  /* apply handlers */
-  app.get("/charon/getAvailable", handlers.getAvailable);
-  app.get("/charon/getDataset", handlers.getDataset);
-  app.get("/charon/getNarrative", handlers.getNarrative);
-  app.get("/charon*", (req, res) => {
-    const errorMessage = "Query unhandled -- " + req.originalUrl;
-    utils.warn(errorMessage);
-    return res.status(500).type("text/plain").send(errorMessage);
-  });
-
-  return handlersArg ?
-    `Custom server handlers provided.` :
-    `Looking for datasets in ${datasetsPath}\nLooking for narratives in ${narrativesPath}`;
-};
+/**
+ * Adds route handlers for the three canonical charon routes to the *app*
+ */
+function defaultRouteHandlers({app, dataPaths}) {
+  app.get("/charon/getAvailable", require("./server/getAvailable").setUpGetAvailableHandler(dataPaths));
+  app.get("/charon/getDataset", require("./server/getDataset").setUpGetDatasetHandler(dataPaths));
+  app.get("/charon/getNarrative", require("./server/getNarrative").setUpGetNarrativeHandler(dataPaths));
+  const sep = "\n - "
+  return 'Looking for datasets & narratives in the following paths,\n' +
+    '(if there are multiple matches then the first one will be used)' + sep +
+    Object.entries(dataPaths)
+      .map(([p, dataTypes]) => `${p} (${Array.from(dataTypes).join(', ')})`)
+      .join(sep);
+}
 
 const getAuspiceBuild = (customBuildOnly) => {
   const cwd = path.resolve(process.cwd());
@@ -109,6 +107,8 @@ function hasAuspiceBuild(directory) {
 }
 
 const run = (args) => {
+  const dataPaths = processPathArguments(args)
+
   /* Basic server set up */
   const app = express();
   app.set('port', process.env.PORT || 4000);
@@ -128,9 +128,17 @@ const run = (args) => {
   let handlerMsg = "";
   if (args.gh_pages) {
     handlerMsg = serveRelativeFilepaths({app, dir: path.resolve(args.gh_pages)});
+  } else if (args.handlers) {
+    handlerMsg = customRouteHandlers(app, path.resolve(args.handlers));
   } else {
-    handlerMsg = loadAndAddHandlers({app, handlersArg: args.handlers, datasetDir: args.datasetDir, narrativeDir: args.narrativeDir});
+    handlerMsg = defaultRouteHandlers({app, dataPaths});
   }
+  /* Handle unhandled API (charon) routes */
+  app.get("/charon*", (req, res) => {
+    const errorMessage = "Query unhandled -- " + req.originalUrl;
+    utils.warn(errorMessage);
+    return res.status(500).type("text/plain").send(errorMessage);
+  });
 
   /* this must be the last "get" handler, else the "*" swallows all other requests */
   app.get("*", (req, res) => {
@@ -167,6 +175,9 @@ const run = (args) => {
 module.exports = {
   addParser,
   run,
-  loadAndAddHandlers,
+  addDatasetNarrativePathArgs,
+  processPathArguments,
+  defaultRouteHandlers,
+  customRouteHandlers,
   serveRelativeFilepaths
 };

--- a/docs/introduction/how-to-run.rst
+++ b/docs/introduction/how-to-run.rst
@@ -22,7 +22,7 @@ And then run ``auspice`` via:
 
 .. code:: bash
 
-   auspice view --datasetDir datasets
+   auspice view datasets
 
 This will allow you to run Auspice locally (i.e. from your computer) and view the dataset which is behind `nextstrain.org/zika <https://nextstrain.org/zika>`__. :ref:`See below <introduction-obtaining-a-set-of-input-files>` for how to download all of the data available on `nextstrain.org <https://nextstrain.org>`__.
 
@@ -31,15 +31,9 @@ To analyse your own data, please see the tutorials on the `nextstrain docs <http
 ``auspice view``
 ----------------
 
-This is the main command we'll run Auspice with, as it makes Auspice available in a web browser for you. There are two common arguments used:
+This is the main command we'll run Auspice with, as it makes Auspice available in a web browser for you.
 
-+---------------------+--------------------------+---------------------------------------------------------------------------------------------------------+
-| argument name       | data supplied            | description                                                                                             |
-+=====================+==========================+=========================================================================================================+
-| datasetDir          | PATH                     | Directory where datasets (JSONs) are sourced. This is ignored if you define custom handlers.            |
-+---------------------+--------------------------+---------------------------------------------------------------------------------------------------------+
-| narrativeDir        | PATH                     | Directory where narratives (Markdown files) are sourced. This is ignored if you define custom handlers. |
-+---------------------+--------------------------+---------------------------------------------------------------------------------------------------------+
+Provide one or more pats to search for datasets (JSON) or narratives (markdown) files in: ``auspice view PATH [PATH ...]`` (see above for how to obtain a dataset JSON to start with).
 
 For more complicated setups, where you define your own server handlers, see :ref:`supplying custom handlers to the Auspice server <server-api-supplying-custom-handlers>`.
 

--- a/scripts/fetch-test-data
+++ b/scripts/fetch-test-data
@@ -1,12 +1,50 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-# Provision specific JSONs for tests
+const fs = require('fs');
+const path = require('path');
 
-set -x -e -o pipefail
+const DEST = path.join(__dirname, '..', 'test', 'fetched-jsons');
+const CHARON = 'https://nextstrain.org/charon/getDataset?prefix=';
 
-DEST="test/fetched-jsons"
-CHARON="https://nextstrain.org/charon/getDataset?prefix="
-FETCH="curl --fail --compressed"
+const datasets = [
+  { src: 'ebola/all-outbreaks@2026-05-18', dst: 'ebola-all-outbreaks' },
+  { src: 'ebola/ebov-2013@2025-10-14', dst: 'ebola-ebov-2013' },
+  { src: 'mumps/global@2026-05-30', dst: 'mumps', tipFrequencies: true},
+];
 
-${FETCH} ${CHARON}/ebola/all-outbreaks@2026-05-18 --output ${DEST}/ebola-all-outbreaks.json
-${FETCH} ${CHARON}/ebola/ebov-2013@2025-10-14 --output ${DEST}/ebola-ebov-2013.json
+async function main() {
+  if (!fs.existsSync(DEST)) {
+    console.error(`Expected directory ${DEST} to exist`);
+    process.exit(1);
+  }
+
+  const fetches = datasets.flatMap(({src, dst, tipFrequencies}) => {
+    const items = [
+      {url: `${CHARON}/${src}`, output: `${dst}.json`},
+    ];
+    if (tipFrequencies) {
+      items.push({url: `${CHARON}/${src}&type=tip-frequencies`, output: `${dst}_tip-frequencies.json`});
+    }
+    return items;
+  });
+
+  await Promise.all(
+    fetches.map(async ({url, output}) => {
+      console.log(`Fetching ${url}`);
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+      }
+      const outputPath = path.join(DEST, output);
+      fs.writeFileSync(outputPath, Buffer.from(await res.arrayBuffer()));
+      console.log(`  -> ${outputPath}`);
+    })
+  );
+
+  console.log(`Fetched ${fetches.length} files`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/server-fetch.test.js
+++ b/test/server-fetch.test.js
@@ -1,0 +1,86 @@
+/**
+ * Exercises the CLI's default `/charon/getDataset` handler against real on-disk
+ * JSONs (provisioned into `test/fetched-jsons/` via `npm run fetch-test-data`).
+ *
+ * We stand up a minimal express server using the exact handler factory that
+ * `auspice view` / `auspice develop` use, listen on an ephemeral port, and make
+ * real HTTP requests so the streaming response path is exercised end-to-end.
+ *
+ * The `mumps` fixtures consist of a v2 dataset (`mumps.json`) plus its
+ * tip-frequencies sidecar (`mumps_tip-frequencies.json`). The client requests
+ * sidecars via the same getDataset route with a `type` query param, e.g.
+ * `/charon/getDataset?prefix=mumps&type=tip-frequencies`
+ * (see src/actions/loadData.js).
+ */
+
+const express = require("express");
+const fs = require("fs");
+const path = require("path");
+const { setUpGetDatasetHandler } = require("../cli/server/getDataset");
+
+const DATA_DIR = path.resolve(__dirname, "fetched-jsons");
+const MAIN_FIXTURE = path.join(DATA_DIR, "mumps.json");
+const SIDECAR_FIXTURE = path.join(DATA_DIR, "mumps_tip-frequencies.json");
+
+const fixturesAvailable = fs.existsSync(MAIN_FIXTURE) && fs.existsSync(SIDECAR_FIXTURE);
+
+/* The fetched JSONs are gitignored; skip (with a clear message) rather than fail
+ * if they haven't been provisioned via `npm run fetch-test-data`. */
+const describeOrSkip = fixturesAvailable ? describe : describe.skip;
+if (!fixturesAvailable) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `[server-fetch.test] Skipping: fixtures missing in ${DATA_DIR}. ` +
+    `Provision them with \`npm run fetch-test-data\`.`
+  );
+  process.exit(1)
+}
+
+describeOrSkip("CLI default getDataset handler", () => {
+  let server;
+  let baseUrl;
+
+  beforeAll((done) => {
+    const app = express();
+    /* `dataPaths` mirrors the structure produced by `processPathArguments`:
+     * an object mapping an absolute path to the set of data types to serve from it. */
+    const dataPaths = { [DATA_DIR]: new Set(["datasets"]) };
+    app.get("/charon/getDataset", setUpGetDatasetHandler(dataPaths));
+    server = app.listen(0, () => {
+      const { port } = server.address();
+      baseUrl = `http://127.0.0.1:${port}/charon/getDataset`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  it("serves the main (v2) dataset JSON (sanity check)", async () => {
+    const res = await fetch(`${baseUrl}?prefix=mumps`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.version).toBe("v2");
+    expect(json).toHaveProperty("tree");
+  });
+
+  it("serves the tip-frequencies sidecar JSON", async () => {
+    const res = await fetch(`${baseUrl}?prefix=mumps&type=tip-frequencies`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const expected = JSON.parse(fs.readFileSync(SIDECAR_FIXTURE, "utf8"));
+    expect(json.pivots).toEqual(expected.pivots);
+  });
+
+  it("a valid prefix but unknown type is a 400 (Bad Request)", async () => {
+    const res = await fetch(`${baseUrl}?prefix=mumps&type=foo`);
+    expect(res.status).toBe(400);
+  });
+
+  it("dataset doesn't exist is a 404 (Not Found)", async () => {
+    const res = await fetch(`${baseUrl}?prefix=foo`);
+    expect(res.status).toBe(404);
+  });
+
+});


### PR DESCRIPTION
The previous interface was slightly cumbersome - I often found myself wanting to source both datasets & narratives from some directory X and having to type in the rather long `--datasetDir X --narrativeDir X`, and often I'd misspell / pluralise the argument names; using a simple positional argument `X` is much nicer. The ability to use multiple directories is also functionality I've long wanted.

The previous CLI interface is preserved in its entirety for backwards compatibility and is mutually exclusive with the new positional-args style.
