### PR TITLE
Allow protein-only datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## version 2.68.0 - 2026/01/20
+* Allow protein-only datasets, i.e. a dataset whose genome annotation is missing a nuc block but with CDSs defined. This work is in tandem with [this Augur PR](https://github.com/nextstrain/augur/pull/1958). ([Auspice PR #2040](https://github.com/nextstrain/auspice/pull/2040))
 
+## version 2.68.0 - 2026/01/20
 
 #### Major changes
 
@@ -18,24 +19,20 @@
 
 ## version 2.67.0 - 2025/11/03
 
-
 * Mutations in a node-info modal (via tip click or shift+branch click) are now clickable. Clicking on a mutation will colour the tree by the genotypes at that position. Shift+clicking will append that position to the current genotype colouring (if possible), or remove it if it's already part of it. Command clicking (with or without shift) will behave similarly but filter the tree via the specific mutated state instead of changing the colouring. ([#2018](https://github.com/nextstrain/auspice/pull/2018))
 * Shift-clicking bars in the entropy panel will now add the position to the existing color-by (as long as the gene is the same), or remove it if it was already part of the color-by. ([#2019](https://github.com/nextstrain/auspice/pull/2019))
 * Added support for Node.js version 24 and its corresponding NPM version (11). ([#2012](https://github.com/nextstrain/auspice/pull/2012))
 
 ## version 2.66.0 - 2025/09/05
 
-
 * Fixed a bug that prevented drag-and-drop metadata files from being parsed that was introduced in version 2.64.0 ([#2007](https://github.com/nextstrain/auspice/pull/2007))
 * Added SVG-download support for the measurements panel. ([#2005](https://github.com/nextstrain/auspice/pull/2005))
 
 ## version 2.65.0 - 2025/09/02
 
-
 * "show all branch labels" toggle has been updated to only show labels for visible branches, i.e. branches of selected tips after applying filters ([#2004](https://github.com/nextstrain/auspice/pull/2004))
 
 ## version 2.64.0 - 2025/08/15
-
 
 * Link-outs are explicitly disabled for v1 datasets because the nextstrain.org API does not support the v1 -> v2 conversion. ([#2002](https://github.com/nextstrain/auspice/pull/2002))
 * Added a `treeZoom=selected` query to load trees at the same zoom level after the "zoom to selected" button has been pressed, where applicable. See [the view settings docs](https://docs.nextstrain.org/projects/auspice/en/latest/advanced-functionality/view-settings.html) for more details. ([#1321](https://github.com/nextstrain/auspice/pull/1321))
@@ -54,7 +51,6 @@
 
 ## version 2.63.1 - 2025/06/04
 
-
 * Fixed a bug where datasets without the (optional!) `display_defaults` would crash, which included newick files dragged onto auspice.us. ([#1986](https://github.com/nextstrain/auspice/pull/1986))
 
 ## version 2.63.0 - 2025/06/02
@@ -71,7 +67,6 @@
 * Dropped support for Node.JS versions 16 & 18 and their corresponding NPM versions (7 & 8). ([#1975](https://github.com/nextstrain/auspice/pull/1975))
 
 ## version 2.62.0 - 2025/01/21
-
 
 * Added a new color tree by measurements feature.
   Clicking on a group in the measurements panel will add a new coloring to the tree,

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -226,7 +226,7 @@ const modifyStateViaURLQuery = (state, query) => {
   if (query.focus) {
     if (query.focus !== "selected") {
       console.error(`Invalid focus value of ${JSON.stringify(query.focus)}; removing focus.`);
-      delete query.focus; 
+      delete query.focus;
     } else if (state.showStreamTrees) {
       console.error(`Cannot use focus and streamtrees at the same time; removing focus.`);
       delete query.focus;
@@ -1161,7 +1161,10 @@ export const createStateFromQueryOrJSONs = ({
   /* calculate entropy in view */
   if (entropy.loaded) {
     /* The selected CDS + positions are only known if a genotype color-by has been set (display defaults | url) */
-    entropy.selectedCds = nucleotide_gene;
+    /* if the JSON is proteinOnly and we have a single gene (and CDS within that gene), default to viewing that gene */
+    entropy.selectedCds = (entropy.genomeMap[0].proteinOnly && entropy.genomeMap[0].genes.length === 1 && entropy.genomeMap[0].genes[0].cds.length === 1) ?
+      entropy.genomeMap[0].genes[0].cds[0] :
+      nucleotide_gene;
     entropy.selectedPositions = [];
     if (isColorByGenotype(controls.colorBy)) {
       const gt = decodeColorByGenotype(controls.colorBy);

--- a/src/components/controls/color-by.js
+++ b/src/components/controls/color-by.js
@@ -136,10 +136,12 @@ class ColorBy extends React.Component {
 
   getGtGeneOptions() {
     if (!this.props.genomeMap?.length) return [];
-    const options = [
-      // Nuc is first option, especially helpful when there are many many genes/CDSs
-      {value: nucleotide_gene, label: "nucleotide"}
-    ]
+    const proteinOnly = this.props.genomeMap?.[0].proteinOnly === true;
+    const options = proteinOnly ?
+      [] :
+      [ // Nuc is first option, especially helpful when there are many many genes/CDSs
+        {value: nucleotide_gene, label: "nucleotide"}
+      ]
     this.props.genomeMap[0].genes.forEach((gene) => {
       /**
        * A lot of the code in this file refers to "gene(s)", however the actual dropdown

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -106,7 +106,7 @@ EntropyChart.prototype._setZoomBounds = function _setZoomBounds() {
     const cdsGenomeCoords = this.selectedCds.segments.map((s) => s.rangeGenome).flat();
     this.zoomBounds = [Math.min(...cdsGenomeCoords), Math.max(...cdsGenomeCoords)];
   } else {
-    this.zoomBounds = [0, this.genomeMap[0].range[1]];
+    this.zoomBounds = [...this.genomeMap[0].range];
   }
 }
 
@@ -425,7 +425,7 @@ EntropyChart.prototype._drawNavCds = function _drawNavCds() {
  * Arguments (all optional):
  * selected: string - only return segments from the currently selected CDS
  * range: (RangeGenome|undefined) - return only segments which are visible in that range
- * @returns 
+ * @returns
  */
 EntropyChart.prototype._cdsSegments = function _cdsSegments({range=undefined, selected=false}) {
   const cdsSegments = []
@@ -518,7 +518,7 @@ EntropyChart.prototype._drawBars = function _drawBars() {
     .enter().append("rect")
     .attr("class", "bar")
     .attr("id", barSvgId)
-    .attr("x", (d) => this.aa ? 
+    .attr("x", (d) => this.aa ?
       this.scales.xMain((d.codon-1)*3+2) - barWidthHalf :
       this.scales.xMain(d.x) - barWidthHalf
     )
@@ -558,21 +558,22 @@ EntropyChart.prototype._drawBars = function _drawBars() {
 EntropyChart.prototype._setScales = function _setScales(yMax) {
   this.scales = {};
 
-  const genomeLength = this.genomeMap[0].range[1];
-  const mainAxisLength = this.selectedCds === nucleotide_gene ? genomeLength : this.selectedCds.length;
-  /* Note that the domains start at zero, but there is no nuc/aa plotted at scale(0). We do, however, shift the bars
-  left a bit so that the ~center of the bar is over scale(xVal). Starting at 0 therefore gives us some room to allow
-  this for a bar at scale(1). Given this, we should perhaps be using mainAxisLength+1 for the domain. TODO. */
+  const genomeRange = this.genomeMap[0].range;
+  const mainAxisMax = this.selectedCds === nucleotide_gene ? genomeRange[1] : this.selectedCds.length;
+  const mainAxisStart = this.selectedCds === nucleotide_gene ? genomeRange[0] : 0;
+  /* Note that for CDS view the domain starts at zero, but there is no aa plotted at scale(0). We do, however, shift
+  the bars left a bit so that the ~center of the bar is over scale(xVal). Starting at 0 therefore gives us some room
+  to allow this for a bar at scale(1). Given this, we should perhaps be using mainAxisMax+1 for the domain. TODO. */
   this.scales.xMain = scaleLinear()
-    .domain([0, mainAxisLength])
+    .domain([mainAxisStart, mainAxisMax])
     .range([0, this.offsets.widthNarrow]); // origin is shifted via transform on <g>
   this.scales.xNav = scaleLinear()
-    .domain([0, genomeLength])
+    .domain([...genomeRange])
     .range([0, this.offsets.width]); // origin is shifted via transform on <g>
   this.scales.y = scaleLinear()
     .domain([0, yMax])
     .range([this.offsets.heightMainBars, 0]);
-  this.scales.xMainUpperLimit = mainAxisLength;
+  this.scales.xMainUpperLimit = mainAxisMax;
 };
 
 EntropyChart.prototype._drawAxes = function _drawAxes() {
@@ -618,8 +619,9 @@ EntropyChart.prototype._drawAxes = function _drawAxes() {
 
 EntropyChart.prototype._updateMainScaleAndAxis = function _updateMainScaleAndAxis(yMax) {
 
-  const genomeLength = this.genomeMap[0].range[1];
-  const mainAxisLength = this.selectedCds === nucleotide_gene ? genomeLength : this.selectedCds.length;
+  const genomeRange = this.genomeMap[0].range;
+  const mainAxisLength = this.selectedCds === nucleotide_gene ? genomeRange[1] : this.selectedCds.length;
+  const mainAxisStart = this.selectedCds === nucleotide_gene ? genomeRange[0] : 0;
 
   if (this.scales.xMain.domain()[1] !== mainAxisLength) {
     /* update the svg <g> transforms (only technically necessary on nucleotide <-> CDS change */
@@ -631,7 +633,7 @@ EntropyChart.prototype._updateMainScaleAndAxis = function _updateMainScaleAndAxi
       .attr("height", this.offsets.heightMainBars);
 
     /* update the scales & rerender x-axis */
-    this.scales.xMain.domain([0, mainAxisLength])
+    this.scales.xMain.domain([mainAxisStart, mainAxisLength])
       .range([0, this.offsets.widthNarrow]); // origin is shifted via transform on <g>
     this.scales.xMainUpperLimit = mainAxisLength;
     this._groups.mainXAxis.call(this.axes.xMain);
@@ -693,7 +695,7 @@ EntropyChart.prototype._calcOffsets = function _calcOffsets(width, height) {
   this.offsets.navCdsRectHeight = navCdsRectHeight;
   this.offsets.navAxisY1 = height - marginBottom - this.offsets.brushHandleHeight -
     tickSpace - navCdsNegativeStrandSpace;
-  this.offsets.navCdsY1 = this.offsets.navAxisY1 - 
+  this.offsets.navCdsY1 = this.offsets.navAxisY1 -
     tinySpace - // space above axis line before any CDS appears
     navCdsPositiveStrandSpace;
   this.offsets.navCdsPositiveStrandSpace = navCdsPositiveStrandSpace;
@@ -711,15 +713,15 @@ EntropyChart.prototype._calcOffsets = function _calcOffsets(width, height) {
   updates as we zoom, but zooming doesn't change the offsets. When (if) a CDS is
   selected then the axis doesn't change position, but the space above it (and
   thus mainCdsY1, heightMainBars) changes */
-  this.offsets.mainAxisY1 = this.offsets.brushY1 - 
+  this.offsets.mainAxisY1 = this.offsets.brushY1 -
     tinySpace -
     tickSpace;
-  if (this.aa) {  
-    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 - 
+  if (this.aa) {
+    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 -
       tinySpace - // space above axis line before any CDS appears
       mainCdsRectHeight; // space only for a single rect
   } else {
-    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 - 
+    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 -
       tinySpace - // space above axis line before any CDS appears
       mainCdsNegativeStrandSpace -
       tinySpace - // space between -ve, +ve strand CDSs
@@ -736,9 +738,9 @@ EntropyChart.prototype._calcOffsets = function _calcOffsets(width, height) {
 
   /* mainY1 is the top of the bar chart, and so the bars are the space that's left over */
   this.offsets.mainY1 = marginTop;
-  this.offsets.heightMainBars = this.offsets.mainCdsY1 - 
-    this.offsets.mainY1 - 
-    tinySpace; // space between topmost CDS + bars starting 
+  this.offsets.heightMainBars = this.offsets.mainCdsY1 -
+    this.offsets.mainY1 -
+    tinySpace; // space between topmost CDS + bars starting
 
   /* We now consider the horizontal offsets.
   The Nav, Brush, and y-axis all use x1,x2, width, which never changes */
@@ -767,21 +769,21 @@ EntropyChart.prototype._updateOffsets = function _updateOffsets() {
   if (this.aa) {
     this.offsets.x1Narrow = this.offsets.x1 + this.offsets.xMainInternalPad
     this.offsets.widthNarrow = this.offsets.width - 2*this.offsets.xMainInternalPad;
-    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 - 
+    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 -
       this.offsets.tinySpace - // space above axis line before any CDS appears
       this.offsets.mainCdsRectHeight; // space only for a single rect
   } else {
     this.offsets.x1Narrow = this.offsets.x1;
     this.offsets.widthNarrow = this.offsets.width;
-    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 - 
+    this.offsets.mainCdsY1 = this.offsets.mainAxisY1 -
       this.offsets.tinySpace - // space above axis line before any CDS appears
       this.offsets.mainCdsNegativeStrandSpace -
       this.offsets.tinySpace - // space between -ve, +ve strand CDSs
       this.offsets.mainCdsPositiveStrandSpace;
   }
-  this.offsets.heightMainBars = this.offsets.mainCdsY1 - 
-    this.offsets.mainY1 - 
-    this.offsets.tinySpace; // space between topmost CDS + bars starting 
+  this.offsets.heightMainBars = this.offsets.mainCdsY1 -
+    this.offsets.mainY1 -
+    this.offsets.tinySpace; // space between topmost CDS + bars starting
 }
 
 /**
@@ -792,7 +794,7 @@ EntropyChart.prototype._updateOffsets = function _updateOffsets() {
 EntropyChart.prototype._setUpZoomBrush = function _setUpZoomBrush() {
   this.brush = brushX()
     .extent([   // Extent viewport is relative to the <g id=navBrush> transform
-      [0, 0],   // top-left 
+      [0, 0],   // top-left
       [this.offsets.width, this.offsets.brushHeight] // bottom-right
     ])
     .on("brush", () => { // https://github.com/d3/d3-brush#brush_on
@@ -823,7 +825,7 @@ EntropyChart.prototype._setUpZoomBrush = function _setUpZoomBrush() {
     .attr("class", "handle--custom")
     .attr("stroke", darkGrey)
     .attr("stroke-width", 2)
-    .attr("cursor", (_, i) => this.zoomCoordinates[i]===this.zoomBounds[i] ? 
+    .attr("cursor", (_, i) => this.zoomCoordinates[i]===this.zoomBounds[i] ?
       (i===0 ? "e-resize" : "w-resize") : "ew-resize")
     .attr("d", `M0,0 -5,${height} 5,${height} Z`)
     /* see the extent x,y params in brushX() (above) */
@@ -844,7 +846,7 @@ EntropyChart.prototype._setUpZoomBrush = function _setUpZoomBrush() {
  * (i) hiding the original brush
  * (ii) adding rectangles either side of the original brush which extend to the genome bounds
  * This is safe to call in any situation - whether the selected CDS is wrapping or not.
- * 
+ *
  * The rectangles set up here must be moved by another method (e.g. this._brushChanged).
  */
 EntropyChart.prototype._setUpZoomBrushWrapping = function _setUpZoomBrushWrapping() {
@@ -900,7 +902,7 @@ EntropyChart.prototype._brushChanged = function _brushChanged(final=false) {
   const s = d3event.selection || this.scales.xNav.range();
   const start_end = s.map(this.scales.xNav.invert, this.scales.xNav);
   this.zoomCoordinates = start_end.map(Math.round);
-  
+
   if (this.selectedCds===nucleotide_gene) {
     this.scales.xMain.domain(this.zoomCoordinates);
   } else {
@@ -916,7 +918,7 @@ EntropyChart.prototype._brushChanged = function _brushChanged(final=false) {
         });
     }
   }
-    
+
   this.axes.xMain = this.axes.xMain.scale(this.scales.xMain)
   this._groups.mainXAxis.call(this.axes.xMain);
   this._drawBars();
@@ -927,14 +929,14 @@ EntropyChart.prototype._brushChanged = function _brushChanged(final=false) {
       .attr("transform", (d, i) => `translate(${this.scales.xNav(this.zoomCoordinates[i])},${this.offsets.brushHeight})`);
     if (final) {
       this._groups.navBrush.selectAll(".handle--custom")
-        .attr("cursor", (_, i) => this.zoomCoordinates[i]===this.zoomBounds[i] ? 
+        .attr("cursor", (_, i) => this.zoomCoordinates[i]===this.zoomBounds[i] ?
           (i===0 ? "e-resize" : "w-resize") : "ew-resize");
     }
   }
   if (this._navBrushWrappingSelection) {
     this._navBrushWrappingSelection
       .attr("x", (d, i) => i===0 ? 0 : this.scales.xNav(this.zoomCoordinates[1]))
-      .attr("width", (d, i) => i===0 ? this.scales.xNav(this.zoomCoordinates[0]) : 
+      .attr("width", (d, i) => i===0 ? this.scales.xNav(this.zoomCoordinates[0]) :
         this.offsets.width - this.scales.xNav(this.zoomCoordinates[1]))
   }
 };
@@ -954,7 +956,7 @@ EntropyChart.prototype._setUpMousewheelZooming = function _setUpMousewheelZoomin
   const zoomExtents = [
     [this.offsets.x1Narrow, this.offsets.mainY1],     // top-left of the viewport extent
     [this.offsets.widthNarrow,                        // bottom-right of the viewport extent
-      this.offsets.heightMainBars+this.offsets.mainY1]  
+      this.offsets.heightMainBars+this.offsets.mainY1]
   ];
 
   const applyMousewheelZoom = zoom()
@@ -1032,7 +1034,7 @@ EntropyChart.prototype._createGroups = function _createGroups() {
   this._groups.mainCds = this.svg.append("g")
     .attr("id", "mainCds")
     .attr("transform", "translate(" + this.offsets.x1Narrow + "," + this.offsets.mainCdsY1 + ")");
-    
+
   this._groups.mainYAxis = this.svg.append("g")
     .attr("id", "entropyYAxis") // NOTE - id is referred to by tooltip
     .attr("transform", "translate(" + this.offsets.x1 + "," + this.offsets.mainY1 + ")")
@@ -1052,7 +1054,7 @@ EntropyChart.prototype._createGroups = function _createGroups() {
   this._groups.mainClip.append("clipPath")
     /** The coordinates here get translated by element where we apply the clipping.
      * In our case it's this._groups.mainBars.
-     * see https://bl.ocks.org/mbostock/4015254 
+     * see https://bl.ocks.org/mbostock/4015254
      */
     .attr("class", "clipPath")
     .attr("id", "clip") /* accessed by elements to be clipped via `url(#clip)` */
@@ -1063,7 +1065,7 @@ EntropyChart.prototype._createGroups = function _createGroups() {
       .attr("width", this.offsets.widthNarrow)
       .attr("height", this.offsets.heightMainBars);
 }
-  
+
 
 
 EntropyChart.prototype._mainTooltipAa = function _mainTooltipAa(d) {
@@ -1191,7 +1193,7 @@ EntropyChart.prototype._cdsTooltip = function _cdsTooltip(d) {
             <tr><td style={{minWidth: '100px'}}>Phase</td><td>{d.phase}</td></tr>
           </tbody>
         </table>
-        
+
         {this.selectedCds?.name !== d.cds.name &&
           (<div style={infoPanelStyles.comment}>
             {t("Click to view this CDS in isolation")}

--- a/src/components/entropy/entropyD3.js
+++ b/src/components/entropy/entropyD3.js
@@ -501,6 +501,22 @@ EntropyChart.prototype._drawBars = function _drawBars() {
     return this._drawLoadingState();
   }
 
+  if (this.bars.length === 0) {
+    // render "no muts here" text following approach of _drawLoadingState
+    this._groups.mainBars
+      .append("text")
+      .attr("x", () => this.scales.xMain.range()[1]/2)
+      .attr("y", () => this.scales.y.range()[0]/2)
+      .attr("pointer-events", "none")
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "middle")
+      .style("fill", darkGrey)
+      .style("font-size", '3rem')
+      .style("font-weight", 300)
+      .text(this.aa ? `No mutations for ${this.selectedCds.name}` : 'No nucleotide mutations')
+    return;
+  }
+
   /* Calculate bar width */
   const validXPos = this.scales.xMain.domain()[0]; // any value inside the scale's domain will do
   let barWidth = this.scales.xMain(validXPos+1) - this.scales.xMain(validXPos); // pixels between 2 nucleotides

--- a/src/components/entropy/index.js
+++ b/src/components/entropy/index.js
@@ -141,7 +141,8 @@ class Entropy extends React.Component {
 
   resetLayout(styles) {
     if (this.props.narrativeMode || !this.state.chart) return null;
-    const viewingGenome = this.props.selectedCds===nucleotide_gene;
+    const viewingGenome = this.props.selectedCds === nucleotide_gene;
+    const dontShowNuc = this.props.genomeMap[0].proteinOnly && this.props.genomeMap[0].genes.length === 1;
     /**
      * The intention for this button is to be inactive when viewing the genome &
      * fully zoomed out, however zoom actions do not trigger redux state changes
@@ -155,7 +156,7 @@ class Entropy extends React.Component {
           key={1}
           style={tabGroupMember}
           onClick={() => {
-            if (viewingGenome) {
+            if (viewingGenome || dontShowNuc) {
               this.state.chart.update({
                 zoomMin: this.state.chart.zoomBounds[0],
                 zoomMax: this.state.chart.zoomBounds[1],
@@ -228,7 +229,7 @@ class Entropy extends React.Component {
   }
   componentDidMount() {
     if (this.props.loaded) {
-      this.setUp(this.props); 
+      this.setUp(this.props);
       const observer = new IntersectionObserver(this.visibilityOnScreenChange.bind(this), {threshold: 0.0});
       observer.observe(this.d3entropy)
     }

--- a/src/components/tree/infoPanels/hover.js
+++ b/src/components/tree/infoPanels/hover.js
@@ -173,9 +173,9 @@ const TipMutations = ({node, t}) => {
  * @param  {Object} props.node     branch node which is currently highlighted
  * @param  {Object} props.geneSortFn function to sort a list of genes
  * @param  {Object} props.observedMutations counts of all observed mutations across the tree
-
+ * @param  {boolean}  props.proteinOnly Is the dataset protein only, i.e. no nuc annotation/mutations
  */
-const BranchMutations = ({node, geneSortFn, observedMutations, t}) => {
+const BranchMutations = ({node, geneSortFn, observedMutations, proteinOnly, t}) => {
   if (!node.branch_attrs || !node.branch_attrs.mutations) return null;
   const elements = []; // elements to render
   const mutations = node.branch_attrs.mutations;
@@ -187,7 +187,9 @@ const BranchMutations = ({node, geneSortFn, observedMutations, t}) => {
     (muts.length > maxNum ? ` + ${muts.length-maxNum} more` : '');
 
   /* --------- NUCLEOTIDE MUTATIONS --------------- */
-  if (categorisedMutations.nuc) {
+  if (proteinOnly) {
+    // don't render anything
+  } else if (categorisedMutations.nuc) {
     const nDisplay = 5; // max number of mutations to display per category
     if (categorisedMutations.nuc.unique.length) {
       elements.push(<InfoLine name='Unique Nucleotide mutations:' value={subset(categorisedMutations.nuc.unique, nDisplay)} key="nuc_unique"/>);
@@ -399,7 +401,7 @@ function StreamRibbonInfo({node, streamDetails, colorBy}) {
   const streamCountsSummary = streamCounts.total === streamCounts.visible ?
   `${streamCounts.total} (all visible)` :
   `${streamCounts.visible}/${streamCounts.total}`;
-  
+
   const category = node.streamCategories[streamDetails.categoryIndex].name;
   const rippleNodeIdxs = node.streamCategories.filter((s) => s.name===category).at(0).nodes;
   const nVisible = rippleNodeIdxs.filter((idx) => node.shell.that.nodes[idx].visibility===NODE_VISIBLE).length;
@@ -482,6 +484,7 @@ const HoverInfoPanel = ({
   geneSortFn,
   observedMutations,
   tipLabelKey,
+  proteinOnly,
   t
 }) => {
   if (!selectedNode) return null
@@ -491,7 +494,7 @@ const HoverInfoPanel = ({
   if (selectedNode.streamDetails) {
     return (
       <Container node={node} panelDims={panelDims} xy={[selectedNode.streamDetails.x, selectedNode.streamDetails.y]}>
-        {selectedNode.isBranch ? 
+        {selectedNode.isBranch ?
           <StreamConnectorInfo node={node} lineType={['joiner', 'backbone'][selectedNode.streamDetails.categoryIndex]}/> :
           <StreamRibbonInfo node={node} streamDetails={selectedNode.streamDetails} colorBy={colorBy}/>}
       </Container>
@@ -516,7 +519,7 @@ const HoverInfoPanel = ({
       ) : (
         <>
           <BranchDescendants node={node} t={t} tipLabelKey={tipLabelKey}/>
-          <BranchMutations node={node} geneSortFn={geneSortFn} observedMutations={observedMutations} t={t}/>
+          <BranchMutations node={node} geneSortFn={geneSortFn} observedMutations={observedMutations} proteinOnly={proteinOnly} t={t}/>
           <BranchLength node={node} t={t} isTerminal={false}/>
           <ColorBy node={node} colorBy={colorBy} colorByConfidence={colorByConfidence} colorScale={colorScale} colorings={colorings}/>
           <Comment>

--- a/src/components/tree/tree.tsx
+++ b/src/components/tree/tree.tsx
@@ -163,6 +163,7 @@ export class TreeComponent extends React.Component<TreeComponentProps, TreeCompo
           observedMutations={this.props.tree.observedMutations}
           panelDims={{width: this.props.width, height: this.props.height, spaceBetweenTrees}}
           tipLabelKey={this.props.tipLabelKey}
+          proteinOnly={this.props.genomeMap?.[0].proteinOnly===true}
           t={t}
         />
         <NodeClickedPanel
@@ -203,7 +204,7 @@ export class TreeComponent extends React.Component<TreeComponentProps, TreeCompo
         <TreeButtons {...this.props}  mainTree={true}
           offsetPx={this.props.showTreeToo ? widthPerTree + spaceBetweenTrees + 5 : 5} />
 
-        {this.props.showTreeToo && 
+        {this.props.showTreeToo &&
           <TreeButtons {...this.props} mainTree={false} offsetPx={5} />}
       </Card>
     );

--- a/src/util/entropyCreateStateFromJsons.ts
+++ b/src/util/entropyCreateStateFromJsons.ts
@@ -14,7 +14,7 @@ type Strand = '+' | '-' // other GFF-valid options are '.' and '?'
 /**
  * Specifies the range of the each segment's corresponding position in the genome,
  * or defines the range of the genome (chromosome) itself.
- * Start is always less than or equal to end. 
+ * Start is always less than or equal to end.
  * Start is 1-based, End is 1-based closed. I.e. GFF.
  */
 type RangeGenome = [number, number]
@@ -35,6 +35,11 @@ interface ChromosomeMetadata {
 
 interface Chromosome {
   name: string
+
+  /* For protein only analyses th nucleotide range (i.e. the chromosome) isn't known. Auspice will create it to span the
+  ranges reported by the proteins (CDSs), but it's a placeholder and there won't be any nucleotide mutations annotated */
+  proteinOnly: boolean
+
   range: RangeGenome
   genes: Gene[]
   metadata: ChromosomeMetadata
@@ -60,7 +65,7 @@ interface CDS {
 
 type Phase = 0 | 1 | 2
 
-type Frame = 0 | 1 | 2
+type Frame = 0 | 1 | 2 | 'unknown'
 
 interface CdsSegment {
   rangeLocal: RangeLocal
@@ -77,8 +82,7 @@ interface CdsSegment {
 }
 
 /**
- * This is in flux -- Richard's working on an updated representation for the JSON
- * Here we do our best to massage the JSON annotations block into a hierarchical
+ * Convert JSON annotations block into a hierarchical
  * representation of Genome → Chromosome[] → Gene[] → CDS[] → CDS_Segment[].
  * The intention is for this structure to entirely replace the various other pieces of redux
  * state such as 'annotations', 'geneMap', 'geneLengths', 'genomeAnnotations'.
@@ -101,24 +105,24 @@ export const genomeMap = (annotations: UnknownJsonObject): Chromosome[] => {
     .filter(([name,]) => name==='nuc')
     .map(([, annotation]) => annotation)[0];
 
-  if (!nucAnnotation) {
-    throw new Error("Genome annotation missing 'nuc' definition");
-  }
-  if (typeof nucAnnotation !== 'object') {
-    throw new Error("Genome annotation for 'nuc' is not a JSON object.");
-  }
-  if (!('start' in nucAnnotation) || !('end' in nucAnnotation)) {
-    throw new Error("Genome annotation for 'nuc' missing start or end");
-  }
-  if (typeof nucAnnotation.start !== 'number' || typeof nucAnnotation.end !== 'number') {
-    throw new Error("Genome annotation for 'nuc.start' or 'nuc.end' is not a number.");
-  }
-  if ('strand' in nucAnnotation && nucAnnotation.strand === '-') {
-    throw new Error("Auspice can only display genomes represented as positive strand." +
-      "Note that -ve strand RNA viruses are typically annotated as 5' → 3'.");
-  }
+  let rangeGenome: RangeGenome | undefined = undefined;
+  if (nucAnnotation) {
+    if (typeof nucAnnotation !== 'object') {
+      throw new Error("Genome annotation for 'nuc' is not a JSON object.");
+    }
+    if (!('start' in nucAnnotation) || !('end' in nucAnnotation)) {
+      throw new Error("Genome annotation for 'nuc' missing start or end");
+    }
+    if (typeof nucAnnotation.start !== 'number' || typeof nucAnnotation.end !== 'number') {
+      throw new Error("Genome annotation for 'nuc.start' or 'nuc.end' is not a number.");
+    }
+    if ('strand' in nucAnnotation && nucAnnotation.strand === '-') {
+      throw new Error("Auspice can only display genomes represented as positive strand." +
+        "Note that -ve strand RNA viruses are typically annotated as 5' → 3'.");
+    }
 
-  const rangeGenome: RangeGenome =  [nucAnnotation.start, nucAnnotation.end];
+    rangeGenome = [nucAnnotation.start, nucAnnotation.end];
+  }
 
 
   /* Group by genes -- most JSONs will not include this information, so it'll essentially be
@@ -175,8 +179,9 @@ export const genomeMap = (annotations: UnknownJsonObject): Chromosome[] => {
   }
 
   const chromosome: Chromosome = {
+    proteinOnly: rangeGenome === undefined,
     name: 'source',
-    range: rangeGenome,
+    range: rangeGenome || nucRangeToSpanGenes(genes),
     genes,
     metadata
   }
@@ -200,6 +205,18 @@ export const entropyCreateState = (genomeAnnotations: UnknownJsonObject): unknow
   return defaultEntropyState();
 };
 
+function nucRangeToSpanGenes(genes: Gene[]): RangeGenome {
+  let [min, max] = [Infinity, 0];
+  for (const gene of genes) {
+    for (const cds of gene.cds) {
+      for (const segment of cds.segments) {
+        if (segment.rangeGenome[0] < min) min = segment.rangeGenome[0];
+        if (segment.rangeGenome[1] > max) max = segment.rangeGenome[1];
+      }
+    }
+  }
+  return [min, max]
+}
 
 function validColor(color: string | undefined | unknown): false | string {
   if (typeof color !== "string") return false;
@@ -220,7 +237,7 @@ function* nextColorGenerator(): Generator<string> {
 function cdsFromAnnotation(
   cdsName: string,
   annotation: UnknownJsonObject,
-  rangeGenome: RangeGenome,
+  rangeGenome: RangeGenome | undefined,
   defaultColor: string | void,
 ): CDS {
   const invalidCds: CDS = {
@@ -236,13 +253,13 @@ function cdsFromAnnotation(
     /** GFF allows for strands '?' (features whose strandedness is relevant, but unknown) and '.' (features that are not stranded),
      * which are represented by augur as '?' and null, respectively. (null comes from `None` in python.)
      * In both cases it's not a good idea to make an assumption of strandedness, or to assume it's even a CDS. */
-    console.error(`[Genome annotation]  ${cdsName} has strand ` + 
+    console.error(`[Genome annotation]  ${cdsName} has strand ` +
       (annotation.strand !== undefined ? annotation.strand : '(missing)') +
       ". This CDS will be ignored.");
     return invalidCds;
   }
   const positive = strand==='+';
-  
+
   let length = 0;  // rangeLocal length
   const segments: CdsSegment[] = [];
   if (annotation.start && annotation.end) {
@@ -252,17 +269,20 @@ function cdsFromAnnotation(
       return invalidCds;
     }
 
-    /* The simplest case is where a JSON annotation block defines a
-    contiguous CDS, however it may be a wrapping CDS (i.e. cds end > genome
-    end */
-    if (annotation.end <= rangeGenome[1]) {
-      length = annotation.end-annotation.start+1;    
+    /** The simplest case is where a JSON annotation block defines a
+     *  contiguous CDS, however it may be a wrapping CDS (i.e. cds end > genome
+     *  end. (Note: For such wrapping genes to be interpreted correctly the annotations JSON
+     *  needs to define a nuc block so we have a `rangeGenome`, without this we can still parse
+     *  the CDS we just won't interpret it as wrapping.)
+     */
+    if (!rangeGenome || annotation.end <= rangeGenome[1]) {
+      length = annotation.end-annotation.start+1;
       segments.push({
         segmentNumber: 1,
         rangeLocal: [1, length],
         rangeGenome: [annotation.start, annotation.end],
         phase: 0,
-        frame: _frame(annotation.start, annotation.end, 0, rangeGenome[1], positive),
+        frame: _frame(annotation.start, annotation.end, 0, rangeGenome?.[1], positive),
       })
     } else {
       /* We turn this into the equivalent JsonSegments to minimise code duplication */
@@ -298,7 +318,7 @@ function cdsFromAnnotation(
         rangeLocal: [previousRangeLocalEnd+1, previousRangeLocalEnd+segmentLength],
         rangeGenome: [segment.start, segment.end],
         phase,
-        frame: _frame(segment.start, segment.end, phase, rangeGenome[1], positive)
+        frame: _frame(segment.start, segment.end, phase, rangeGenome?.[1], positive)
       };
       segments.push(s);
       length += segmentLength;
@@ -350,17 +370,22 @@ function _frame(
 
   phase: Phase,
 
-  /** 1 based */
-  genomeLength: number,
+  /** 1 based. May not be known (undefined) */
+  genomeLength: number|undefined,
   positiveStrand: boolean,
 ): Frame {
   /* TypeScript cannot infer the exact range of values from a modulo operation,
    * so it is manually provided.
    */
+  if (positiveStrand) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return (start + phase - 1) % 3 as 0 | 1 | 2;
+  }
+  if (!genomeLength) {
+    return 'unknown' // frame unknown if we don't know the length
+  }
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  return (positiveStrand ?
-    (start+phase-1)%3 :
-    Math.abs((end-phase-genomeLength)%3)) as 0 | 1 | 2;
+  return Math.abs((end-phase-genomeLength)%3) as 0 | 1 | 2;
 }
 
 /**


### PR DESCRIPTION
Allows datasets with a genome annotation without a `nuc` key, i.e. those which only have CDSs defined.

Companion PR to https://github.com/nextstrain/augur/pull/1958

See commit messages for more details (each commit is tiny!)


- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
