### PR TITLE
Allow JSONs to control downloading ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## version 2.69.0 - 2026/04/14
+* Expose sharing options in the dataset JSON (`.meta.sharing`) to provide fine-grained control on which assets Auspice offers for download. See [view settings docs](https://docs.nextstrain.org/projects/auspice/en/stable/advanced-functionality/view-settings.html) for more. ([#2047](https://github.com/nextstrain/auspice/pull/2047))
 
+## version 2.69.0 - 2026/04/14
 
 * Allow protein-only datasets, i.e. a dataset whose genome annotation is missing a nuc block but with CDSs defined. This work is in tandem with [this Augur PR](https://github.com/nextstrain/augur/pull/1958). ([Auspice PR #2040](https://github.com/nextstrain/auspice/pull/2040))
 

--- a/docs/advanced-functionality/view-settings.rst
+++ b/docs/advanced-functionality/view-settings.rst
@@ -174,3 +174,26 @@ The following query options are specifically for the measurements panel.
 | ``mf_<field_name>``  | | Filters for the measurements data. Multiple values for  | | ``mf_reference_strain=A/Alabama/5/2010``                   |
 |                      | | the same field are specified by multiple query params   | | ``mf_clade_reference=145S.2&mf_clade_reference=158N/189K`` |
 +----------------------+-----------------------------------------------------------+--------------------------------------------------------------+
+
+
+Sharing: control which assets Auspice exposes for download
+----------------------------------------------------------
+
+The ``.meta.sharing`` object controls which options Auspice exposes in the download-data modal.
+By default all options are available for download.
+(You can open the download-data modal via a button in the footer or by pressing "d".)
+
+.. code:: json
+
+  "sharing": {
+    "dataset_json": true,
+    "metadata_tsv": true,
+    "authors": true,
+    "trees": true,
+    "entropy": true,
+    "screenshot": true
+  },
+
+.. note::
+
+    GISAID datasets have different default values to comply with data sharing agreements.

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -24,6 +24,7 @@ import { hasMultipleGridPanels } from "./panelDisplay";
 import { strainSymbolUrlString } from "../middleware/changeURL";
 import { combineMeasurementsControlsAndQuery, encodeMeasurementColorBy, loadMeasurements } from "./measurements";
 import { processStreams, labelStreamMembership, availableStreamLabelKeys } from "../util/treeStreams";
+import { computeMetadataSharing } from "../util/metadataJsonParsing";
 
 export const doesColorByHaveConfidence = (controlsState, colorBy) =>
   controlsState.coloringsPresentOnTreeWithConfidence.has(colorBy);
@@ -898,6 +899,7 @@ const createMetadataStateFromJSON = (json) => {
     metadata.geoResolutions = json.meta.geo_resolutions;
   }
 
+  metadata.sharing = computeMetadataSharing(metadata, json.meta?.sharing)
 
   if (Object.prototype.hasOwnProperty.call(metadata, "loaded")) {
     console.error("Metadata JSON must not contain the key \"loaded\". Ignoring.");

--- a/src/components/download/downloadButtons.js
+++ b/src/components/download/downloadButtons.js
@@ -25,12 +25,12 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
   const filePrefix = getFilePrefix();
   const temporal = distanceMeasure === "num_date";
 
-  /* set gisaidProvenance based on supplied JSON metadata */
-  const gisaidProvenance = (metadata?.dataProvenance || []).filter((el) => el.name.toUpperCase()==='GISAID').length>0;
-  /* Verify that we can parse dataset name from URL to support Auspice JSON download */
+  /**
+   * Currently our ability to download JSONs relies on parsing the URL and re-fetching the
+   * JSON. Check that we can parse datasets from the URL before exposing the button here.
+   * This check will be removed as part of <https://github.com/nextstrain/auspice/issues/2000>
+   */
   const datasetNames = getDatasetNamesFromUrl(window.location.pathname);
-  const supportAuspiceJsonDownload = !gisaidProvenance && datasetNames.some(Boolean);
-
   const entropyBar = entropy?.selectedCds===nucleotide_gene ? "nucleotide" : "codon";
 
   return (
@@ -44,7 +44,7 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
         <p/>
         {partialData ? `Currently ${selectedTipsCount}/${totalTipCount} tips are displayed and will be downloaded.` : `Currently the entire dataset (${totalTipCount} tips) will be downloaded.`}
       </div>
-      {supportAuspiceJsonDownload && (
+      {metadata.sharing.dataset_json && datasetNames.some(Boolean) && (
         <Button
           name="Auspice (Nextstrain) JSON"
           description={`The main Auspice dataset JSON(s) for the current view`}
@@ -52,33 +52,39 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
           onClick={() => helpers.auspiceJSON(dispatch, datasetNames)}
         />
       )}
-      <Button
-        name={`${temporal ? 'TimeTree' : 'Tree'} (Newick)`}
-        description={`Phylogenetic tree in Newick format with branch lengths in units of ${temporal?'years':'divergence'}.`}
-        icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({isNewick: true, dispatch, filePrefix, tree, temporal})}
-      />
-      <Button
-        name={`${temporal ? 'TimeTree' : 'Tree'} (Nexus)`}
-        description={`Phylogeny in Nexus format with branch lengths in units of ${temporal?'years':'divergence'}. Colorings are included as annotations.`}
-        icon={<RectangularTreeIcon width={iconWidth} selected />}
-        onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal})}
-      />
-      {gisaidProvenance ?
+      {metadata.sharing.trees && (
+        <>
+          <Button
+            name={`${temporal ? 'TimeTree' : 'Tree'} (Newick)`}
+            description={`Phylogenetic tree in Newick format with branch lengths in units of ${temporal ? 'years' : 'divergence'}.`}
+            icon={<RectangularTreeIcon width={iconWidth} selected />}
+            onClick={() => helpers.exportTree({ isNewick: true, dispatch, filePrefix, tree, temporal })}
+          />
+          <Button
+            name={`${temporal ? 'TimeTree' : 'Tree'} (Nexus)`}
+            description={`Phylogeny in Nexus format with branch lengths in units of ${temporal?'years':'divergence'}. Colorings are included as annotations.`}
+            icon={<RectangularTreeIcon width={iconWidth} selected />}
+            onClick={() => helpers.exportTree({dispatch, filePrefix, tree, colorings: metadata.colorings, colorBy, temporal})}
+          />
+        </>
+      )}
+      {metadata.sharing.gisaid_acknowledgments && (
         <Button
           name="Acknowledgments (TSV)"
           description={`Per-sample acknowledgments (n = ${selectedTipsCount}).`}
           icon={<MetaIcon width={iconWidth} selected />}
           onClick={() => helpers.acknowledgmentsTSV(dispatch, filePrefix, tree.nodes, tree.visibility)}
-        /> :
+        />
+      )}
+      {metadata.sharing.metadata_tsv && (
         <Button
           name="Metadata (TSV)"
           description={`Per-sample metadata (n = ${selectedTipsCount}).`}
           icon={<MetaIcon width={iconWidth} selected />}
           onClick={() => helpers.strainTSV(dispatch, filePrefix, tree.nodes, tree.visibility)}
         />
-      }
-      {helpers.areAuthorsPresent(tree) && (
+      )}
+      {metadata.sharing.authors && helpers.areAuthorsPresent(tree) && (
         <Button
           name="Author Metadata (TSV)"
           description={`Metadata for ${selectedTipsCount} samples grouped by their ${getNumUniqueAuthors(tree.nodes, tree.visibility)} authors.`}
@@ -86,7 +92,7 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
           onClick={() => helpers.authorTSV(dispatch, filePrefix, tree)}
         />
       )}
-      {entropy.loaded && (
+      {metadata.sharing.entropy && entropy.loaded && (
         <Button
           name="Genetic diversity data (TSV)"
           description={`The data behind the diversity panel showing ${entropy.showCounts?`a count of changes across the tree`:`normalised shannon entropy`} per ${entropyBar}.`}
@@ -94,22 +100,24 @@ export const DownloadButtons = ({dispatch, t, tree, entropy, metadata, colorBy, 
           onClick={() => helpers.entropyTSV(dispatch, filePrefix, entropy)}
         />
       )}
-      <Button
-        name="Screenshot (SVG)"
-        description="Screenshot of the current nextstrain display in SVG format; CC-BY licensed."
-        icon={<PanelsGridIcon width={iconWidth} selected />}
-        onClick={() => helpers.SVG(
-          dispatch,
-          t,
-          metadata,
-          tree.nodes,
-          visibility,
-          getFilePrefix(),
-          panelsToDisplay,
-          panelLayout,
-          relevantPublications
-        )}
-      />
+      {metadata.sharing.screenshot && (
+        <Button
+          name="Screenshot (SVG)"
+          description="Screenshot of the current nextstrain display in SVG format; CC-BY licensed."
+          icon={<PanelsGridIcon width={iconWidth} selected />}
+          onClick={() => helpers.SVG(
+            dispatch,
+            t,
+            metadata,
+            tree.nodes,
+            visibility,
+            getFilePrefix(),
+            panelsToDisplay,
+            panelLayout,
+            relevantPublications
+          )}
+        />
+      )}
     </>
   );
 };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -5,6 +5,8 @@ export type Metadata = {
   rootSequenceSecondTree?: unknown
   identicalGenomeMapAcrossBothTrees?: boolean
   colorings: Colorings
+  sharing: MetadataSharing
+  dataProvenance?: { name: string; url: string; }[]
 }
 
 export type Colorings = {
@@ -34,3 +36,19 @@ export type Legend = {
   /** Custom legendBounds. Only considered for continuous scales. */
   bounds?: [number, number]
 }[]
+
+/**
+ * Fine-grained controls on the ability of Auspice to download various
+ * assets of the dataset. The defaults are to allow downloading of all
+ * applicable assets
+ */
+export interface MetadataSharing {
+  dataset_json: boolean;
+  metadata_tsv: boolean;
+  authors: boolean;
+  trees: boolean;
+  entropy: boolean;
+  /** gisaid_acknowledgments is not exposed as a JSON configuration, it is set dynamically within Auspice  */
+  gisaid_acknowledgments?: boolean;
+  screenshot: boolean;
+}

--- a/src/util/metadataJsonParsing.ts
+++ b/src/util/metadataJsonParsing.ts
@@ -1,0 +1,56 @@
+import type { Metadata } from "../metadata";
+
+/* control ability to share / download assets */
+export function computeMetadataSharing(
+  metadataState: Partial<Metadata>,
+  userData: any,
+): Metadata['sharing'] {
+
+  /** begin with defaults */
+  const sharing: Metadata['sharing'] = {
+    dataset_json: true,
+    metadata_tsv: true,
+    authors: true,
+    trees: true,
+    entropy: true,
+    screenshot: true
+  }
+
+  for (const [key, value] of Object.entries(_parseJsonSharingData(userData, Object.keys(sharing)))) {
+    sharing[key] = value;
+  }
+
+  /* Hardcode overrides for GISAID datasets */
+  const gisaid = (metadataState?.dataProvenance || []).filter((el) => el.name.toUpperCase() === 'GISAID').length > 0;
+  if (gisaid) {
+    sharing.dataset_json = false;
+    sharing.metadata_tsv = false;
+    sharing.gisaid_acknowledgments = true;
+  }
+
+  return sharing;
+}
+
+
+function _parseJsonSharingData(data: any, validKeys: string[]): Partial<Metadata['sharing']> {
+  if (data === undefined) return {};
+  if (!(typeof data === 'object' && !Array.isArray(data) && data !== null)) {
+    console.warn(`JSON.metadata.sharing must be an object (dict)`);
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(data)
+      .map(([key, value]): [string,boolean]|null => {
+        if (!validKeys.includes(key)) {
+          console.warn(`JSON.metadata.sharing.${key} is not a valid key`);
+          return null;
+        }
+        if (value !== false && value !== true) {
+          console.warn(`JSON.metadata.sharing.${key} must be a boolean value, not ${value}`);
+          return null;
+        }
+        return [key, value]
+      })
+      .filter((x) => !!x)
+  )
+}


### PR DESCRIPTION
Allows a new JSON.metadata.sharing object/dict to provide fine grained control over the ability to download each asset. There is no change in current behaviour for datasets which don't define the 'sharing' data structure.

This commit also refactors things a little to guarantee the redux metadata state is valid up-front (for the 'sharing' key), thus making the rendering components simpler.

[Related slack thread](https://bedfordlab.slack.com/archives/C0K3GS3J8/p1778484044141669)

Needs to be coordinated with updated docs and updated JSON schemas (in Augur)