### PR TITLE
splash: Use anchor element for links

### DIFF
--- a/src/components/splash/splash.js
+++ b/src/components/splash/splash.js
@@ -16,20 +16,7 @@ const ColumnList = styled.ul`
   column-gap: 20px;
 `;
 
-const formatDataset = (requestPath, dispatch, changePage) => {
-  return (
-    <li key={requestPath}>
-      <div
-        style={{color: "#5097BA", textDecoration: "none", cursor: "pointer", fontWeight: "400", fontSize: "94%"}}
-        onClick={() => dispatch(changePage({path: requestPath, push: true}))}
-      >
-        {requestPath}
-      </div>
-    </li>
-  );
-};
-
-const SplashContent = ({available, browserDimensions, dispatch, errorMessage, changePage}) => {
+const SplashContent = ({available, browserDimensions, errorMessage}) => {
 
   const Header = () => (
     <>
@@ -89,7 +76,11 @@ const SplashContent = ({available, browserDimensions, dispatch, errorMessage, ch
           <div style={{display: "flex", flexWrap: "wrap"}}>
             <div style={{flex: "1 50%", minWidth: "0"}}>
               <ColumnList width={browserDimensions.width}>
-                {data.map((d) => formatDataset(d.request, dispatch, changePage))}
+                {data.map((d) => (
+                  <li key={d.request}>
+                    <a href={d.request}>{d.request}</a>
+                  </li>
+                ))}
               </ColumnList>
             </div>
           </div>


### PR DESCRIPTION
## Description of proposed changes

Replaces div styled to look like links with anchor elements so that behavior such as opening links in a new tab work as expected.

Although the default `SplashContent` component no longer uses the `dispatch` and  `changePage` props, I'm keeping them in the parent `Splash` component to prevent breaking changes in the customizable splash component API.

Resolves <https://github.com/nextstrain/auspice/issues/2008>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
