### PR TITLE
Fix drag-and-drop metadata

### DIFF
--- a/src/actions/filesDropped/metadata.js
+++ b/src/actions/filesDropped/metadata.js
@@ -250,13 +250,13 @@ function checkDataForErrors(dispatch, getState, newNodeAttrs, newColorings, igno
   if (droppedColorings.size) {
     dispatch(warningNotification({
       message: `Ignoring ${droppedColorings.size} columns as they are already set as colorings or are "special" cases to be ignored`,
-      details: droppedColorings.join(", ")
+      details: [...droppedColorings].join(", ")
     }));
   }
   if (droppedNodes.size) {
     dispatch(warningNotification({
       message: `Ignoring ${droppedNodes.size} taxa (CSV rows) nodes (rows) as they don't appear in the tree`,
-      details: droppedNodes.join(", ")
+      details: [...droppedNodes].join(", ")
     }));
   }
 


### PR DESCRIPTION
## Description

30706ec20040bf1e9a201e48083a8cd0bea23447 switched to importing `core-js/stable`  instead of the full library which dropped support for `Set.join()`. 

This commit converts the Sets to arrays to join the values based on discussion  in https://github.com/nextstrain/auspice/issues/2006.

Resolves https://github.com/nextstrain/auspice/issues/2006

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
