### PR TITLE
Add measurements panel to SVG download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Fixed a bug that prevented drag-and-drop metadata files from being parsed that was introduced in version 2.64.0 ([#2007](https://github.com/nextstrain/auspice/pull/2007))
+* Added SVG-download support for the measurements panel. ([#2005](https://github.com/nextstrain/auspice/pull/2005))
 
 ## version 2.65.0 - 2025/09/02
 

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -440,28 +440,44 @@ const createBoundingDimensionsAndPositionPanels = (panels, panelLayout, numLines
     panels.tree.width += (spaceBetweenTrees + panels.secondTree.width);
   }
 
-  // If display includes measurements panel then just position panels as if
-  // we are using the "full" display because the map will have the "full" dimensions
-  if (panelLayout === "grid" && panels.measurements) {
-    panelLayout = "full";
-  }
-
-  if (panels.tree && panels.map) {
-    if (panelLayout === "grid") {
-      width = panels.tree.width + padding + panels.map.width;
-      height = Math.max(panels.tree.height, panels.map.height);
-      panels.map.x = panels.tree.width + padding;
+  // Special handling of layout if measurements panel is included
+  // Display as if we are in "full" view to display all filtered measurements
+  if (panels.measurements) {
+    if (panels.tree) {
+      width = Math.max(panels.tree.width, panels.measurements.width);
+      height = panels.tree.height + padding + panels.measurements.height;
+      panels.measurements.y = panels.tree.height + padding;
     } else {
-      width = Math.max(panels.tree.width, panels.map.width);
-      height = panels.tree.height + padding + panels.map.height;
-      panels.map.y = panels.tree.height + padding;
+      width = panels.measurements.width;
+      height = panels.measurements.height;
     }
-  } else if (panels.tree) {
-    width = panels.tree.width;
-    height = panels.tree.height;
-  } else if (panels.map) {
-    width = panels.map.width;
-    height = panels.map.height;
+
+    panels.measurementsXAxis.y = height;
+    height += panels.measurementsXAxis.height;
+
+    if (panels.map) {
+      width = Math.max(width, panels.map.width);
+      panels.map.y = height + padding;
+      height += padding + panels.map.height;
+    }
+  } else {
+    if (panels.tree && panels.map) {
+      if (panelLayout === "grid") {
+        width = panels.tree.width + padding + panels.map.width;
+        height = Math.max(panels.tree.height, panels.map.height);
+        panels.map.x = panels.tree.width + padding;
+      } else {
+        width = Math.max(panels.tree.width, panels.map.width);
+        height = panels.tree.height + padding + panels.map.height;
+        panels.map.y = panels.tree.height + padding;
+      }
+    } else if (panels.tree) {
+      width = panels.tree.width;
+      height = panels.tree.height;
+    } else if (panels.map) {
+      width = panels.map.width;
+      height = panels.map.height;
+    }
   }
 
   if (panels.entropy) {
@@ -546,11 +562,19 @@ const writeSVGPossiblyIncludingMap = (dispatch, filePrefix, panelsInDOM, panelLa
       }
     }
   }
-  if (panelsInDOM.indexOf("measurements" !== -1)) {
-    // Placeholder for measurements panel in downloaded SVG
-    // Used to determine the layout of the map panel since the measurements
-    // panel influences the map's layout in the "Grid" display
-    panels.measurements = {}
+  if (panelsInDOM.indexOf("measurements") !== -1) {
+    try {
+      panels.measurements = processXMLString((new XMLSerializer()).serializeToString(document.getElementById("d3MeasurementsSVG")));
+      panels.measurementsXAxis = processXMLString((new XMLSerializer()).serializeToString(document.getElementById("d3MeasurementsXAxisSVG")));
+      // Get the actual width of SVG from the measurements container since the SVG just uses width=100%
+      const measurementsContainer = document.getElementById("measurementsSVGContainer");
+      panels.measurements.width = measurementsContainer.clientWidth;
+      panels.measurementsXAxis.width = measurementsContainer.clientWidth;
+    } catch (e) {
+      panels.measurements = undefined;
+      errors.push("measurements");
+      console.error("Measurements SVG save error:", e);
+    }
   }
   if (panelsInDOM.indexOf("entropy") !== -1) {
     try {

--- a/src/components/download/helperFunctions.js
+++ b/src/components/download/helperFunctions.js
@@ -440,6 +440,12 @@ const createBoundingDimensionsAndPositionPanels = (panels, panelLayout, numLines
     panels.tree.width += (spaceBetweenTrees + panels.secondTree.width);
   }
 
+  // If display includes measurements panel then just position panels as if
+  // we are using the "full" display because the map will have the "full" dimensions
+  if (panelLayout === "grid" && panels.measurements) {
+    panelLayout = "full";
+  }
+
   if (panels.tree && panels.map) {
     if (panelLayout === "grid") {
       width = panels.tree.width + padding + panels.map.width;
@@ -539,6 +545,12 @@ const writeSVGPossiblyIncludingMap = (dispatch, filePrefix, panelsInDOM, panelLa
         console.error("Second Tree / tanglegram SVG save error:", e);
       }
     }
+  }
+  if (panelsInDOM.indexOf("measurements" !== -1)) {
+    // Placeholder for measurements panel in downloaded SVG
+    // Used to determine the layout of the map panel since the measurements
+    // panel influences the map's layout in the "Grid" display
+    panels.measurements = {}
   }
   if (panelsInDOM.indexOf("entropy") !== -1) {
     try {


### PR DESCRIPTION
## Description of proposed changes

[community build in test app](https://nextstrain-s-nextstrain-odvsnx.herokuapp.com/community/joverlee521/nextstrain-testing/flu/seasonal/h1n1pdm/ha/09-17)

Requested by @huddlej on [Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1756924488904799).

From discussion in person, we want all filtered measurements usually displayed in the scrolling panel as one long panel in the SVG. This does mean the downloaded SVG in "Grid" display is not ideal since the tree and measurement panels have the smaller "Grid" widths while the other panels are all "full" panels. 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
