### PR TITLE
Improve legend & frequencies display of continous color scales

### DIFF
--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -11,6 +11,7 @@ import { unassigned_label } from "../../util/processFrequencies";
 import { isColorByGenotype, decodeColorByGenotype } from "../../util/getGenotype";
 import { numericToCalendar } from "../../util/dateHelpers";
 import { computeTemporalGridPoints } from "../tree/phyloTree/grid";
+import { formatBounds } from "../../util/colorScale";
 
 /* C O N S T A N T S */
 const opacity = 0.85;
@@ -195,7 +196,9 @@ const getMeaningfulLabels = (categories, colorScale) => {
       if (colorScale.legendLabels?.has(name)) {
         return colorScale.legendLabels.get(name);
       }
-      return `${colorScale.legendBounds[name][0].toFixed(2)} - ${colorScale.legendBounds[name][1].toFixed(2)}`;
+      // Format the bounds for display. Note: Auspice has a 'temporal' colorscale but
+      // it's not (?) ever used - even for `num_date`!
+      return formatBounds(colorScale.legendBounds[name], colorScale.colorBy==='num_date')
     });
   }
   return categories.slice();

--- a/src/components/frequencies/functions.js
+++ b/src/components/frequencies/functions.js
@@ -188,10 +188,15 @@ const turnMatrixIntoSeries = (categories, nPivots, matrix) => {
 
 const getMeaningfulLabels = (categories, colorScale) => {
   if (colorScale.continuous) {
-    return categories.map((name) => name === unassigned_label ?
-      unassigned_label :
-      `${colorScale.legendBounds[name][0].toFixed(2)} - ${colorScale.legendBounds[name][1].toFixed(2)}`
-    );
+    return categories.map((name) => {
+      if (name === unassigned_label) {
+        return unassigned_label;
+      }
+      if (colorScale.legendLabels?.has(name)) {
+        return colorScale.legendLabels.get(name);
+      }
+      return `${colorScale.legendBounds[name][0].toFixed(2)} - ${colorScale.legendBounds[name][1].toFixed(2)}`;
+    });
   }
   return categories.slice();
 };

--- a/src/components/tree/legend/item.js
+++ b/src/components/tree/legend/item.js
@@ -11,6 +11,7 @@ const LegendItem = ({
   rectStroke,
   rectFill,
   label,
+  tooltip,
   value
 }) => (
   <g
@@ -28,14 +29,16 @@ const LegendItem = ({
       height={legendRectSize}
       fill={rectFill}
       stroke={rectStroke}
-    />
+    >
+      <title>{tooltip}</title>
+    </rect>  
     <text
       x={legendRectSize + legendSpacing + 5}
       y={legendRectSize - legendSpacing}
       style={{fontSize: 12, fill: darkGrey, fontFamily: dataFont}}
       clipPath={clipId?`url(#${clipId})`:undefined}
     >
-      <title>{label}</title>
+      <title>{tooltip}</title>
       {label}
     </text>
   </g>

--- a/src/components/tree/legend/legend.js
+++ b/src/components/tree/legend/legend.js
@@ -5,6 +5,7 @@ import LegendItem from "./item";
 import { headerFont, darkGrey } from "../../../globalStyles";
 import { fastTransitionDuration, months } from "../../../util/globals";
 import { getBrighterColor, getColorByTitle } from "../../../util/colorHelpers";
+import { formatBounds } from "../../../util/colorScale";
 import { numericToCalendar } from "../../../util/dateHelpers";
 import { TOGGLE_LEGEND } from "../../../actions/types";
 
@@ -163,6 +164,7 @@ class Legend extends React.Component {
             value={d}
             label={this.styleLabelText(d)}
             index={i}
+            tooltip={tooltipText(this.props.colorScale, d)}
             clipId={i<maxNumPerColumn ? "legendFirstColumnClip" : undefined}
           />
         );
@@ -235,5 +237,20 @@ class Legend extends React.Component {
     );
   }
 }
+
+/**
+ * Create the text to be shown as a tooltip on the legend entry
+ */
+function tooltipText(colorScale, value) {
+  if (!colorScale.continuous) {
+    return value
+  }
+  
+  const bounds = colorScale.legendBounds[value];
+  const temporal = colorScale.colorBy==='num_date';
+  
+  return `Bounds: ${formatBounds(bounds, temporal)}`;
+}
+
 
 export default Legend;

--- a/src/util/colorScale.ts
+++ b/src/util/colorScale.ts
@@ -608,7 +608,10 @@ function parseUserProvidedLegendData(
  */
 export function formatBounds(bounds: [number, number], temporal: boolean):string {
   if (temporal) {
-    return `(${numericToCalendar(bounds[0])}, ${numericToCalendar(bounds[0])}]`;
+    // lower/uppermost bounds are often infinity, which doesn't go to a calendar date nicely!
+    const lower = bounds[0] === -Infinity ? '-∞' : numericToCalendar(bounds[0]);
+    const upper = bounds[1] === Infinity ? '∞' : numericToCalendar(bounds[1]);
+    return `(${lower}, ${upper}]`;
   } 
   return `(${bounds[0].toFixed(2)}, ${bounds[1].toFixed(2)}]`;
 }

--- a/src/util/colorScale.ts
+++ b/src/util/colorScale.ts
@@ -12,6 +12,7 @@ import { sortedDomain } from "./sortedDomain";
 import { ColoringInfo, Legend, Metadata } from "../metadata";
 import { ColorScale, ControlsState, Genotype, LegendBounds, LegendLabels, LegendValues, ScaleType } from "../reducers/controls";
 import { ReduxNode, TreeState, TreeTooState, Visibility } from "../reducers/tree/types";
+import { numericToCalendar } from "./dateHelpers";
 
 export const unknownColor = "#ADB1B3";
 
@@ -560,13 +561,8 @@ function parseUserProvidedLegendData(
 
   const legendValues: LegendValues = data.map((d) => d.value);
 
-  const legendLabels: LegendLabels = new Map(
-    data.map((d) => {
-      return (typeof d.display === "string" || typeof d.display === "number") ? [d.value, d.display] : [d.value, d.value];
-    })
-  );
-
   let legendBounds: LegendBounds = {};
+  let userProvidedLegendBounds: boolean;
   if (scaleType==="continuous") {
     const boundArrays = data.map((d) => d.bounds)
       .filter((b) => Array.isArray(b) && b.length === 2 && typeof b[0] === "number" && typeof b[1] === "number")
@@ -583,9 +579,36 @@ function parseUserProvidedLegendData(
       });
     if (boundArrays.length===legendValues.length) {
       legendValues.forEach((v, i) => {legendBounds[v]=boundArrays[i];});
+      userProvidedLegendBounds = true;
     } else {
       legendBounds = createLegendBounds(legendValues);
+      userProvidedLegendBounds = false;
     }
   }
+
+  const legendLabels: LegendLabels = new Map(
+    data.map((d, idx) => {
+      if (typeof d.display === "string" || typeof d.display === "number") {
+        return [d.value, d.display];
+      }
+      // If the JSON scale defined bounds, but not a 'display' property, then display the bounds not the anchor value
+      if (scaleType==="continuous" && userProvidedLegendBounds) {
+        return [d.value, formatBounds(legendBounds[legendValues[idx]], false)];
+      }
+      return [d.value, d.value]; // display the value since the 'display' key wasn't specified in the JSON
+    })
+  );
+
   return {legendValues, legendLabels, legendBounds};
+}
+
+/** format the (continuous scale's bin's) bounds for display using mathematical
+ * notation to indicate the range is exclusive of the lower bound, inclusive of
+ * the upper
+ */
+export function formatBounds(bounds: [number, number], temporal: boolean):string {
+  if (temporal) {
+    return `(${numericToCalendar(bounds[0])}, ${numericToCalendar(bounds[0])}]`;
+  } 
+  return `(${bounds[0].toFixed(2)}, ${bounds[1].toFixed(2)}]`;
 }


### PR DESCRIPTION
A number of small (but nice) improvements to how we display information associated with a legend entry (bin) for continuous scales. See commit messages for full details as well as screenshots in this PR. Motivated by bug no. 1 in #2014 which this fixes.

**on-hover legend displays the bounds for continuous scales, including date-formatting**
<img width="269" height="194" alt="image" src="https://github.com/user-attachments/assets/8c626008-55e3-4ce1-be9b-238c12fcb675" />

**frequencies panel uses JSON-defined "display", where available**
<img width="1029" height="92" alt="image" src="https://github.com/user-attachments/assets/d96af7c9-c1c1-484a-a423-21f651521b24" />



