### PR TITLE
Only run docs CI on schedule or code change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,9 +121,3 @@ jobs:
     - run: gh workflow run ci.yml --repo nextstrain/docker-base
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
-
-  build-docs:
-    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
-    with:
-      docs-directory: docs/
-      environment-file: docs/conda.yml

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,26 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths: &paths
+      - docs/**
+      - .github/workflows/docs.yaml
+
+  pull_request:
+    paths: *paths
+
+  workflow_dispatch:
+
+  # Routinely check that we continue to work in the face of external changes.
+  schedule:
+    # Every Monday at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * 1"
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
+    with:
+      docs-directory: docs/
+      environment-file: docs/conda.yml


### PR DESCRIPTION
## Description of proposed changes

Previously, docs CI was run on every code change, even when docs were untouched. This tended to generate noise with many false positives.

Scheduled runs still catch when any existing links break, but at a weekly frequency so that any false positives are less noisy.

## Related issue(s)

- https://github.com/nextstrain/.github/issues/116

## Checklist

- [x] This PR has a "Docs / ci / build" check
- [x] Checks pass
- [x] ~If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR~ N/A
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~ N/A

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories
