### PR TITLE
Update "Show all labels" only show branch labels for visible branches

### DIFF
--- a/src/components/tree/phyloTree/labels.js
+++ b/src/components/tree/phyloTree/labels.js
@@ -72,7 +72,7 @@ const branchLabelFontWeight = (key) => {
 
 /** createBranchLabelVisibility (the return value should be passed to d3 style call)
  * @param {str} key e.g. "aa" or "clade"
- * @param {bool} showAll
+ * @param {bool} showAll show all labels for visible nodes
  * @param {str} layout
  * @param {int} totalTipsInView visible tips also in view
  * @return {func} Returns a function with 1 argument: the current node (branch).
@@ -80,8 +80,8 @@ const branchLabelFontWeight = (key) => {
  *                NOTE: the fn should only be provided nodes which have a label.
  */
 const createBranchLabelVisibility = (key, showAll, layout, totalTipsInView) => (d) => {
-  if (showAll) return "visible";
   if (d.visibility !== NODE_VISIBLE) return "hidden";
+  if (showAll) return "visible";
   const magicTipFractionToShowBranchLabel = 0.03;
   /* if the number of _visible_ tips descending from this node are over the
   magicTipFractionToShowBranchLabel (c/w the total number of _visible_ and


### PR DESCRIPTION
## Description of proposed changes

This commit updates the toggle to only show all branch labels for the selected tips instead of showing all branch labels regardless of filter status.

Originally proposed by @huddlej in Slack 
https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1756404579124849

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
