### PR TITLE
CHANGELOG: update link flagged in docs CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1619,7 +1619,7 @@ This also fixed potential issues related to loading datasets where the URL queri
 ## version 1.14.0 - 2018/02/27
 
 ### Features
-* Strain search (using [awesomplete](https://projects.verou.me/awesomplete/)).
+* Strain search (using [awesomplete](https://nudeui.github.io/awesomplete/)).
 This highlights the path to a single tip and increases the tip radius.
 Strain is stored in the URL query (`s=...`) and can be restored via URL.
 Selected strain also appears in the info panel (top of screen).


### PR DESCRIPTION
## Description of proposed changes

Broken link flagged in docs CI
<https://github.com/nextstrain/auspice/actions/runs/30292637356/job/90065818483>

Based on latest commits, looks like the project was recently transfered to nudeui org.
<https://github.com/nudeui/awesomplete/commit/7cb7514b3a8032c6fe8af614c81d3bb6e8640ac5>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [x] ~(to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].~

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
