### PR TITLE
LinkOutModal/MicrobeTrace: remove 500 tip warning

### DIFF
--- a/src/components/modal/LinkOutModalContents.jsx
+++ b/src/components/modal/LinkOutModalContents.jsx
@@ -154,11 +154,9 @@ function MicrobeTraceLinkOut() {
   const displayName = 'microbetrace.cdc.gov';
   const {pathname, origin} = clientDetails();
   const {showTreeToo} = useSelector((state) => state.controls)
-  const {mainTreeNumTips, originalVersion} = useSelector((state) => state.metadata);
+  const {originalVersion} = useSelector((state) => state.metadata);
 
   // MicrobeTrace should work similarly to Taxonium (see above)
-  // but trees >500 tips are very slow to load (we don't prevent the display of such trees,
-  // however we do show a warning)
   let unsupportedMessage;
   if (showTreeToo) {
     unsupportedMessage = "tanglegrams aren't supported";
@@ -181,11 +179,6 @@ function MicrobeTraceLinkOut() {
       <ButtonText href={url()} target="_blank" rel="noreferrer noopener">{displayName}</ButtonText>
       <ButtonDescription>
         View this data in MicrobeTrace (<a href='https://github.com/CDCgov/MicrobeTrace/wiki' target="_blank" rel="noreferrer noopener">learn more</a>).
-        {mainTreeNumTips>500 && (
-          <span>
-            {` Note that trees with over 500 tips may have trouble loading (this one has ${mainTreeNumTips}).`}
-          </span>
-        )}
       </ButtonDescription>
     </ButtonContainer>
   )


### PR DESCRIPTION
## Description of proposed changes

We no longer need to warn about trees with >500 tips since MicrobeTrace v2.2 includes improvements for loading larger trees. <https://github.com/CDCgov/MicrobeTrace/releases/tag/v2.2>

For instances where the tree has too many links for MicrobeTrace to display, the app no longer hangs and will display a more specific warning to user as shown in
<https://github.com/nextstrain/auspice/issues/2074#issuecomment-5096244701>.

## Related issue(s)

Resolves https://github.com/nextstrain/auspice/issues/2074

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] If making user-facing changes, add a message in [CHANGELOG.md](https://github.com/nextstrain/auspice/blob/HEAD/CHANGELOG.md) summarizing the changes in this PR
- [ ] (to be done by a Nextstrain team member) [Create preview PRs on downstream repositories][1].

[1]: https://github.com/nextstrain/auspice/blob/-/DEV_DOCS.md#test-on-downstream-repositories

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
