### PR TITLE
Shift click entropy bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 * Mutations in a node-info modal (via tip click or shift+branch click) are now clickable. Clicking on a mutation will colour the tree by the genotypes at that position. Shift+clicking will append that position to the current genotype colouring (if possible), or remove it if it's already part of it. Command clicking (with or without shift) will behave similarly but filter the tree via the specific mutated state instead of changing the colouring. ([#2018](https://github.com/nextstrain/auspice/pull/2018))
+* Shift-clicking bars in the entropy panel will now add the position to the existing color-by (as long as the gene is the same), or remove it if it was already part of the color-by. ([#2019](https://github.com/nextstrain/auspice/pull/2019))
 * Added support for Node.js version 24 and its corresponding NPM version (11). ([#2012](https://github.com/nextstrain/auspice/pull/2012))
 
 ## version 2.66.0 - 2025/09/05

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -1093,7 +1093,9 @@ EntropyChart.prototype._mainTooltipAa = function _mainTooltipAa(d) {
           {this.showCounts ? `${t("Num changes observed")}: ${d.y}` : `${t("Normalised Shannon entropy")}: ${d.y}`}
         </div>
         <div style={infoPanelStyles.comment}>
-        {t("Click to color tree & map by this genotype")}
+          {t("Click to color tree & map by this genotype")}
+          <br/>
+          {t("Shift+click to add/remove positions")}
         </div>
       </div>
     );
@@ -1146,6 +1148,8 @@ EntropyChart.prototype._mainTooltipNuc = function _mainTooltipAa(d) {
         </div>
         <div style={infoPanelStyles.comment}>
           {t("Click to color tree & map by this genotype")}
+          <br/>
+          {t("Shift+click to add/remove positions")}
         </div>
       </div>
     );


### PR DESCRIPTION
This builds on the ability to shift-click additional mutations in a tree's info modal <https://github.com/nextstrain/auspice/pull/2018> and have them added/removed from the current color-by, as applicable.

Closes https://github.com/nextstrain/auspice/issues/1766
