### PR TITLE
Use organization variables for git user name/email

### DIFF
--- a/.github/workflows/preview_on_downstream_repo.yaml
+++ b/.github/workflows/preview_on_downstream_repo.yaml
@@ -49,8 +49,8 @@ jobs:
           npm install nextstrain/auspice#${{ github.sha }}
           git add package.json package-lock.json
 
-          git config user.name "nextstrain-bot"
-          git config user.email "nextstrain-bot@users.noreply.github.com"
+          git config user.name "${{ vars.GIT_USER_NAME_NEXTSTRAIN_BOT }}"
+          git config user.email "${{ vars.GIT_USER_EMAIL_NEXTSTRAIN_BOT }}"
           git commit --message="[testing only] Upgrade Auspice to ${{ github.sha }}"
 
       - name: Create Pull Request


### PR DESCRIPTION
## Description of proposed changes

These lines are referenced in a new [internal wiki section](https://nextstrain.atlassian.net/wiki/spaces/NEXTSTRAIN/pages/170688571/GitHub+nextstrain-bot+usage#Git-user-details) on the organization variables, so the variables should be used here as an example.

## Checklist

- [x] Checks pass
- [x] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].
- [x] Test commit looks good: https://github.com/nextstrain/auspice.us/commit/db99b815e2380a2f208583d43de1516782206c05

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories
