### PR TITLE
Fix streamtrees display for narratives

### DIFF
--- a/narratives/test_streamtrees.md
+++ b/narratives/test_streamtrees.md
@@ -1,0 +1,15 @@
+---
+title: Test narrative which renders markdown as the main panel
+authors: "Nextstrain team"
+date: "2026-05-20"
+dataset: "https://nextstrain.org/ebola/all-outbreaks"
+---
+
+
+# [Opening dataset](https://nextstrain.org/ebola/all-outbreaks)
+
+Streamtrees with outbreak label
+
+# [Same dataset, different stream label](https://nextstrain.org/ebola/all-outbreaks?streamLabel=outbreak_geo)
+
+Streamtrees with outbreak_geo label

--- a/scripts/get-data.sh
+++ b/scripts/get-data.sh
@@ -2,7 +2,7 @@
 
 data_files=(
   "dengue_all.json" "dengue_denv1.json" "dengue_denv2.json" "dengue_denv3.json" "dengue_denv4.json"\
-  "ebola.json" "ebola_root-sequence.json" \
+  "ebola_all-outbreaks.json" "ebola.json" "ebola_root-sequence.json" \
   "ebola_2019-09-14-no-epi-id_meta.json" "ebola_2019-09-14-no-epi-id_tree.json" \
   "lassa_s_tree.json" "lassa_s_meta.json" \
   "lassa_l_tree.json" "lassa_l_meta.json" \

--- a/src/actions/recomputeReduxState.js
+++ b/src/actions/recomputeReduxState.js
@@ -1129,7 +1129,7 @@ export const createStateFromQueryOrJSONs = ({
    * Note: currently we don't support LHS/RHS trees + streamtrees, but this should
    * be feasible to implement if desired.
    */
-  if (controls.showStreamTrees && treeToo) controls.showStreamTrees = false;
+  if (controls.showStreamTrees && treeToo && treeToo.loaded) controls.showStreamTrees = false;
   if (controls.showStreamTrees) {
     tree.streams = labelStreamMembership(tree.nodes[0], controls.streamTreeBranchLabel)
     if (Object.keys(tree.streams).length) {


### PR DESCRIPTION
## Description of proposed changes

`showStreamTrees` was always getting set to false when loading the same dataset in narratives because the `treeToo` state is truthy when loading in the old state. Check `treeToo.loaded` to avoid showing streamtrees for tangletrees.


## Related issue(s)

Resolves https://github.com/nextstrain/auspice/issues/2050

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
