### PR TITLE
Performance: selective incremental redraw + lighter full-render draw

### DIFF
--- a/src/components/tree/phyloTree/change.ts
+++ b/src/components/tree/phyloTree/change.ts
@@ -439,6 +439,21 @@ export const change = function change(
   if (svgHasChangedDimensions || changeNodeOrder) {
     this.nodes.forEach((d) => {d.update = true;});
   }
+  /* A branch's stem start-point is offset by its stem-parent's stroke-width
+   * (mapToScreen: xBase - 0.5*(parentStrokeWidth - strokeWidth)). So when
+   * thicknesses change we must also redraw the CHILDREN of every thickness-changed
+   * branch: their own thickness (hence d.update) may be unchanged, yet their stem
+   * path start has moved. Without this, a filter/date change can leave a child stem
+   * a few px off from a full render. Collect first, then flag, to avoid cascading. */
+  if (changeBranchThickness) {
+    const stemChildren: PhyloNode[] = [];
+    this.nodes.forEach((d) => {
+      if (d.update && d.n.hasChildren) {
+        for (const child of d.n.children) stemChildren.push(child.shell);
+      }
+    });
+    stemChildren.forEach((c) => { if (c) c.update = true; });
+  }
 
   /** PHYLOTREE METHODS
    * Note the order here is (often) critical! This order reflects the order in the initial tree render cycle

--- a/src/components/tree/phyloTree/change.ts
+++ b/src/components/tree/phyloTree/change.ts
@@ -430,7 +430,13 @@ export const change = function change(
       zoomIntoClade.n.parent.shell;
     applyToChildren(this.zoomNode, (d: PhyloNode) => {d.inView = true;});
   }
-  if (svgHasChangedDimensions || changeNodeOrder || changeVisibility) {
+  /* A visibility change (date filter / animation tick) does NOT move node
+   * positions (setDisplayOrder/setLayout are gated off for it, and mapToScreen's
+   * domain uses inView, which only zoom changes). So we trust the selective
+   * d.update set that updateNodesWithNewData() just computed from the visibility
+   * and stroke-width deltas, rather than blanket-flagging every node — this is
+   * what lets modifySVG touch only the changed band instead of all ~50k paths. */
+  if (svgHasChangedDimensions || changeNodeOrder) {
     this.nodes.forEach((d) => {d.update = true;});
   }
 

--- a/src/components/tree/phyloTree/change.ts
+++ b/src/components/tree/phyloTree/change.ts
@@ -407,9 +407,7 @@ export const change = function change(
   /* change the requested properties on the nodes */
   updateNodesWithNewData(this.nodes, nodePropsToModify);
 
-  // recalculate gradients here?
   if (changeColorBy) {
-    this.updateColorBy();
     this.measurementsColorGrouping = newMeasurementsColorGrouping;
   }
   // recalculate existing regression if needed

--- a/src/components/tree/phyloTree/layouts.ts
+++ b/src/components/tree/phyloTree/layouts.ts
@@ -218,7 +218,10 @@ export const unrootedLayout = function unrootedLayout(this: PhyloTreeType): void
  * arcs and whether that arc is more than pi or not
  */
 export const radialLayout = function radialLayout(this: PhyloTreeType): void {
-  const maxDisplayOrder = Math.max(...this.nodes.map((d) => d.displayOrder).filter((val) => val));
+  let maxDisplayOrder = 0;
+  this.nodes.forEach((d) => {
+    if (d.displayOrder && d.displayOrder > maxDisplayOrder) maxDisplayOrder = d.displayOrder;
+  });
   const offset = this.nodes[0].depth;
   this.nodes.forEach((d) => {
     const angleCBar1 = 2.0 * 0.95 * Math.PI * d.displayOrderRange[0] / maxDisplayOrder;
@@ -344,7 +347,7 @@ export const setScales = function setScales(this: PhyloTreeType): void {
 */
 export const mapToScreen = function mapToScreen(this: PhyloTreeType): void {
   timerStart("mapToScreen");
-  const inViewTerminalNodes = this.nodes.filter((d) => !d.n.hasChildren).filter((d) => d.inView);
+  const inViewTerminalNodes = this.nodes.filter((d) => !d.n.hasChildren && d.inView);
 
   /* set up space (padding) for axes etc, as we don't want the branches & tips to occupy the entire SVG! */
   this.margins = {

--- a/src/components/tree/phyloTree/renderers.ts
+++ b/src/components/tree/phyloTree/renderers.ts
@@ -221,7 +221,11 @@ export const drawTips = function drawTips(this: PhyloTreeType): void {
   timerStart("drawTips");
   const params = this.params;
   if (!("tips" in this.groups)) {
-    this.groups.tips = this.svg.append("g").attr("id", "tips").attr("clip-path", "url(#treeClip)");
+    this.groups.tips = this.svg.append("g").attr("id", "tips").attr("clip-path", "url(#treeClip)")
+      /* constant tip presentation set once on the group and inherited, rather than written per-circle */
+      .style("pointer-events", "auto")
+      .style("cursor", "pointer")
+      .style("stroke-width", params.tipStrokeWidth); /* don't want branch thicknesses applied */
   }
 
   const nodes = (this.params.showStreamTrees ? this.nodes.filter((d) => !d.n.inStream) : this.nodes)
@@ -240,12 +244,9 @@ export const drawTips = function drawTips(this: PhyloTreeType): void {
     .on("mouseover", this.callbacks.onTipHover)
     .on("mouseout", this.callbacks.onTipLeave)
     .on("click", this.callbacks.onTipClick)
-    .style("pointer-events", "auto")
     .style("visibility", (d) => d.visibility === NODE_VISIBLE ? "visible" : "hidden")
     .style("fill", (d) => d.fill || params.tipFill)
-    .style("stroke", (d) => d.tipStroke || params.tipStroke)
-    .style("stroke-width", () => params.tipStrokeWidth) /* don't want branch thicknesses applied */
-    .style("cursor", "pointer");
+    .style("stroke", (d) => d.tipStroke || params.tipStroke);
 
   timerEnd("drawTips");
 };
@@ -304,7 +305,10 @@ export const drawBranches = function drawBranches(this: PhyloTreeType): void {
   /* PART 1: draw the branch Ts (i.e. the bit connecting nodes parent branch ends to child branch beginnings)
   Only rectangular & radial trees have this, so we remove it for clock / unrooted layouts */
   if (!("branchTee" in this.groups)) {
-    this.groups.branchTee = this.svg.append("g").attr("id", "branchTee").attr("clip-path", "url(#treeClip)");
+    this.groups.branchTee = this.svg.append("g").attr("id", "branchTee").attr("clip-path", "url(#treeClip)")
+      /* constant tee presentation, inherited by the child paths */
+      .style("pointer-events", "auto")
+      .style("fill", "none");
   }
   if (this.layout === "clock" || this.layout === "scatter" || this.layout === "unrooted") {
     this.groups.branchTee.selectAll("*").remove();
@@ -320,26 +324,18 @@ export const drawBranches = function drawBranches(this: PhyloTreeType): void {
       .style("stroke", (d) => d.branchStroke || params.branchStroke)
       .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
       .style("visibility", getBranchVisibility)
-      .style("fill", "none")
-      .style("pointer-events", "auto")
       .on("mouseover", this.callbacks.onBranchHover)
       .on("mouseout", this.callbacks.onBranchLeave)
       .on("click", this.callbacks.onBranchClick);
   }
 
-  /* PART 2: draw the branch stems (i.e. the actual branches) */
-
-  /* PART 2a: Create linear gradient definitions which can be applied to branch stems for which
-  the start & end stroke colour is different */
-  if (!this.groups.branchGradientDefs) {
-    this.groups.branchGradientDefs = this.svg.append("defs");
-  }
-  this.groups.branchGradientDefs.selectAll("*").remove();
-  // TODO -- explore if duplicate <def> elements (e.g. same colours on each end) slow things down
-  this.updateColorBy();
-  /* PART 2b: Draw the stems */
+  /* PART 2: draw the branch stems (i.e. the actual branches).
+   * (SVG gradient strokes were disabled in 2020, so there is no gradient <defs> to build here.) */
   if (!("branchStem" in this.groups)) {
-    this.groups.branchStem = this.svg.append("g").attr("id", "branchStem").attr("clip-path", "url(#treeClip)");
+    this.groups.branchStem = this.svg.append("g").attr("id", "branchStem").attr("clip-path", "url(#treeClip)")
+      /* constant stem presentation, inherited by the child paths */
+      .style("pointer-events", "auto")
+      .style("stroke-linecap", "round");
   }
   this.groups.branchStem
     .selectAll('.branch')
@@ -349,15 +345,10 @@ export const drawBranches = function drawBranches(this: PhyloTreeType): void {
     .attr("class", "branch S")
     .attr("id", (d) => getDomId("branchS", d.n.name))
     .attr("d", (d) => d.branch[0])
-    .style("stroke", (d) => {
-      if (!d.branchStroke) return params.branchStroke;
-      return strokeForBranch(d, "S");
-    })
-    .style("stroke-linecap", "round")
+    .style("stroke", (d) => d.branchStroke || params.branchStroke)
     .style("stroke-width", (d) => d['stroke-width'] || params.branchStrokeWidth)
     .style("visibility", getBranchVisibility)
     .style("cursor", (d) => d.visibility === NODE_VISIBLE ? "pointer" : "default")
-    .style("pointer-events", "auto")
     .on("mouseover", this.callbacks.onBranchHover)
     .on("mouseout", this.callbacks.onBranchLeave)
     .on("click", this.callbacks.onBranchClick);

--- a/src/util/colorHelpers.js
+++ b/src/util/colorHelpers.js
@@ -58,9 +58,7 @@ export const getTipColorAttribute = (node, colorScale) => {
 /* takes around 2ms on a 2000 tip tree */
 export const calcNodeColor = (tree, colorScale) => {
   if (tree && tree.nodes && colorScale && colorScale.colorBy) {
-    const nodeColorAttr = tree.nodes.map((n) => getTipColorAttribute(n, colorScale));
-    // console.log(nodeColorAttr.map((n) => colorScale.scale(n)))
-    return nodeColorAttr.map((n) => colorScale.scale(n));
+    return tree.nodes.map((n) => colorScale.scale(getTipColorAttribute(n, colorScale)));
   }
   return null;
 };


### PR DESCRIPTION
_Via Claude_

## Summary

Application-code performance optimizations for the phyloTree renderer, targeting the two dominant costs on large trees: the **incremental update** path (`phylotree.change()` → `modifySVG`, every date-filter/animation tick) and the **full-render draw** (`drawBranches`/`drawTips`, every load and layout change).

Stacked on #2078 (perf-infra), which adds the profiling harness (`npm run profile`) and the render-equivalence suite (`npm run render-equiv`) used to measure and guard every change here. Base is `perf-infra`; retarget to `v3` once that merges.

All numbers below are on the 35k-tip `spike-sm` tree from https://nextstrain.org/groups/trajectories/spike-sm

## Changes

**1. Selective redraw on visibility change** (`change.ts`) — `phylotree.change()` blanket-marked every node `d.update = true` on any visibility change, discarding the selective changed-set that `updateNodesWithNewData()` already computes from the visibility/stroke-width deltas. That forced `modifySVG` to rewrite the path + styles on all ~50k branches every tick. A visibility change does not move node positions (`setDisplayOrder`/`setLayout` are gated off for it; `mapToScreen`'s domain keys on `inView`, which only zoom changes), so the selective set is sufficient.
→ per-tick `modifySVG` **383ms → 84ms (−78%)**, `phylotree.change()` **427ms → 126ms (−70%)**.

**2. Flag stem-children on thickness change** (`change.ts`) — A stem's start point is offset by its parent's stroke-width (`xBase − 0.5·(parentStrokeWidth − strokeWidth)`). The selective set flags a branch only when its *own* thickness changes, so a branch whose parent thickened but whose own thickness held kept a stale stem start (up to ~5px off; endpoint always correct). We now also flag children of every thickness-changed branch so their stem `d` is recomputed — making the selective redraw byte-identical to a full render.

**3. Lighter full-render draw** (`renderers.ts`, `change.ts`) — `drawBranches`/`drawTips` wrote constant presentation styles (`pointer-events`, `cursor`, `stroke-linecap`, tee `fill:none`, tip `stroke-width`) inline on each of ~67k elements. These are set only at draw time (`modifySVG` never touches them), so we set them once on each parent `<g>` and let SVG style-inheritance apply them — removing ~150k+ per-element style writes. Also removed the dead branch-gradient machinery (`updateColorBy` is a no-op; `strokeForBranch` returns a plain colour; gradients disabled since 2020) and inlined `strokeForBranch` in the stem stroke callback.
→ `drawBranches` **−8–10% (~25–40ms)**, `drawTips` **up to −8%** per full render.

**4. Batch A: O(N) cleanups** (`layouts.ts`, `colorHelpers.js`) — Behaviour-preserving: collapse a chained `.filter().filter()` in `mapToScreen` to one pass; replace `Math.max(...nodes.map()…)` in `radialLayout` with a single loop (also removes a spread-argument stack-overflow risk on 35k-tip trees); fuse two chained `.map()` passes in `calcNodeColor`.

## Why this is render-safe

**By suite.** `npm run render-equiv` drives each operation through the real incremental path in-app (`history.pushState` + a `popstate` event, which the app turns into a `phylotree.change()` — zero source changes) and asserts the settled SVG is **byte-identical** to a from-scratch full render of the same end state. Fresh run on this branch: **19/19 passed, 0 mismatches**, covering colorBy (categorical + continuous), all four layouts, distance toggle, date filter, trait filter, zoom-to-clade, confidence, four multi-step sequences, plus zika and spike-sm (spike checks pass with 134k changed elements). For change (3) the snapshot reads `getComputedStyle` for the now-inherited constants, so it still verifies they resolve identically in both paths.

**By logic.**
- (1) is safe because a visibility change provably does not move nodes — the position inputs (`setDisplayOrder`/`setLayout`/`inView`) are all gated off for it, so the pre-computed selective `d.update` set is exactly the set of elements whose DOM differs. The suite's `datefilter`, `traitfilter`, and their sequences exercise this.
- (2) closes the one gap (1) opened (stale stem start on unchanged-thickness children); the suite's filter/date scenarios go byte-identical only with it in place — this fix is exactly what took them from 1 mismatch to 0.
- (3) moves only constants that `modifySVG` never sets, so no incremental path can produce a different value; per-node props (cx/cy/r, fill, stroke, visibility, `d`, per-node stroke-width, visibility-dependent cursor) stay inline and unchanged. The removed gradient code was already inert.
- (4) is pure computational refactor — same outputs, fewer array passes.

## Test plan

- [x] `npm run render-equiv` — 19/19, 0 mismatches (incremental ≡ full render)
- [x] `npm run profile` before/after vs perf-infra baseline — deltas above
- [x] `npm run type-check` && `npm run lint`
- [x] Manual smoke on spike-sm: date-filter animation, zoom, layout switch, colorBy, confidence, hover/click

🤖 Generated with [Claude Code](https://claude.com/claude-code)