### PR TITLE
[dev] fix font fetching

### DIFF
--- a/cli/develop.js
+++ b/cli/develop.js
@@ -52,7 +52,7 @@ const run = (args) => {
 
   /* Redirects / to webpack-generated index */
   app.use((req, res, next) => {
-    if (!/^\/__webpack_hmr|^\/charon|\.[A-Za-z0-9]{1,4}$/.test(req.path)) {
+    if (!/^\/__webpack_hmr|^\/charon|\.[A-Za-z0-9]{1,5}$/.test(req.path)) {
       req.url = webpackConfig.output.publicPath;
     }
     next();


### PR DESCRIPTION
Fetches for `.woff2` fonts were failing in development mode, with 21 console warnings of:

Failed to decode downloaded font: http://localhost:4000/dist/[hash].woff2

This happened because the URL-rewriting middleware only considered file extensions of 1-4 characters, and `.woff2` has 5!
