### PR TITLE
OIDC publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       # Note: --ignore-scripts skips an otherwise unnecessary Auspice build, but
       # also skips life cycle scripts for dependencies. If the job fails here,
       # try removing this flag.
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       # Note: --ignore-scripts skips an otherwise unnecessary Auspice build, but
       # also skips life cycle scripts for dependencies. If the job fails here,
       # try removing this flag.
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci --loglevel verbose
       - run: npx --yes bundlesize
 
@@ -86,8 +86,8 @@ jobs:
         with:
           # Node.js version doesn't matter; npm version is more important when
           # it comes to lockfiles.
-          node-version: 20
-      - run: npm install -g npm@8
+          node-version: 24
+      - run: npm install -g npm@11
       - run: npm install --ignore-scripts
       - run: |
           if git diff --exit-code package-lock.json; then
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - run: node --version
       - run: npm ci --loglevel verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/release' }}
     needs: [build-and-smoke-test, unit-test, lint, type-check, check-lockfile]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -110,8 +113,6 @@ jobs:
       - run: node --version
       - run: npm ci --loglevel verbose
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   rebuild-docker-image:
     needs: [publish]


### PR DESCRIPTION
Closes #2034.

Changes made to [auspice's npm Trusted Publisher settings](https://www.npmjs.com/package/auspice) following [the npm docs](https://docs.npmjs.com/trusted-publishers)

