### PR TITLE
Declare support for Node.js 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Added support for Node.js version 24 and its corresponding NPM version (11). ([#2012](https://github.com/nextstrain/auspice/pull/2012))
+
 ## version 2.66.0 - 2025/09/05
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,8 +129,8 @@
         "typescript": "^5.0.2"
       },
       "engines": {
-        "node": "^20 || ^22",
-        "npm": "^9 || ^10"
+        "node": "^20 || ^22 || ^24",
+        "npm": "^9 || ^10 || ^11"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "repository": "github:nextstrain/auspice",
   "homepage": "https://www.npmjs.com/package/auspice",
   "engines": {
-    "node": "^20 || ^22",
-    "npm": "^9 || ^10"
+    "node": "^20 || ^22 || ^24",
+    "npm": "^9 || ^10 || ^11"
   },
   "bin": {
     "auspice": "./auspice.js"


### PR DESCRIPTION
## Description of proposed changes

I did some local testing with Node.js 24 and it worked fine without any code changes.

## Related issue(s)

Follow-up to https://github.com/nextstrain/auspice/pull/1975#discussion_r2110811691

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ N/A, downstream repos use Node.js 20

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
