### PR TITLE
Export URLs in metadata TSVs

### DIFF
--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -844,8 +844,8 @@ const createMetadataStateFromJSON = (json) => {
   if (json.meta.build_avatar) {
     metadata.buildAvatar = json.meta.build_avatar;
   }
-  if (json.meta.data_provenance) {
-    metadata.dataProvenance = json.meta.data_provenance;
+  if (Array.isArray(json?.meta?.data_provenance)) {
+    metadata.dataProvenance = json.meta.data_provenance.filter((el) => typeof el.name === 'string')
   }
   if (json.meta.filters) {
     metadata.filters = json.meta.filters;

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -26,16 +26,7 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
   const temporal = distanceMeasure === "num_date";
 
   /* set gisaidProvenance based on supplied JSON metadata */
-  let gisaidProvenance = false;
-  if ("dataProvenance" in metadata) {
-    for (const source of metadata.dataProvenance) {
-      if ("name" in source) {
-        if (source.name.toUpperCase() === "GISAID") {
-          gisaidProvenance = true;
-        }
-      }
-    }
-  }
+  const gisaidProvenance = (metadata?.dataProvenance || []).filter((el) => el.name.toUpperCase()==='GISAID').length>0;
   /* Verify that we can parse dataset name from URL to support Auspice JSON download */
   const datasetNames = getDatasetNamesFromUrl(window.location.pathname);
   const supportAuspiceJsonDownload = !gisaidProvenance && datasetNames.some(Boolean);

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -73,22 +73,20 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         icon={<RectangularTreeIcon width={iconWidth} selected />}
         onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal})}
       />
-      {gisaidProvenance && (
+      {gisaidProvenance ?
         <Button
           name="Acknowledgments (TSV)"
           description={`Per-sample acknowledgments (n = ${selectedTipsCount}).`}
           icon={<MetaIcon width={iconWidth} selected />}
           onClick={() => helpers.acknowledgmentsTSV(dispatch, filePrefix, tree.nodes, tree.visibility)}
-        />
-      )}
-      {!gisaidProvenance && (
+        /> :
         <Button
           name="Metadata (TSV)"
           description={`Per-sample metadata (n = ${selectedTipsCount}).`}
           icon={<MetaIcon width={iconWidth} selected />}
           onClick={() => helpers.strainTSV(dispatch, filePrefix, tree.nodes, tree.visibility)}
         />
-      )}
+      }
       {helpers.areAuthorsPresent(tree) && (
         <Button
           name="Author Metadata (TSV)"

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -285,10 +285,10 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
 
     /* handle `accession` specially */
     const accession = getAccessionFromNode(node);
-    if ("accession" in accession) {
+    if (accession.accession) {
       const traitName = "accession";
       if (!headerFields.includes(traitName)) headerFields.push(traitName);
-      tipTraitValues[node.name][traitName] = accession.accession;
+      tipTraitValues[node.name][traitName] = accession.accession + (accession.url ? `: ${accession.url}` : '');
     }
   }
 

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -271,7 +271,7 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
       if (!headerFields.includes(traitName)) headerFields.push(traitName);
       tipTraitValues[node.name][traitName] = fullAuthorInfo.value;
       if (isPaperURLValid(fullAuthorInfo)) {
-        tipTraitValues[node.name][traitName] += ` (${fullAuthorInfo.paper_url})`;
+        tipTraitValues[node.name][traitName] += `: ${fullAuthorInfo.paper_url}`;
       }
     }
 
@@ -343,7 +343,7 @@ export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, nodeVisibilities
       if (!headerFields.includes(traitName)) headerFields.push(traitName);
       tipTraitValues[node.name][traitName] = fullAuthorInfo.value;
       if (isPaperURLValid(fullAuthorInfo)) {
-        tipTraitValues[node.name][traitName] += ` (${fullAuthorInfo.paper_url})`;
+        tipTraitValues[node.name][traitName] += `: ${fullAuthorInfo.paper_url}`;
       }
     }
 

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -2,7 +2,7 @@
 import { unparse } from "papaparse";
 import { errorNotification, infoNotification, warningNotification } from "../../actions/notifications";
 import { spaceBetweenTrees } from "../tree/tree";
-import { getTraitFromNode, getDivFromNode, getFullAuthorInfoFromNode, getVaccineFromNode, getAccessionFromNode } from "../../util/treeMiscHelpers";
+import { getTraitFromNode, getUrlFromNode, getDivFromNode, getFullAuthorInfoFromNode, getVaccineFromNode, getAccessionFromNode } from "../../util/treeMiscHelpers";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { NODE_VISIBLE, nucleotide_gene } from "../../util/globals";
 import { datasetSummary } from "../info/datasetSummary";
@@ -254,6 +254,10 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
       if (value) {
         if (typeof value === 'string') {
           tipTraitValues[node.name][trait] = value;
+          const url = getUrlFromNode(node, trait);
+          if (url) {
+            tipTraitValues[node.name][trait] += `: ${url}`;
+          }
         } else if (typeof value === "number") {
           tipTraitValues[node.name][trait] = parseFloat(value).toFixed(2);
         }


### PR DESCRIPTION
Closes #1994. See commit messages for details.

Note that we don't have a way to do this in the other direction, i.e. drag-and-drop a metadata TSV onto a dataset and have the URLs parsed appropriately. We should enable this, although note that you can't "round-trip" a data as you might expect as drag-and-dropped files can't currently overwrite existing metadata fields. 