### PR TITLE
Export URLs in TSVs via additional column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Link-outs are explicitly disabled for v1 datasets because the nextstrain.org API does not support the v1 -> v2 conversion. ([#2002](https://github.com/nextstrain/auspice/pull/2002))
 * Added a `treeZoom=selected` query to load trees at the same zoom level after the "zoom to selected" button has been pressed, where applicable. See [the view settings docs](https://docs.nextstrain.org/projects/auspice/en/latest/advanced-functionality/view-settings.html) for more details. ([#1321](https://github.com/nextstrain/auspice/pull/1321))
+* Downloaded metadata and acknowledgments TSVs will now use extra columns to export associated URLs. ([#2003](https://github.com/nextstrain/auspice/pull/2003))
+
 
 ## version 2.63.1 - 2025/06/04
 

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -250,7 +250,7 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const traits = Object.keys(node.node_attrs).filter((k) => !nodeAttrsToIgnore.includes(k));
     for (const trait of traits) {
       const value = getTraitFromNode(node, trait);
-      if (value) {
+      if (value !== undefined) {
         headerInsert(headerFields, null, trait);
         if (typeof value === 'string') {
           tipTraitValues[node.name][trait] = value;

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -235,7 +235,7 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const numDate = getTraitFromNode(node, "num_date");
     if (numDate) {
       const traitName = "date"; // matches use in augur metadata.tsv
-      if (!headerFields.includes(traitName)) headerFields.push(traitName);
+      headerInsert(headerFields, null, traitName)
       const numDateConfidence = getTraitFromNode(node, "num_date", {confidence: true});
       if (numDateConfidence && numDateConfidence[0] !== numDateConfidence[1]) {
         tipTraitValues[node.name][traitName] = `${numericToCalendar(numDate)} (${numericToCalendar(numDateConfidence[0])} - ${numericToCalendar(numDateConfidence[1])})`;
@@ -249,14 +249,15 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const nodeAttrsToIgnore = ["author", "div", "num_date", "vaccine", "accession"];
     const traits = Object.keys(node.node_attrs).filter((k) => !nodeAttrsToIgnore.includes(k));
     for (const trait of traits) {
-      if (!headerFields.includes(trait)) headerFields.push(trait);
       const value = getTraitFromNode(node, trait);
       if (value) {
+        headerInsert(headerFields, null, trait);
         if (typeof value === 'string') {
           tipTraitValues[node.name][trait] = value;
           const url = getUrlFromNode(node, trait);
           if (url) {
-            tipTraitValues[node.name][trait] += `: ${url}`;
+            headerInsert(headerFields, trait, urlify(trait));
+            tipTraitValues[node.name][urlify(trait)] = url;
           }
         } else if (typeof value === "number") {
           tipTraitValues[node.name][trait] = parseFloat(value).toFixed(2);
@@ -268,10 +269,11 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const fullAuthorInfo = getFullAuthorInfoFromNode(node);
     if (fullAuthorInfo) {
       const traitName = "author";
-      if (!headerFields.includes(traitName)) headerFields.push(traitName);
+      headerInsert(headerFields, null, traitName);
       tipTraitValues[node.name][traitName] = fullAuthorInfo.value;
       if (isPaperURLValid(fullAuthorInfo)) {
-        tipTraitValues[node.name][traitName] += `: ${fullAuthorInfo.paper_url}`;
+        headerInsert(headerFields, traitName, urlify(traitName));
+        tipTraitValues[node.name][urlify(traitName)] = fullAuthorInfo.paper_url;
       }
     }
 
@@ -279,7 +281,7 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const vaccine = getVaccineFromNode(node);
     if (vaccine && vaccine.selection_date) {
       const traitName = "vaccine_selection_date";
-      if (!headerFields.includes(traitName)) headerFields.push(traitName);
+      headerInsert(headerFields, null, traitName);
       tipTraitValues[node.name][traitName] = vaccine.selection_date;
     }
 
@@ -287,8 +289,12 @@ export const strainTSV = (dispatch, filePrefix, nodes, nodeVisibilities) => {
     const accession = getAccessionFromNode(node);
     if (accession.accession) {
       const traitName = "accession";
-      if (!headerFields.includes(traitName)) headerFields.push(traitName);
-      tipTraitValues[node.name][traitName] = accession.accession + (accession.url ? `: ${accession.url}` : '');
+      headerInsert(headerFields, null, traitName);
+      tipTraitValues[node.name][traitName] = accession.accession;
+      if (accession.url) {
+        headerInsert(headerFields, traitName, urlify(traitName));
+        tipTraitValues[node.name][urlify(traitName)] = accession.url;
+      }
     }
   }
 
@@ -331,7 +337,7 @@ export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, nodeVisibilities
     for (const traitName of traitsToExport) {
       const traitValue = getTraitFromNode(node, traitName);
       if (traitValue) {
-        if (!headerFields.includes(traitName)) headerFields.push(traitName);
+        headerInsert(headerFields, null, traitName)
         tipTraitValues[node.name][traitName] = traitValue;
       }
     }
@@ -340,10 +346,11 @@ export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, nodeVisibilities
     const fullAuthorInfo = getFullAuthorInfoFromNode(node);
     if (fullAuthorInfo) {
       const traitName = "author";
-      if (!headerFields.includes(traitName)) headerFields.push(traitName);
+      headerInsert(headerFields, null, traitName)
       tipTraitValues[node.name][traitName] = fullAuthorInfo.value;
       if (isPaperURLValid(fullAuthorInfo)) {
-        tipTraitValues[node.name][traitName] += `: ${fullAuthorInfo.paper_url}`;
+        headerInsert(headerFields, traitName, urlify(traitName));
+        tipTraitValues[node.name][urlify(traitName)] = fullAuthorInfo.paper_url;
       }
     }
 
@@ -354,6 +361,34 @@ export const acknowledgmentsTSV = (dispatch, filePrefix, nodes, nodeVisibilities
   write(filename, MIME.tsv, createTsvString(Object.values(tipTraitValues), headerFields));
   dispatch(infoNotification({message: `Acknowledgments exported to ${filename}`}));
 };
+
+
+/**
+ * Inserts *el2* after *el1* in the provided *arr* array (modified in-place)
+ * if *el1* is `null` then we add *el2* to the end of the array (in-place)
+ * If *el2* is already in the *arr* nothing is done
+ */
+function headerInsert(arr, el1, el2) {
+  if (arr.includes(el2)) return
+  if (el1===null) {
+    arr.push(el2);
+    return
+  }
+  const idx1 = arr.indexOf(el1);
+  if (idx1===-1) {
+    console.warn(`Element ${el1} not present in provided array`)
+    return;
+  }
+  arr.splice(idx1+1, 0, el2);
+}
+
+/**
+ * For a column *name* return the associated column name to use for URLs
+ */
+function urlify(name) {
+  return `${name}__url`;
+}
+
 
 export const exportTree = ({dispatch, filePrefix, tree, isNewick, temporal, colorings, colorBy}) => {
   try {


### PR DESCRIPTION
PR #1998 (merged but unreleased) exported URLs associated with metadata by appending to the value, i.e. `<value> :<url>`. This commit switches to using a separate column `<column_name>__url` for the URL. This change is motivated by a desire to encode URLs consistently across the nextstrain ecosystem, including in pathogen repo ingest pipelines¹ and `augur export`.

This commit essentially reverts commits 7315a9b4fddadf499bb9f85f77745442a72c9342, d7c85058caf61bfb25f42e000ed1bdd4c1ae50ad and 68c0fa6095ad4e11de790e39dece8b65a3b0d58b (all part of #1998).

¹ https://github.com/nextstrain/rsv/pull/94#discussion_r2214163028

- [ ] CHANGELOG
