### PR TITLE
[bugfix] datasets without display_defaults

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -482,7 +482,7 @@ const modifyControlsStateViaTree = (state, tree, treeToo, metadata) => {
   }
 
   state.availableStreamLabelKeys = availableStreamLabelKeys(tree.availableBranchLabels, metadata.streamLabels);
-  if (metadata.displayDefaults.streamLabel) {
+  if (metadata?.displayDefaults?.streamLabel) {
     if (state.availableStreamLabelKeys.includes(metadata.displayDefaults.streamLabel)) {
       state.showStreamTrees = true;
       state.streamTreeBranchLabel = metadata.displayDefaults.streamLabel;


### PR DESCRIPTION
The code in #1902 included an assumption that `display_defaults` was set within `modifyControlsStateViaTree`, however it is not guaranteed to be set until later on (specifically, after `modifyStateViaMetadata` has run).

Better smoke testing would have flagged this. Specifically, we should maintain a wide variety of datasets (I already have these locally!) and ensure that each one loads correctly, for some easily testable definition of correct.

The code within `recomputeReduxState` is hard to keep track of. I'm not sure TypeScript would help here due to our reliance on incremental object construction. Maybe? Without a much more comprehensive test suite I'm very hesitant to make sweeping changes there.

Closes <https://github.com/nextstrain/auspice.us/issues/122>
