### PR TITLE
Tree buttons for each tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* When multiple trees are displayed ("tangletrees") the tree-buttons (zoom out, zoom to selected, zoom to root) are now present for each tree and only change their respective tree. ([#2026](https://github.com/nextstrain/auspice/pull/2026))
 * Downloaded TSV will include associated URL regardless of value type ([#2024](https://github.com/nextstrain/auspice/pull/2024))
 * Tip info modal displays link for traits that have a URL regardless of value type ([#2024](https://github.com/nextstrain/auspice/pull/2024))
 

--- a/src/components/framework/card.js
+++ b/src/components/framework/card.js
@@ -27,7 +27,7 @@ class Card extends React.Component {
         fontWeight: 500,
         backgroundColor: "#FFFFFF",
         borderTop: "thin solid #BBB",
-        minHeight: "15px"
+        minHeight: this.props.tallTitle ? 25 : 15,
       }
     };
   }

--- a/src/components/tree/tangle/index.js
+++ b/src/components/tree/tangle/index.js
@@ -80,7 +80,7 @@ class Tangle extends React.Component {
     }
   }
   render() {
-    const textStyles = {position: "absolute", top: 5, zIndex: 100, fontSize: 16, color: "#000", fontWeight: 500};
+    const textStyles = {position: "absolute", top: 25, zIndex: 100, fontSize: 16, color: "#000", fontWeight: 500};
     const lefts = [this.props.width/2 - this.props.spaceBetweenTrees/2, this.props.width/2 + this.props.spaceBetweenTrees/2];
     return (
       <div id="TangleContainer">

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -149,7 +149,7 @@ export class TreeComponent extends React.Component<TreeComponentProps, TreeCompo
     const { t } = this.props;
     const widthPerTree = this.props.showTreeToo ? (this.props.width - spaceBetweenTrees) / 2 : this.props.width;
     return (
-      <Card center infocard={this.props.showOnlyPanels} title={t("Phylogeny")}>
+      <Card center infocard={this.props.showOnlyPanels} title={t("Phylogeny")} tallTitle={!!this.props.showTreeToo}>
         <ErrorBoundary>
           <Legend width={this.props.width}/>
         </ErrorBoundary>
@@ -199,7 +199,12 @@ export class TreeComponent extends React.Component<TreeComponentProps, TreeCompo
           this.renderTreeDiv({width: widthPerTree, height: this.props.height, mainTree: false}) :
           null
         }
-        <TreeButtons {...this.props} />
+
+        <TreeButtons {...this.props}  mainTree={true}
+          offsetPx={this.props.showTreeToo ? widthPerTree + spaceBetweenTrees + 5 : 5} />
+
+        {this.props.showTreeToo && 
+          <TreeButtons {...this.props} mainTree={false} offsetPx={5} />}
       </Card>
     );
   }


### PR DESCRIPTION
For single trees (i.e. 99% of Auspice usage) there should be no changes.

For tangle-trees I often want more fine-grained control than the current situation and making the buttons per-tree gives me this. There are occasions where we'll now have to click two buttons, but that's an acceptable trade off for me. (Perhaps we can implement a shift-click to apply to both trees if this really frustrates someone!)

Example:

<img width="1400" height="120" alt="image" src="https://github.com/user-attachments/assets/803ba4ac-30c0-4f08-bd2f-34c2948d41e5" />


